### PR TITLE
fix: resolve video download crash and token refresh validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,13 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 - **File**: `cli/commands/download/downloader.py`
 - **Root cause**: The `download()` method's video branch (`elif isinstance(item, Video)`) was truncated — it started the download task but had no `_download_with_retry()` call, no `return` statement, and therefore implicitly returned `None`, crashing the tuple unpacking in `handle_item`.
 - **Fix**: Completed the video download loop body to mirror the track branch: creates `DownloadTask`, calls `_download_with_retry()`, handles per-quality failure with `continue`, converts `.ts` → `.mp4` via `convert_to_mp4()`, and returns `(download_path, True)` on success or `(None, False)` when all qualities fail.
+- **Improvement**: `convert_to_mp4` failure is now tracked with a `conversion_ok` flag — on failure, `show_item_result` displays `"[yellow]Downloaded (conversion failed)"` with `item_path=None` instead of a misleading success message.
 
 #### Token Refresh — `Failed to refresh token: 3 validation errors for AuthResponse`
 - **File**: `core/auth/models.py`
 - **Root cause**: Tidal's API started returning `birthday`, `created`, and `updated` fields as non-integer values (floats or strings). Pydantic v1 raised `type_error.integer` because the model declared them as `int` / `Optional[int]` with strict validation.
 - **Fix**: Added a `@validator("birthday", "created", "updated", pre=True)` to `AuthResponse.User` that coerces any incoming value to `int` via `int(float(v))`, accepting integers, floats, and numeric strings transparently.
+- **Improvement**: The cast is wrapped in `try/except (TypeError, ValueError)` and raises a descriptive `ValueError` for non-numeric values instead of propagating a raw exception.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ---
 
+## [1.0.1] - 2026-03-05 (Bug Fix Release)
+
+### 🐛 Fixed
+
+#### Video Download — `TypeError: cannot unpack non-iterable NoneType object`
+- **File**: `cli/commands/download/downloader.py`
+- **Root cause**: The `download()` method's video branch (`elif isinstance(item, Video)`) was truncated — it started the download task but had no `_download_with_retry()` call, no `return` statement, and therefore implicitly returned `None`, crashing the tuple unpacking in `handle_item`.
+- **Fix**: Completed the video download loop body to mirror the track branch: creates `DownloadTask`, calls `_download_with_retry()`, handles per-quality failure with `continue`, converts `.ts` → `.mp4` via `convert_to_mp4()`, and returns `(download_path, True)` on success or `(None, False)` when all qualities fail.
+
+#### Token Refresh — `Failed to refresh token: 3 validation errors for AuthResponse`
+- **File**: `core/auth/models.py`
+- **Root cause**: Tidal's API started returning `birthday`, `created`, and `updated` fields as non-integer values (floats or strings). Pydantic v1 raised `type_error.integer` because the model declared them as `int` / `Optional[int]` with strict validation.
+- **Fix**: Added a `@validator("birthday", "created", "updated", pre=True)` to `AuthResponse.User` that coerces any incoming value to `int` via `int(float(v))`, accepting integers, floats, and numeric strings transparently.
+
+---
+
 ## [1.0.0] - 2026-03-01 (Production Release)
 
 ### 🎉 Initial Production Release

--- a/FORK.md
+++ b/FORK.md
@@ -261,6 +261,10 @@ See [LICENSE](LICENSE) file for details.
 
 ## 📝 Version History
 
+- **v1.0.1** (March 2026) - Bug fix release
+  - Fixed video downloads crashing with `TypeError: cannot unpack non-iterable NoneType object`
+  - Fixed token refresh failing with `type_error.integer` on `birthday`/`created`/`updated` fields
+
 - **v1.0.0** (March 2026) - Initial production release
   - Python 3.10+ support
   - Pydantic v1 compatibility

--- a/cli/commands/download/downloader.py
+++ b/cli/commands/download/downloader.py
@@ -1023,9 +1023,11 @@ class Downloader:
                         )
                         continue
 
+                    conversion_ok = True
                     try:
                         download_path = convert_to_mp4(download_path)
                     except Exception as exc:
