### PR TITLE
test: downloader transport/retry/cancellation (block 2) + progress-reset fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,9 @@ dev = [
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0",
     "responses>=0.24",
-    "aioresponses>=0.7.6",
+    # NB: aioresponses is intentionally NOT used — it is incompatible with the
+    # pinned aiohttp 3.14 (ClientResponse now requires `stream_writer`). The
+    # downloader tests use a real local aiohttp server instead (tests/test_downloader.py).
     "mypy>=1.0",
     "black>=23.0",
     "ruff>=0.1.0",

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,0 +1,137 @@
+"""Downloader coverage (block 2): a short/mismatched body is detected and
+retried, an HTTP error is retried, and a mid-stream cancel aborts without
+retrying and without publishing a partial file.
+
+Uses a real local aiohttp server (aioresponses is incompatible with aiohttp
+3.14), so the client stack, streaming, staging → move → integrity → retry path
+is exercised end to end. `_download_with_retry` runs on a minimal host that
+reuses the real method + session factory.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from tiddl.cli.commands.download.downloader import Downloader, DownloadTask
+from tiddl.core import cancel
+
+AUDIO_CT = "audio/flac"  # not json/text/xml -> treated as audio by the downloader
+
+
+class _StubOutput:
+    def __init__(self):
+        self.console = types.SimpleNamespace(print=lambda *a, **k: None)
+
+    def download_advance(self, task_id, size=0):
+        pass
+
+
+class _StubDownloader:
+    """Minimal host for the real _download_with_retry / _get_http_session."""
+
+    _get_http_session = Downloader._get_http_session
+    _download_with_retry = Downloader._download_with_retry
+
+    def __init__(self):
+        self._http_session = None
+        self.rich_output = _StubOutput()
+
+
+def _scripted_app(script: list) -> web.Application:
+    """A /track handler that replays `script` (one spec per request):
+    ("ok", n) -> 200 with n bytes; ("status", code) -> that status."""
+    state = {"i": 0}
+
+    async def handler(request):
+        spec = script[min(state["i"], len(script) - 1)]
+        state["i"] += 1
+        if spec[0] == "ok":
+            return web.Response(body=b"\x00" * spec[1], content_type=AUDIO_CT)
+        if spec[0] == "status":
+            return web.Response(status=spec[1], content_type=AUDIO_CT)
+        raise AssertionError(f"unknown spec {spec!r}")
+
+    app = web.Application()
+    app.router.add_get("/track", handler)
+    return app
+
+
+async def _start(script: list) -> TestServer:
+    server = TestServer(_scripted_app(script))
+    await server.start_server()
+    return server
+
+
+@pytest.fixture(autouse=True)
+def _reset_cancel():
+    cancel.clear()
+    yield
+    cancel.clear()
+
+
+@pytest.fixture
+def fast_sleep(monkeypatch):
+    """Skip the downloader's 2s retry back-off so retry tests stay fast."""
+    async def _instant(*_a, **_k):
+        return None
+
+    import tiddl.cli.commands.download.downloader as dl
+    monkeypatch.setattr(dl.asyncio, "sleep", _instant)
+
+
+async def _download(server: TestServer, task: DownloadTask) -> bool:
+    url = str(server.make_url("/track"))
+    dl = _StubDownloader()
+    try:
+        return await dl._download_with_retry(task, [url], task_id=0)
+    finally:
+        if dl._http_session is not None:
+            await dl._http_session.close()
+
+
+async def test_short_body_is_detected_and_retried(tmp_path, fast_sleep):
+    server = await _start([("ok", 3000), ("ok", 5000)])  # short then full
+    try:
+        task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
+        ok = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.attempts == 2
+    assert (tmp_path / "out.bin").stat().st_size == 5000
+
+
+async def test_http_error_is_retried_then_succeeds(tmp_path, fast_sleep):
+    server = await _start([("status", 500), ("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
+        ok = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.attempts == 2
+
+
+async def test_cancellation_midstream_aborts_without_retry(tmp_path, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_is_cancelled():
+        calls["n"] += 1
+        return calls["n"] >= 2  # False at the top-of-loop check, True at the first chunk
+
+    monkeypatch.setattr("tiddl.core.cancel.is_cancelled", fake_is_cancelled)
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
+        ok = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is False
+    assert task.attempts == 1                    # aborted, did not retry
+    assert not (tmp_path / "out.bin").exists()   # partial dropped, nothing published

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -125,31 +125,35 @@ def _no_staging_leftovers(stage_dir) -> bool:
     return not list(stage_dir.glob("tiddl-*.part.*"))
 
 
-async def _download(server: TestServer, task: DownloadTask) -> bool:
+async def _download(server: TestServer, task: DownloadTask):
+    """Returns (ok, stub) so a test can inspect the stub (e.g. visual resets)."""
     url = str(server.make_url("/track"))
     dl = _StubDownloader()
     try:
-        return await dl._download_with_retry(task, [url], task_id=0)
+        ok = await dl._download_with_retry(task, [url], task_id=0)
     finally:
         if dl._http_session is not None:
             await dl._http_session.close()
+    return ok, dl
 
 
 async def test_short_body_is_detected_and_retried(tmp_path, fast_sleep, stage_dir):
     server = await _start([("ok", 3000), ("ok", 5000)])  # short then full
     try:
         task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
-        ok = await _download(server, task)
+        ok, dl = await _download(server, task)
     finally:
         await server.close()
 
     assert ok is True
     assert task.attempts == 2
     assert task.status == DownloadStatus.COMPLETED
+    assert task.error_message is None            # transient error cleared on success
     assert (tmp_path / "out.bin").stat().st_size == 5000
     # The per-attempt counter must reset: not 3000 + 5000 = 8000 (160%).
     assert task.bytes_downloaded == 5000
     assert task.progress_percentage == 100
+    assert dl.rich_output.resets == 1            # exactly one visual reset, for the single retry
     assert _no_staging_leftovers(stage_dir)
 
 
@@ -157,13 +161,14 @@ async def test_http_error_is_retried_then_succeeds(tmp_path, fast_sleep, stage_d
     server = await _start([("status", 500), ("ok", 5000)])
     try:
         task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
-        ok = await _download(server, task)
+        ok, _ = await _download(server, task)
     finally:
         await server.close()
 
     assert ok is True
     assert task.attempts == 2
     assert task.status == DownloadStatus.COMPLETED
+    assert task.error_message is None
     assert _no_staging_leftovers(stage_dir)
 
 
@@ -171,13 +176,14 @@ async def test_http_error_exhausted_fails(tmp_path, fast_sleep, stage_dir):
     server = await _start([("status", 500)])  # always 500
     try:
         task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
-        ok = await _download(server, task)
+        ok, _ = await _download(server, task)
     finally:
         await server.close()
 
     assert ok is False
     assert task.attempts == task.max_attempts == 3
     assert task.status == DownloadStatus.FAILED
+    assert task.error_message  # set to the transient error when attempts are exhausted
     assert not (tmp_path / "out.bin").exists()
     assert _no_staging_leftovers(stage_dir)
 
@@ -188,13 +194,14 @@ async def test_real_truncation_is_cleaned_and_retried(tmp_path, fast_sleep, stag
     server = await _start([("truncate", 5000, 3000), ("ok", 5000)])
     try:
         task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
-        ok = await _download(server, task)
+        ok, _ = await _download(server, task)
     finally:
         await server.close()
 
     assert ok is True
     assert task.attempts == 2
     assert task.status == DownloadStatus.COMPLETED
+    assert task.error_message is None
     assert (tmp_path / "out.bin").stat().st_size == 5000
     assert _no_staging_leftovers(stage_dir)
 
@@ -215,7 +222,7 @@ async def test_cancellation_midstream_aborts_without_retry(tmp_path, monkeypatch
         task = DownloadTask(
             url="x", output_path=tmp_path / "out.bin", expected_size=2 * CHUNK_SIZE
         )
-        ok = await _download(server, task)
+        ok, _ = await _download(server, task)
     finally:
         await server.close()
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,11 +1,10 @@
-"""Downloader coverage (block 2): a short/mismatched body is detected and
-retried, an HTTP error is retried, and a mid-stream cancel aborts without
-retrying and without publishing a partial file.
+"""Downloader coverage (block 2): transport / retry / cancellation.
 
-Uses a real local aiohttp server (aioresponses is incompatible with aiohttp
-3.14), so the client stack, streaming, staging → move → integrity → retry path
-is exercised end to end. `_download_with_retry` runs on a minimal host that
-reuses the real method + session factory.
+Uses a real local aiohttp server (aioresponses is incompatible with the pinned
+aiohttp 3.14). `_download_with_retry` runs on a minimal host that reuses the real
+method + session factory, so streaming, staging → move → integrity → retry runs
+end to end. Staging is redirected into the test's tmp dir so we can assert no
+`tiddl-*.part.*` leftovers.
 """
 from __future__ import annotations
 
@@ -15,7 +14,12 @@ import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
 
-from tiddl.cli.commands.download.downloader import Downloader, DownloadTask
+from tiddl.cli.commands.download.downloader import (
+    CHUNK_SIZE,
+    Downloader,
+    DownloadStatus,
+    DownloadTask,
+)
 from tiddl.core import cancel
 
 AUDIO_CT = "audio/flac"  # not json/text/xml -> treated as audio by the downloader
@@ -24,9 +28,13 @@ AUDIO_CT = "audio/flac"  # not json/text/xml -> treated as audio by the download
 class _StubOutput:
     def __init__(self):
         self.console = types.SimpleNamespace(print=lambda *a, **k: None)
+        self.resets = 0
 
     def download_advance(self, task_id, size=0):
         pass
+
+    def download_reset(self, task_id):
+        self.resets += 1
 
 
 class _StubDownloader:
@@ -41,8 +49,11 @@ class _StubDownloader:
 
 
 def _scripted_app(script: list) -> web.Application:
-    """A /track handler that replays `script` (one spec per request):
-    ("ok", n) -> 200 with n bytes; ("status", code) -> that status."""
+    """A /track handler replaying `script` (one spec per request):
+    ("ok", n)              -> 200 with n bytes
+    ("status", code)       -> that status, empty body
+    ("truncate", decl, n)  -> 200, Content-Length=decl but only n bytes then abort
+    """
     state = {"i": 0}
 
     async def handler(request):
@@ -52,6 +63,14 @@ def _scripted_app(script: list) -> web.Application:
             return web.Response(body=b"\x00" * spec[1], content_type=AUDIO_CT)
         if spec[0] == "status":
             return web.Response(status=spec[1], content_type=AUDIO_CT)
+        if spec[0] == "truncate":
+            declared, sent = spec[1], spec[2]
+            resp = web.StreamResponse(status=200, headers={"Content-Type": AUDIO_CT})
+            resp.content_length = declared
+            await resp.prepare(request)
+            await resp.write(b"\x00" * sent)
+            request.transport.abort()  # abrupt close -> client ClientPayloadError
+            return resp
         raise AssertionError(f"unknown spec {spec!r}")
 
     app = web.Application()
@@ -74,12 +93,36 @@ def _reset_cancel():
 
 @pytest.fixture
 def fast_sleep(monkeypatch):
-    """Skip the downloader's 2s retry back-off so retry tests stay fast."""
+    """Skip the downloader's retry back-off without mutating the global asyncio
+    module (which the aiohttp server relies on): swap the downloader's `asyncio`
+    reference for a proxy whose only override is an instant `sleep`."""
+    import asyncio as _asyncio
+
+    import tiddl.cli.commands.download.downloader as dl
+
     async def _instant(*_a, **_k):
         return None
 
+    class _AsyncioProxy:
+        def __getattr__(self, name):
+            return _instant if name == "sleep" else getattr(_asyncio, name)
+
+    monkeypatch.setattr(dl, "asyncio", _AsyncioProxy())
+
+
+@pytest.fixture
+def stage_dir(tmp_path, monkeypatch):
+    """Redirect the downloader's local staging into a known dir so tests can
+    assert no partial `tiddl-*.part.*` file is left behind."""
+    d = tmp_path / "stage"
+    d.mkdir()
     import tiddl.cli.commands.download.downloader as dl
-    monkeypatch.setattr(dl.asyncio, "sleep", _instant)
+    monkeypatch.setattr(dl.tempfile, "gettempdir", lambda: str(d))
+    return d
+
+
+def _no_staging_leftovers(stage_dir) -> bool:
+    return not list(stage_dir.glob("tiddl-*.part.*"))
 
 
 async def _download(server: TestServer, task: DownloadTask) -> bool:
@@ -92,7 +135,7 @@ async def _download(server: TestServer, task: DownloadTask) -> bool:
             await dl._http_session.close()
 
 
-async def test_short_body_is_detected_and_retried(tmp_path, fast_sleep):
+async def test_short_body_is_detected_and_retried(tmp_path, fast_sleep, stage_dir):
     server = await _start([("ok", 3000), ("ok", 5000)])  # short then full
     try:
         task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
@@ -102,10 +145,15 @@ async def test_short_body_is_detected_and_retried(tmp_path, fast_sleep):
 
     assert ok is True
     assert task.attempts == 2
+    assert task.status == DownloadStatus.COMPLETED
     assert (tmp_path / "out.bin").stat().st_size == 5000
+    # The per-attempt counter must reset: not 3000 + 5000 = 8000 (160%).
+    assert task.bytes_downloaded == 5000
+    assert task.progress_percentage == 100
+    assert _no_staging_leftovers(stage_dir)
 
 
-async def test_http_error_is_retried_then_succeeds(tmp_path, fast_sleep):
+async def test_http_error_is_retried_then_succeeds(tmp_path, fast_sleep, stage_dir):
     server = await _start([("status", 500), ("ok", 5000)])
     try:
         task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
@@ -115,17 +163,12 @@ async def test_http_error_is_retried_then_succeeds(tmp_path, fast_sleep):
 
     assert ok is True
     assert task.attempts == 2
+    assert task.status == DownloadStatus.COMPLETED
+    assert _no_staging_leftovers(stage_dir)
 
 
-async def test_cancellation_midstream_aborts_without_retry(tmp_path, monkeypatch):
-    calls = {"n": 0}
-
-    def fake_is_cancelled():
-        calls["n"] += 1
-        return calls["n"] >= 2  # False at the top-of-loop check, True at the first chunk
-
-    monkeypatch.setattr("tiddl.core.cancel.is_cancelled", fake_is_cancelled)
-    server = await _start([("ok", 5000)])
+async def test_http_error_exhausted_fails(tmp_path, fast_sleep, stage_dir):
+    server = await _start([("status", 500)])  # always 500
     try:
         task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
         ok = await _download(server, task)
@@ -133,5 +176,51 @@ async def test_cancellation_midstream_aborts_without_retry(tmp_path, monkeypatch
         await server.close()
 
     assert ok is False
-    assert task.attempts == 1                    # aborted, did not retry
-    assert not (tmp_path / "out.bin").exists()   # partial dropped, nothing published
+    assert task.attempts == task.max_attempts == 3
+    assert task.status == DownloadStatus.FAILED
+    assert not (tmp_path / "out.bin").exists()
+    assert _no_staging_leftovers(stage_dir)
+
+
+async def test_real_truncation_is_cleaned_and_retried(tmp_path, fast_sleep, stage_dir):
+    # Content-Length says 5000 but the server sends 3000 then aborts -> the client
+    # raises ClientPayloadError; the partial is cleaned and the download retries.
+    server = await _start([("truncate", 5000, 3000), ("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=tmp_path / "out.bin", expected_size=5000)
+        ok = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.attempts == 2
+    assert task.status == DownloadStatus.COMPLETED
+    assert (tmp_path / "out.bin").stat().st_size == 5000
+    assert _no_staging_leftovers(stage_dir)
+
+
+async def test_cancellation_midstream_aborts_without_retry(tmp_path, monkeypatch, stage_dir):
+    # Real midstream cancel: >= 2 chunks; allow the first chunk to be written,
+    # then cancel before the second (is_cancelled: top-check False, chunk1 False,
+    # chunk2 True).
+    calls = {"n": 0}
+
+    def fake_is_cancelled():
+        calls["n"] += 1
+        return calls["n"] >= 3
+
+    monkeypatch.setattr("tiddl.core.cancel.is_cancelled", fake_is_cancelled)
+    server = await _start([("ok", 2 * CHUNK_SIZE)])  # two 1 MiB chunks
+    try:
+        task = DownloadTask(
+            url="x", output_path=tmp_path / "out.bin", expected_size=2 * CHUNK_SIZE
+        )
+        ok = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is False
+    assert task.attempts == 1                     # aborted, did not retry
+    assert task.status == DownloadStatus.FAILED
+    assert not (tmp_path / "out.bin").exists()    # nothing published
+    assert _no_staging_leftovers(stage_dir)       # partial staging file dropped

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -553,12 +553,16 @@ class Downloader:
             task.increment_attempt()
             attempt = task.attempts
 
-            # Per-attempt progress reset: bytes_downloaded accumulates inside the
-            # chunk loop, so without this a retry keeps the previous attempt's
-            # bytes and reports >100% (e.g. 3000+5000 over a 5000-byte file = 160%).
-            # Zero the counter and the visual bar at the start of every attempt.
+            # Per-attempt reset: bytes_downloaded accumulates inside the chunk
+            # loop, so without this a retry keeps the previous attempt's bytes and
+            # reports >100% (e.g. 3000+5000 over a 5000-byte file = 160%). Also
+            # clear the transient error so a task that succeeds after a retry
+            # doesn't keep a stale error_message once it is COMPLETED. The visual
+            # bar only needs resetting on a retry (the first attempt starts clean).
             task.bytes_downloaded = 0
-            self.rich_output.download_reset(task_id)
+            task.error_message = None
+            if attempt > 1:
+                self.rich_output.download_reset(task_id)
 
             try:
                 # Stage the download on LOCAL disk, then move it to the final

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -553,6 +553,13 @@ class Downloader:
             task.increment_attempt()
             attempt = task.attempts
 
+            # Per-attempt progress reset: bytes_downloaded accumulates inside the
+            # chunk loop, so without this a retry keeps the previous attempt's
+            # bytes and reports >100% (e.g. 3000+5000 over a 5000-byte file = 160%).
+            # Zero the counter and the visual bar at the start of every attempt.
+            task.bytes_downloaded = 0
+            self.rich_output.download_reset(task_id)
+
             try:
                 # Stage the download on LOCAL disk, then move it to the final
                 # destination once complete. Writing directly to a network share

--- a/tiddl/cli/commands/download/output.py
+++ b/tiddl/cli/commands/download/output.py
@@ -80,8 +80,10 @@ class RichOutput:
         self.download_progress.update(task_id=task_id, advance=size, refresh=True)
 
     def download_reset(self, task_id: TaskID):
-        """Reset a download bar to 0 bytes (used when an attempt is retried)."""
-        self.download_progress.update(task_id=task_id, completed=0, refresh=True)
+        """Reset a download bar for a retry: reset() (not update(completed=0))
+        also restarts the elapsed-time and transfer-speed calculation, so the
+        retry doesn't inherit the failed attempt's timing."""
+        self.download_progress.reset(task_id, completed=0)
 
     def download_finish(self, task_id: TaskID) -> Task:
         task = self.download_progress._tasks.get(task_id)

--- a/tiddl/cli/commands/download/output.py
+++ b/tiddl/cli/commands/download/output.py
@@ -79,6 +79,10 @@ class RichOutput:
     def download_advance(self, task_id: TaskID, size: float):
         self.download_progress.update(task_id=task_id, advance=size, refresh=True)
 
+    def download_reset(self, task_id: TaskID):
+        """Reset a download bar to 0 bytes (used when an attempt is retried)."""
+        self.download_progress.update(task_id=task_id, completed=0, refresh=True)
+
     def download_finish(self, task_id: TaskID) -> Task:
         task = self.download_progress._tasks.get(task_id)
 


### PR DESCRIPTION
## What's in this PR

Block 2, first slice: the downloader's **transport / retry / cancellation** paths, tested against a real local aiohttp server, plus two real bugs the tests surfaced. Small and self-contained — cross-volume/NAS move, metadata and ffmpeg are separate later PRs.

**Commits (4)**
- `ed23dd4` — first downloader tests
- `17c8b5c` — fix(download): reset the per-attempt byte counter on retry
- `5c01f46` — test(download): harden transport/retry/cancellation
- `266ee7f` — fix(download): reset the bar only on retry, clear stale error_message

### Real bugs found by the tests
1. **`bytes_downloaded` was not reset between attempts** → a retry reported >100% progress (a 3000-byte short read + a 5000-byte retry over a 5000-byte file = 160%). Now zeroed per attempt, with the visual bar reset (`Progress.reset()`) only on retries.
2. **A task that succeeded after a retry kept its transient `error_message`** even though its status was COMPLETED. Now cleared at the start of each attempt.

### Coverage (5 tests, real local aiohttp server)
- short / size-mismatched body → integrity catch → retry → success (asserts the counter reset: `bytes_downloaded == 5000`, `progress == 100`, exactly one visual reset);
- HTTP 500 → retry → success; HTTP 500 exhausted → FAILED with an error_message;
- **real truncation**: Content-Length > bytes sent (server aborts) → client `ClientPayloadError` → partial cleaned → retry;
- **real mid-stream cancel**: ≥2 chunks, first written, cancel before the second → one attempt, FAILED, nothing published, no leftover staging file.

`aioresponses` is incompatible with the pinned aiohttp 3.14 (`ClientResponse` requires `stream_writer`), so it's removed from the dev extras and the tests use a real server.

### Verified
62 passed · ruff clean on the tests (the prod fixes add no new violations) · `compileall` clean on 3.10 (uv) and 3.13 · lock in sync.

---

## Contenido (ES)

Block 2, primera parte: rutas de **transporte / reintento / cancelación** del downloader, contra un servidor aiohttp local real, más dos bugs reales que los tests destaparon. PR pequeño y autocontenido — move cross-volumen/NAS, metadata y ffmpeg van en PRs posteriores.

### Bugs reales encontrados
1. **`bytes_downloaded` no se reseteaba entre intentos** → un retry reportaba >100% (3000+5000 sobre 5000 = 160%). Ahora se pone a 0 por intento; la barra visual se reinicia (`Progress.reset()`) solo en reintentos.
2. **Una tarea con éxito tras un retry conservaba su `error_message` transitorio** pese a quedar COMPLETED. Ahora se limpia al inicio de cada intento.

### Cobertura (5 tests)
cuerpo corto→retry (afirma reset del contador y una única reinicialización visual); HTTP 500→retry→éxito; HTTP 500 agotado→FAILED con error_message; **truncación real** (Content-Length>enviado → `ClientPayloadError` → limpieza+retry); **cancelación midstream real** (≥2 chunks, escribe el 1.º y cancela antes del 2.º → 1 intento, FAILED, no publica, sin staging huérfano).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add real-server downloader tests for transport, retry, and cancellation paths, and fix progress and error state handling across retry attempts.

Bug Fixes:
- Reset per-attempt byte counters and visual progress bar on retries to prevent over-100% progress reporting.
- Clear transient error messages at the start of each attempt so successfully retried downloads do not retain stale errors.

Enhancements:
- Introduce a rich-output download bar reset helper to correctly restart progress timing on retries.

Build:
- Remove reliance on aioresponses in dev dependencies due to incompatibility with the pinned aiohttp version and rely on a real aiohttp server for downloader tests.

Tests:
- Add end-to-end downloader tests against a real local aiohttp server covering short bodies, HTTP errors, truncation, and mid-stream cancellation.