### PR TITLE
docs: update documentation for v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ---
 
+## [1.1.1] - 2026-03-09
+
+### 🐛 Fixed
+
+#### Packaging — `tiddl.cli` / `tiddl.core` not found after pip install
+- Moved source into `tiddl/` subdirectory so setuptools discovers the correct namespace
+- Entry points updated to `tiddl.cli.app:main`
+- `pip install git+https://github.com/Np3ir/tiddl-elvigilante` now works correctly
+
+#### Templates not applied from config.toml
+- `model_post_init` (Pydantic v2 only) was silently ignored in Pydantic v1, leaving
+  `track`, `video`, `album`, `playlist`, `mix` templates always empty
+- Replaced with `@validator` (Pydantic v1): specific templates now correctly inherit
+  from `default` when not explicitly set
+- `scan_path` now correctly syncs to `download_path` via `@validator`
+
+### 🔧 Changed
+- `DEFAULT_ARTIST_SEPARATOR` centralized as a module constant in `core/utils/format.py`
+- Parameter renamed from `sep` to `artist_separator` in `generate_template_data` for consistency
+
+---
+
 ## [1.1.0] - 2026-03-09
 
 ### ✨ Added
@@ -166,7 +188,7 @@ All original features preserved:
 
 ### 🔗 Links
 
-- **GitHub**: https://github.com/yourusername/tiddl
+- **GitHub**: https://github.com/Np3ir/tiddl-elvigilante
 - **Original**: https://github.com/oskvr37/tiddl
 - **TIDAL**: https://tidal.com
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -30,7 +30,7 @@ debug = false
 track_quality = "max"
 video_quality = "fhd"
 skip_existing = true
-threads_count = 4
+threads_count = 2
 download_path = "~/Music/tiddl"
 
 [metadata]
@@ -86,7 +86,7 @@ artist_separator = " / "
 
 ### `threads_count`
 - **Type**: integer
-- **Default**: 4
+- **Default**: 2
 - **Range**: 1-20
 - Number of concurrent downloads
 
@@ -280,7 +280,7 @@ debug = false
 track_quality = "max"
 video_quality = "fhd"
 skip_existing = true
-threads_count = 4
+threads_count = 2
 download_path = "~/Music/tiddl"
 scan_path = "~/Music/tiddl"
 singles_filter = "include"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Thank you for your interest in contributing! This document explains how to get i
 ```bash
 # Go to GitHub and click "Fork"
 # Then clone your fork
-git clone https://github.com/yourusername/tiddl-elvigilante.git
+git clone https://github.com/Np3ir/tiddl-elvigilante.git
 cd tiddl-elvigilante
 ```
 

--- a/FORK.md
+++ b/FORK.md
@@ -144,7 +144,7 @@ DESIGN_CONSTRAINTS.md - Design principles
 ### Installation Independence
 ```bash
 # Install directly from this fork
-pip install git+https://github.com/yourusername/tiddl.git
+pip install git+https://github.com/Np3ir/tiddl-elvigilante.git
 
 # No need to install original
 # This fork is completely standalone
@@ -210,7 +210,7 @@ We deeply respect the original work by @oskvr37. This fork:
 
 ### Installation
 ```bash
-pip install git+https://github.com/yourusername/tiddl.git
+pip install git+https://github.com/Np3ir/tiddl-elvigilante.git
 ```
 
 ### First Steps
@@ -252,7 +252,7 @@ See [LICENSE](LICENSE) file for details.
 
 ## 🔗 Links
 
-- **This Fork**: https://github.com/yourusername/tiddl
+- **This Fork**: https://github.com/Np3ir/tiddl-elvigilante
 - **Original Project**: https://github.com/oskvr37/tiddl
 - **Original Author**: @oskvr37
 - **TIDAL**: https://tidal.com

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This application is for personal, educational, and archival purposes only. It is
 
 ### Installation (Easiest)
 ```bash
-pip install git+https://github.com/yourusername/tiddl.git
+pip install git+https://github.com/Np3ir/tiddl-elvigilante
 ```
 
 ### First Use
@@ -63,13 +63,13 @@ tiddl download url https://tidal.com/track/123456789
 
 ### From GitHub (Recommended)
 ```bash
-pip install git+https://github.com/yourusername/tiddl.git
+pip install git+https://github.com/Np3ir/tiddl-elvigilante
 ```
 
 ### Local Development
 ```bash
-git clone https://github.com/yourusername/tiddl.git
-cd tiddl
+git clone https://github.com/Np3ir/tiddl-elvigilante.git
+cd tiddl-elvigilante
 pip install -e .
 ```
 
@@ -161,6 +161,10 @@ enable = true
 lyrics = true
 save_lyrics = true
 cover = true
+
+[templates]
+default = "{album.artist}/{album.title}/{item.number}. {item.title}"
+artist_separator = " / "
 ```
 
 ---