+                        conversion_ok = False
                         log.error(f"Video conversion failed: {exc}")
                         self.rich_output.console.print(
                             f"[red]Error converting video:[/] {display_title} - {exc}"
@@ -1033,9 +1035,9 @@ class Downloader:
 
                     task = self.rich_output.download_finish(task_id=task_id)
                     self.rich_output.show_item_result(
-                        result_message=result_message,
+                        result_message=result_message if conversion_ok else "[yellow]Downloaded (conversion failed)",
                         item_description=task.description,
-                        item_path=download_path,
+                        item_path=download_path if conversion_ok else None,
                     )
                     return download_path, True
 

--- a/cli/commands/download/downloader.py
+++ b/cli/commands/download/downloader.py
@@ -998,4 +998,48 @@ class Downloader:
                         download_path = Path(_prepare_long_path(str(download_path.absolute())))
 
                     task_id = self.rich_output.download_start(f"[{vibrant_color}]{display_title} {quality}")
-                    
+
+                    download_path.parent.mkdir(exist_ok=True, parents=True)
+
+                    task = DownloadTask(
+                        url=urls[0] if urls else "",
+                        output_path=download_path,
+                        track_id=item.id,
+                        track_title=display_title,
+                        max_attempts=MAX_RETRIES
+                    )
+
+                    download_success = await self._download_with_retry(
+                        task=task,
+                        urls=urls,
+                        task_id=task_id,
+                    )
+                    if not download_success:
+                        task = self.rich_output.download_finish(task_id=task_id)
+                        self.rich_output.show_item_result(
+                            result_message="[yellow]Failed (Retrying lower quality)",
+                            item_description=task.description,
+                            item_path=None,
+                        )
+                        continue
+
+                    try:
+                        download_path = convert_to_mp4(download_path)
+                    except Exception as exc:
+                        log.error(f"Video conversion failed: {exc}")
+                        self.rich_output.console.print(
+                            f"[red]Error converting video:[/] {display_title} - {exc}"
+                        )
+
+                    task = self.rich_output.download_finish(task_id=task_id)
+                    self.rich_output.show_item_result(
+                        result_message=result_message,
+                        item_description=task.description,
+                        item_path=download_path,
+                    )
+                    return download_path, True
+
+                self.rich_output.console.print(
+                    f"[red]Error[/] Could not download '{display_title}' in any quality"
+                )
+                return None, False

--- a/core/auth/models.py
+++ b/core/auth/models.py
@@ -29,7 +29,10 @@ class AuthResponse(BaseModel):
         def coerce_to_int(cls, v):
             if v is None:
                 return v
-            return int(float(v))
+            try:
+                return int(float(v))
+            except (TypeError, ValueError):
+                raise ValueError(f"Expected a numeric value for timestamp field, got {v!r}")
         appleUid: Optional[str]
         googleUid: Optional[str]
         accountLinkCreated: bool

--- a/core/auth/models.py
+++ b/core/auth/models.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 
 class AuthResponse(BaseModel):
@@ -24,6 +24,12 @@ class AuthResponse(BaseModel):
         created: int
         updated: int
         facebookUid: int
+
+        @validator("birthday", "created", "updated", pre=True)
+        def coerce_to_int(cls, v):
+            if v is None:
+                return v
+            return int(float(v))
         appleUid: Optional[str]
         googleUid: Optional[str]
         accountLinkCreated: bool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.0.0"
+version = "1.0.1"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
- Fix TypeError in downloader.py: the video download branch inside Downloader.download() was truncated — missing _download_with_retry() call, convert_to_mp4(), and return statement. The method implicitly returned None, crashing the tuple unpack in handle_item (line 261). Completed the loop body to mirror the track branch with per-quality fallback and proper (download_path, True) / (None, False) returns.

- Fix AuthResponse validation in core/auth/models.py: Tidal API now returns birthday/created/updated as non-integer values. Added a pre=True validator to coerce them via int(float(v)), resolving the 3 x type_error.integer errors during token refresh.

- Bump version to 1.0.1 and update CHANGELOG.md / FORK.md.

## Summary by Sourcery

Fix video download crashes and token refresh validation errors, and bump the project patch version.

Bug Fixes:
- Restore the video download branch to correctly perform the download with retries, convert the file to MP4, and return a success/failure tuple instead of implicitly returning None.
- Relax AuthResponse user field parsing to coerce non-integer birthday/created/updated values into integers, resolving token refresh validation errors.

Build:
- Bump project version from 1.0.0 to 1.0.1 in pyproject configuration.

Documentation:
- Update CHANGELOG and FORK documentation with the 1.0.1 bug fix release notes.