@@ -190,7 +194,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 Quick start:
 ```bash
 # Fork and clone
-git clone https://github.com/yourusername/tiddl.git
+git clone https://github.com/Np3ir/tiddl.git
 cd tiddl
 
 # Create feature branch
@@ -211,7 +215,7 @@ MIT License - See [LICENSE](LICENSE) file for details.
 
 ## 🔗 Links
 
-- **This Fork:** https://github.com/yourusername/tiddl
+- **This Fork:** https://github.com/Np3ir/tiddl-elvigilante
 - **Original Project:** https://github.com/oskvr37/tiddl
 - **TIDAL:** https://tidal.com
 - **Python:** https://python.org
@@ -224,8 +228,10 @@ MIT License - See [LICENSE](LICENSE) file for details.
 Fork of [oskvr37/tiddl](https://github.com/oskvr37/tiddl)
 
 This fork extends the original with:
-- ✅ Python 3.10-3.12 support (original requires 3.13+)
-- ✅ Pydantic v1 compatibility for Python 3.14
+- ✅ Python 3.10-3.14+ support (original requires 3.13+)
+- ✅ Pydantic v1 compatibility
+- ✅ Configurable `artist_separator` for filenames and metadata tags
+- ✅ Correct pip packaging (`tiddl.cli` / `tiddl.core` namespace)
 - ✅ Enhanced documentation
 - ✅ Modular architecture
 - ✅ Production-grade quality
@@ -238,6 +244,6 @@ This tool respects TIDAL's ToS and copyright laws. Users are responsible for ens
 
 ---
 
-**Version:** 1.0.0  
-**Status:** Production Ready ✅  
-**Last Updated:** March 1, 2026
+**Version:** 1.1.1
+**Status:** Production Ready ✅
+**Last Updated:** March 9, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.0.0"
+version = "1.1.1"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = {text = "MIT"}
@@ -63,13 +63,13 @@ build = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourusername/tiddl-elvigilante"
-Documentation = "https://github.com/yourusername/tiddl-elvigilante#readme"
-Repository = "https://github.com/yourusername/tiddl-elvigilante"
-Issues = "https://github.com/yourusername/tiddl-elvigilante/issues"
-Changelog = "https://github.com/yourusername/tiddl-elvigilante/blob/main/CHANGELOG.md"
+Homepage = "https://github.com/Np3ir/tiddl-elvigilante"
+Documentation = "https://github.com/Np3ir/tiddl-elvigilante#readme"
+Repository = "https://github.com/Np3ir/tiddl-elvigilante"
+Issues = "https://github.com/Np3ir/tiddl-elvigilante/issues"
+Changelog = "https://github.com/Np3ir/tiddl-elvigilante/blob/main/CHANGELOG.md"
 "Original Project" = "https://github.com/oskvr37/tiddl"
-"About Fork" = "https://github.com/yourusername/tiddl-elvigilante/blob/main/FORK.md"
+"About Fork" = "https://github.com/Np3ir/tiddl-elvigilante/blob/main/FORK.md"
 
 [project.scripts]
 tiddl-elvigilante = "tiddl.cli.app:main"


### PR DESCRIPTION
## Summary

- Replace all `yourusername` → `Np3ir` across all docs
- Bump version to `1.1.1` in pyproject.toml and README
- Add CHANGELOG entries for packaging fix and pydantic v1 validator fix
- Fix `threads_count` default inconsistency (docs said 4, code uses 2)
- Add `artist_separator` to README config example

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Release version 1.1.1 with updated documentation, corrected configuration defaults, and changelog entries for recent packaging and validation fixes.

New Features:
- Document configurable artist_separator support for filenames and metadata tags.

Bug Fixes:
- Document the packaging fix so tiddl.cli and tiddl.core are correctly discoverable after pip installation.
- Document the Pydantic v1 validator changes that restore template inheritance and scan_path synchronization with download_path.
- Align documented threads_count default with the actual runtime default of 2 concurrent downloads.

Enhancements:
- Update project metadata and README to reference the correct GitHub fork URLs and clarify supported Python and Pydantic versions.
- Centralize DEFAULT_ARTIST_SEPARATOR and rename the template parameter to artist_separator for consistent configuration terminology.

Documentation:
- Refresh README, CONFIG, FORK, and CONTRIBUTING documentation for the 1.1.1 release, including installation commands, repository links, version number, and last updated date.
- Add configuration examples showing artist_separator usage and template settings in README and CONFIG.md.