### PR TITLE
fix(download): safe cross-filesystem publish (copy -> verify -> atomic replace)

### DIFF
--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -601,6 +601,44 @@ async def test_publish_success_survives_staging_unlink_failure(
     assert not _dest_leftovers(tmp_path)          # the dest-side .part temp is still cleaned up
 
 
+async def test_dest_tmp_unlink_failure_is_warned_not_fatal(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch, caplog
+):
+    """A best-effort dest-side temp cleanup failure must be observable (a
+    warning) but must never turn an otherwise-successful copy retry into a
+    failure — only the leftover surfaces, nothing silently disappears."""
+    fake, calls = _scripted_copy2(["short", "ok"])  # first copy corrupt, then good
+    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    real_unlink = dlmod._safe_unlink
+
+    def flaky_unlink(path):
+        # Fail only the dest-side ".part." cleanup (the corrupt first copy);
+        # everything else (e.g. the local staging drop) behaves normally.
+        if path is not None and os.path.basename(str(path)).startswith("out.bin.part."):
+            return False
+        return real_unlink(path)
+
+    monkeypatch.setattr(dlmod, "_safe_unlink", flaky_unlink)
+
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    caplog.set_level("WARNING")
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert calls["n"] == 2                     # corrupt copy, then a good re-copy
+    assert dest.stat().st_size == 5000
+    assert task.status == DownloadStatus.COMPLETED
+    assert any(
+        "Could not remove leftover destination-side temp" in r.message
+        for r in caplog.records
+    )
+
+
 async def test_same_volume_uses_atomic_rename_not_copy(
     tmp_path, fast_sleep, stage_dir, monkeypatch
 ):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -335,6 +335,8 @@ async def test_cross_volume_retries_transient_copy_error(
     assert calls["n"] == 3           # two transient failures, then success
     assert dest.stat().st_size == 5000
     assert not _dest_leftovers(tmp_path)
+    assert task.error_message is None       # a transient copy error must not linger
+    assert task.retained_staging is None    # publish was fully clean
 
 
 async def test_cross_volume_bad_copy_is_reverified_and_recopied(
@@ -356,6 +358,7 @@ async def test_cross_volume_bad_copy_is_reverified_and_recopied(
     assert dest.stat().st_size == 5000
     assert _no_staging_leftovers(stage_dir)
     assert not _dest_leftovers(tmp_path)
+    assert task.error_message is None       # the earlier corrupt-copy error must not linger
 
 
 async def test_cross_volume_hash_mismatch_is_detected(
@@ -423,6 +426,8 @@ async def test_cross_volume_replace_retries_then_succeeds(
     assert dest.stat().st_size == 5000
     assert not _dest_leftovers(tmp_path)
     assert _no_staging_leftovers(stage_dir)
+    assert task.error_message is None       # the transient replace error must not linger
+    assert task.retained_staging is None    # publish was fully clean, nothing retained
 
 
 async def test_cross_volume_replace_exhausted_keeps_prior_final(
@@ -513,6 +518,87 @@ async def test_publication_order_copy_fsync_verify_replace(
     assert ok is True
     # local staging verified first, then copy -> fsync -> destination verify -> atomic replace
     assert order == ["verify", "copy", "fsync", "verify", "replace"]
+
+
+async def test_same_volume_replace_retries_then_succeeds(
+    tmp_path, fast_sleep, stage_dir, monkeypatch
+):
+    monkeypatch.setattr(dlmod, "_same_volume", lambda a, b: True)
+    rfake, rcalls = _scripted_replace(["oserror", "ok"])
+    monkeypatch.setattr(dlmod.os, "replace", rfake)
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.attempts == 1          # rename retried in place; no re-download
+    assert rcalls["n"] == 2
+    assert task.status == DownloadStatus.COMPLETED
+    assert task.error_message is None  # the transient rename error must not linger
+    assert dest.stat().st_size == 5000
+
+
+async def test_same_volume_fsyncs_dest_dir_after_rename(
+    tmp_path, fast_sleep, stage_dir, monkeypatch
+):
+    monkeypatch.setattr(dlmod, "_same_volume", lambda a, b: True)
+    order = []
+    real_replace = os.replace
+    real_fsync_dir = dlmod._fsync_dir
+
+    def _replace(src, dst, *a, **k):
+        order.append("replace")
+        return real_replace(src, dst)
+
+    def _fsync_dir(p):
+        order.append("fsync_dir")
+        return real_fsync_dir(p)
+
+    monkeypatch.setattr(dlmod.os, "replace", _replace)
+    monkeypatch.setattr(dlmod, "_fsync_dir", _fsync_dir)
+
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    # dir fsync happens right after the rename, same durability contract as
+    # the cross-filesystem path.
+    assert order == ["replace", "fsync_dir"]
+
+
+async def test_publish_success_survives_staging_unlink_failure(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    """A destination publish must not be reported as failed just because the
+    best-effort delete of the now-redundant local staging copy failed (e.g. an
+    AV/indexer lock, or a remote filesystem that rejects the unlink). The final
+    file must be correct, and the leftover staging must be surfaced via
+    task.retained_staging (+ a warning) rather than silently dropped."""
+    monkeypatch.setattr(dlmod, "_safe_unlink", lambda p: False)
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.status == DownloadStatus.COMPLETED
+    assert dest.stat().st_size == 5000            # the final file IS correct
+    assert task.error_message is None
+    assert task.retained_staging is not None      # leftover staging reported, not hidden
+    assert task.retained_staging.exists()
+    assert not _dest_leftovers(tmp_path)          # the dest-side .part temp is still cleaned up
 
 
 async def test_same_volume_uses_atomic_rename_not_copy(

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -8,12 +8,16 @@ end to end. Staging is redirected into the test's tmp dir so we can assert no
 """
 from __future__ import annotations
 
+import hashlib
+import os
+import shutil
 import types
 
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
 
+import tiddl.cli.commands.download.downloader as dlmod
 from tiddl.cli.commands.download.downloader import (
     CHUNK_SIZE,
     Downloader,
@@ -38,10 +42,12 @@ class _StubOutput:
 
 
 class _StubDownloader:
-    """Minimal host for the real _download_with_retry / _get_http_session."""
+    """Minimal host that reuses the real download + publish machinery."""
 
     _get_http_session = Downloader._get_http_session
     _download_with_retry = Downloader._download_with_retry
+    _publish_staged = Downloader._publish_staged
+    _verify_or_repair = Downloader._verify_or_repair
 
     def __init__(self):
         self._http_session = None
@@ -231,3 +237,300 @@ async def test_cancellation_midstream_aborts_without_retry(tmp_path, monkeypatch
     assert task.status == DownloadStatus.FAILED
     assert not (tmp_path / "out.bin").exists()    # nothing published
     assert _no_staging_leftovers(stage_dir)       # partial staging file dropped
+
+
+# ---------------------------------------------------------------------------
+# Cross-filesystem safe publish: the destination lives on a different volume
+# from the local staging, so the copy -> verify -> atomic os.replace -> drop
+# staging path runs (`_same_volume` is forced False). A scripted copy2 injects
+# transient NAS errors and silent corruption.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cross_volume(monkeypatch):
+    monkeypatch.setattr(dlmod, "_same_volume", lambda a, b: False)
+
+
+def _dest_leftovers(dest_dir):
+    return list(dest_dir.glob("*.part.*"))
+
+
+def _staging_leftovers(stage_dir):
+    return list(stage_dir.glob("tiddl-*.part.*"))
+
+
+def _scripted_replace(script):
+    real = os.replace
+    calls = {"n": 0}
+
+    def fake(src, dst, *a, **k):
+        spec = script[min(calls["n"], len(script) - 1)]
+        calls["n"] += 1
+        if spec == "ok":
+            return real(src, dst)
+        if spec == "oserror":
+            raise OSError("simulated atomic-replace failure")
+        raise AssertionError(spec)
+
+    return fake, calls
+
+
+def _scripted_copy2(script):
+    real = shutil.copy2
+    calls = {"n": 0}
+
+    def fake(src, dst, *a, **k):
+        spec = script[min(calls["n"], len(script) - 1)]
+        calls["n"] += 1
+        if spec == "ok":
+            return real(src, dst)
+        if spec == "oserror":
+            raise OSError("simulated destination write error")
+        if spec == "short":
+            with open(dst, "wb") as f:
+                f.write(b"\x00" * 100)   # wrong size -> verify fails
+            return dst
+        if spec == "corrupt-hash":
+            with open(dst, "wb") as f:
+                f.write(b"\xff" * 5000)  # right size, wrong content -> hash fails
+            return dst
+        raise AssertionError(spec)
+
+    return fake, calls
+
+
+async def test_cross_volume_publish_success(tmp_path, fast_sleep, stage_dir, cross_volume):
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.attempts == 1
+    assert task.status == DownloadStatus.COMPLETED
+    assert dest.stat().st_size == 5000
+    assert _no_staging_leftovers(stage_dir)   # local staging removed after publish
+    assert not _dest_leftovers(tmp_path)      # no dest-side .part temp left
+
+
+async def test_cross_volume_retries_transient_copy_error(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    fake, calls = _scripted_copy2(["oserror", "oserror", "ok"])
+    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.attempts == 1        # re-copied from staging, did NOT re-download
+    assert calls["n"] == 3           # two transient failures, then success
+    assert dest.stat().st_size == 5000
+    assert not _dest_leftovers(tmp_path)
+
+
+async def test_cross_volume_bad_copy_is_reverified_and_recopied(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    fake, calls = _scripted_copy2(["short", "ok"])   # first copy lands corrupt, second good
+    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.attempts == 1        # verify caught the bad copy; staging survived, no re-download
+    assert calls["n"] == 2
+    assert dest.stat().st_size == 5000
+    assert _no_staging_leftovers(stage_dir)
+    assert not _dest_leftovers(tmp_path)
+
+
+async def test_cross_volume_hash_mismatch_is_detected(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    good_hash = hashlib.md5(b"\x00" * 5000).hexdigest()
+    fake, calls = _scripted_copy2(["corrupt-hash", "ok"])  # right size, wrong content, then good
+    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(
+            url="x", output_path=dest, expected_size=5000, expected_hash=good_hash
+        )
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert calls["n"] == 2           # silent same-size corruption caught by hash -> re-copy
+    assert dest.stat().st_size == 5000
+    assert not _dest_leftovers(tmp_path)
+
+
+async def test_cross_volume_exhausted_keeps_staging_no_partial_final(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    fake, _ = _scripted_copy2(["short"])   # every copy corrupts -> never publishes
+    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is False
+    assert task.attempts == 1              # publish failure does NOT re-download
+    assert task.status == DownloadStatus.FAILED
+    assert not dest.exists()              # no incomplete final file
+    assert not _dest_leftovers(tmp_path)  # no dest-side .part temp left
+    # The verified local download is RETAINED for recovery, recorded on the task.
+    kept = _staging_leftovers(stage_dir)
+    assert len(kept) == 1
+    assert task.retained_staging == kept[0]
+
+
+async def test_cross_volume_replace_retries_then_succeeds(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    rfake, rcalls = _scripted_replace(["oserror", "ok"])
+    monkeypatch.setattr(dlmod.os, "replace", rfake)
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.attempts == 1        # the atomic publish retried; no re-download
+    assert rcalls["n"] == 2
+    assert dest.stat().st_size == 5000
+    assert not _dest_leftovers(tmp_path)
+    assert _no_staging_leftovers(stage_dir)
+
+
+async def test_cross_volume_replace_exhausted_keeps_prior_final(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    dest = tmp_path / "out.bin"
+    dest.write_bytes(b"P" * 4000)          # a prior, valid final file
+    rfake, _ = _scripted_replace(["oserror"])   # the atomic publish always fails
+    monkeypatch.setattr(dlmod.os, "replace", rfake)
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is False
+    assert task.status == DownloadStatus.FAILED
+    assert dest.read_bytes() == b"P" * 4000        # prior final file left untouched
+    assert not _dest_leftovers(tmp_path)           # verified temp cleaned up
+    assert len(_staging_leftovers(stage_dir)) == 1  # staging retained
+
+
+async def test_corrupt_local_staging_detected_before_copy(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    copy_calls = {"n": 0}
+    real = shutil.copy2
+
+    def counting_copy(src, dst, *a, **k):
+        copy_calls["n"] += 1
+        return real(src, dst)
+
+    monkeypatch.setattr(dlmod.shutil, "copy2", counting_copy)
+    server = await _start([("ok", 3000)])   # short download -> local staging invalid (size)
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is False
+    assert task.attempts == 3        # invalid local staging -> re-download to the limit
+    assert task.status == DownloadStatus.FAILED
+    assert copy_calls["n"] == 0      # never copied a bad staging to the destination
+    assert not dest.exists()
+
+
+async def test_publication_order_copy_fsync_verify_replace(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    order = []
+    real_copy = shutil.copy2
+    real_fsync = dlmod._fsync_path
+    real_verify = dlmod.FileIntegrityChecker.verify_file_async
+    real_replace = os.replace
+
+    def _copy(src, dst, *a, **k):
+        order.append("copy")
+        return real_copy(src, dst)
+
+    def _fsync(p):
+        order.append("fsync")
+        return real_fsync(p)
+
+    async def _verify(*a, **k):
+        order.append("verify")
+        return await real_verify(*a, **k)
+
+    def _replace(src, dst, *a, **k):
+        order.append("replace")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(dlmod.shutil, "copy2", _copy)
+    monkeypatch.setattr(dlmod, "_fsync_path", _fsync)
+    monkeypatch.setattr(dlmod.FileIntegrityChecker, "verify_file_async", staticmethod(_verify))
+    monkeypatch.setattr(dlmod.os, "replace", _replace)
+
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True
+    # local staging verified first, then copy -> fsync -> destination verify -> atomic replace
+    assert order == ["verify", "copy", "fsync", "verify", "replace"]
+
+
+async def test_same_volume_uses_atomic_rename_not_copy(
+    tmp_path, fast_sleep, stage_dir, monkeypatch
+):
+    monkeypatch.setattr(dlmod, "_same_volume", lambda a, b: True)
+
+    def _boom(*a, **k):
+        raise AssertionError("copy2 must not be called on the same-volume fast path")
+
+    monkeypatch.setattr(dlmod.shutil, "copy2", _boom)
+    server = await _start([("ok", 5000)])
+    dest = tmp_path / "out.bin"
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, _ = await _download(server, task)
+    finally:
+        await server.close()
+
+    assert ok is True                # published via atomic os.replace, no copy
+    assert dest.stat().st_size == 5000

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -54,14 +54,24 @@ def _normalize_dir(path: Path) -> str:
     return os.path.normcase(os.path.normpath(s))
 
 
-def _safe_unlink(path: Optional[Path]) -> None:
-    """Delete a file if it exists, swallowing OS errors (best-effort cleanup)."""
+def _safe_unlink(path: Optional[Path]) -> bool:
+    """Delete a file if it exists, swallowing OS errors (best-effort cleanup).
+
+    Returns True if `path` is gone once this returns (deleted here, or it never
+    existed) and False if an existing file could NOT be removed (e.g. locked by
+    an antivirus/indexer, or a remote filesystem that rejects the unlink).
+    Callers that must not silently claim "no orphan left behind" — i.e. after a
+    successful publish, when the leftover would otherwise go unreported — should
+    check this return value instead of treating cleanup as unconditional."""
     if path is None:
-        return
+        return True
     try:
         Path(path).unlink()
+        return True
+    except FileNotFoundError:
+        return True
     except OSError:
-        pass
+        return False
 
 
 def _same_volume(a: Path, b: Path) -> bool:
@@ -614,11 +624,19 @@ class Downloader:
 
         Contract: the final path is only ever replaced atomically by a
         fully-verified candidate, and the known-good local staging is deleted
-        ONLY after a successful publish. A prior valid final file is never removed
-        by a failed publish.
+        (best-effort — see the ``(True, staging)`` case below) ONLY after a
+        successful publish. A prior valid final file is never removed by a failed
+        publish.
 
         Returns ``(published, retained_staging)``:
-          * ``(True, None)``    published; staging deleted; output_path is verified.
+          * ``(True, None)``    published; local staging deleted; output_path is
+                                 verified; ``task.error_message`` is cleared.
+          * ``(True, staging)``  published — output_path is verified and correct —
+                                 but the local staging copy could not be deleted
+                                 afterwards (best-effort cleanup failure, e.g. an
+                                 AV/indexer lock or a remote filesystem). Logged as
+                                 a warning; the leftover file is safe to delete
+                                 manually once noticed.
           * ``(False, staging)``  the DESTINATION could not be published; the local
                                   staging is retained (caller must NOT re-download);
                                   the prior final file and every temp created here
@@ -648,6 +666,8 @@ class Downloader:
             for move_attempt in range(5):
                 try:
                     os.replace(staging, task.output_path)
+                    await asyncio.to_thread(_fsync_dir, task.output_path.parent)
+                    task.error_message = None
                     return True, None
                 except OSError as e:
                     task.error_message = f"publish rename failed: {e}"
@@ -686,8 +706,23 @@ class Downloader:
                     try:
                         os.replace(dest_tmp, task.output_path)
                         await asyncio.to_thread(_fsync_dir, task.output_path.parent)
-                        _safe_unlink(staging)  # only now is the local copy safe to drop
-                        return True, None
+                        task.error_message = None
+                        # Only now is the local copy safe to drop. This is a
+                        # best-effort delete: report it, don't lie about it — if
+                        # it fails (AV/indexer lock, remote fs), the publish is
+                        # still a success, but the leftover must not go unnoticed.
+                        if await asyncio.to_thread(_safe_unlink, staging):
+                            return True, None
+                        log.warning(
+                            f"Published '{task.track_title}' but could not delete "
+                            f"the local staging copy at {staging}; left in place "
+                            "(best-effort cleanup)."
+                        )
+                        self.rich_output.console.print(
+                            f"[yellow]⚠️  Published, but couldn't remove local "
+                            f"staging copy at {staging}[/] {task.track_title}"
+                        )
+                        return True, staging
                     except OSError as e:
                         task.error_message = f"atomic publish failed: {e}"
                         log.warning(f"{task.error_message} (attempt {replace_attempt+1})")
@@ -743,6 +778,11 @@ class Downloader:
             # bar only needs resetting on a retry (the first attempt starts clean).
             task.bytes_downloaded = 0
             task.error_message = None
+            # A stale retained_staging from an earlier call (e.g. this same
+            # DownloadTask being retried later by an outer caller) must not
+            # survive into a fresh attempt — it's only meaningful as the direct
+            # outcome of THIS attempt's publish.
+            task.retained_staging = None
             if attempt > 1:
                 self.rich_output.download_reset(task_id)
 
@@ -825,6 +865,9 @@ class Downloader:
                 if published:
                     tmp_path = None  # staging consumed/deleted by the publisher
                     task.status = DownloadStatus.COMPLETED
+                    # None unless _publish_staged could not delete the local
+                    # staging copy after a successful publish (see its docstring).
+                    task.retained_staging = retained
                     if attempt > 1:
                         log.info(f"Successfully downloaded '{task.track_title}' on attempt {attempt}")
                         self.rich_output.console.print(

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -74,6 +74,20 @@ def _safe_unlink(path: Optional[Path]) -> bool:
         return False
 
 
+def _safe_unlink_warn(path: Path, context: str) -> bool:
+    """`_safe_unlink` plus an honest log warning when an existing file could
+    not be removed. Cleanup here is always best-effort: a failure logged by
+    this helper never turns an otherwise-successful publish into a failure —
+    it only makes an otherwise-silent leftover observable."""
+    ok = _safe_unlink(path)
+    if not ok:
+        log.warning(
+            f"Could not remove leftover destination-side temp file at {path} "
+            f"({context}); left in place (best-effort cleanup)."
+        )
+    return ok
+
+
 def _same_volume(a: Path, b: Path) -> bool:
     """True if paths `a` and `b` live on the same filesystem (st_dev match).
 
@@ -639,8 +653,9 @@ class Downloader:
                                  manually once noticed.
           * ``(False, staging)``  the DESTINATION could not be published; the local
                                   staging is retained (caller must NOT re-download);
-                                  the prior final file and every temp created here
-                                  are left clean.
+                                  the prior final file is untouched, and every temp
+                                  created here has a best-effort delete attempted
+                                  (a failure to remove one is logged, not hidden).
           * ``(False, None)``   the local staging itself is invalid; re-download.
 
         This is a general cross-filesystem safe publish — it protects any
@@ -684,14 +699,14 @@ class Downloader:
             task.output_path.name + f".part.{uuid.uuid4().hex[:8]}"
         )
         for publish_attempt in range(5):
-            _safe_unlink(dest_tmp)
+            _safe_unlink_warn(dest_tmp, "stale temp from a previous attempt")
             try:
                 await asyncio.to_thread(shutil.copy2, str(staging), str(dest_tmp))
                 await asyncio.to_thread(_fsync_path, dest_tmp)  # commit before verifying
             except OSError as e:
                 task.error_message = f"copy to destination failed: {e}"
                 log.warning(f"{task.error_message} (attempt {publish_attempt+1})")
-                _safe_unlink(dest_tmp)
+                _safe_unlink_warn(dest_tmp, "cleanup after a failed copy")
                 if publish_attempt == 4:
                     break
                 await asyncio.sleep(1.0 + publish_attempt)
@@ -727,7 +742,7 @@ class Downloader:
                         task.error_message = f"atomic publish failed: {e}"
                         log.warning(f"{task.error_message} (attempt {replace_attempt+1})")
                         if replace_attempt == 4:
-                            _safe_unlink(dest_tmp)
+                            _safe_unlink_warn(dest_tmp, "replace exhausted its retries")
                             return False, staging  # keep staging; prior final untouched
                         await asyncio.sleep(1.0 + replace_attempt)
 
@@ -735,12 +750,12 @@ class Downloader:
             # Drop it and re-copy from the surviving staging.
             task.error_message = err
             log.warning(f"Destination validation failed (attempt {publish_attempt+1}): {err}")
-            _safe_unlink(dest_tmp)
+            _safe_unlink_warn(dest_tmp, "cleanup after a corrupt destination copy")
             if publish_attempt < 4:
                 await asyncio.sleep(1.0 + publish_attempt)
 
-        # Publish exhausted: clean the dest temp, KEEP the local staging.
-        _safe_unlink(dest_tmp)
+        # Publish exhausted: best-effort clean the dest temp, KEEP the local staging.
+        _safe_unlink_warn(dest_tmp, "cleanup after publish exhausted its retries")
         return False, staging
 
     async def _download_with_retry(

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -53,6 +53,62 @@ def _normalize_dir(path: Path) -> str:
         s = s[len("\\\\?\\"):]
     return os.path.normcase(os.path.normpath(s))
 
+
+def _safe_unlink(path: Optional[Path]) -> None:
+    """Delete a file if it exists, swallowing OS errors (best-effort cleanup)."""
+    if path is None:
+        return
+    try:
+        Path(path).unlink()
+    except OSError:
+        pass
+
+
+def _same_volume(a: Path, b: Path) -> bool:
+    """True if paths `a` and `b` live on the same filesystem (st_dev match).
+
+    Used by the safe-publish step to pick the atomic-rename fast path. Kept as a
+    module-level function so tests can force the cross-filesystem path."""
+    try:
+        return os.stat(a).st_dev == os.stat(b).st_dev
+    except OSError:
+        return False
+
+
+def _fsync_path(path: Path) -> None:
+    """Best-effort flush of a file's data to storage before it is verified.
+
+    shutil.copy2 only closes the file; on a network share the bytes may still sit
+    in a write cache, so an immediate verify could read cache rather than what
+    actually landed. Filesystems that don't support fsync just no-op."""
+    try:
+        fd = os.open(str(path), os.O_RDWR)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _fsync_dir(path: Path) -> None:
+    """Best-effort fsync of a directory (POSIX only) so a rename into it is
+    durable across a power loss. A no-op on Windows / unsupported filesystems."""
+    if os.name != "posix":
+        return
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
 # ====================================================================
 # IMPROVEMENT 1: Enums for download states
 # ====================================================================
@@ -95,6 +151,9 @@ class DownloadTask:
     max_attempts: int = 3
     bytes_downloaded: int = 0
     error_message: Optional[str] = None
+    # Set when the download succeeded but the destination could not be published:
+    # the verified local file is kept here for recovery/re-publish (never deleted).
+    retained_staging: Optional[Path] = None
 
     @property
     def progress_percentage(self) -> float:
@@ -526,6 +585,129 @@ class Downloader:
             return db_path
         return None
 
+    async def _verify_or_repair(self, candidate: Path, task: DownloadTask):
+        """Verify a candidate file (size/hash). On an MP4/M4A container failure,
+        attempt one faststart repair in place and re-verify. Returns (ok, error)."""
+        ok, err = await FileIntegrityChecker.verify_file_async(
+            candidate, expected_size=task.expected_size, expected_hash=task.expected_hash
+        )
+        if ok:
+            return True, None
+        if candidate.suffix.lower() in [".m4a", ".mp4", ".m4v"]:
+            try:
+                repaired = Path(await asyncio.to_thread(fix_mp4_faststart, candidate))
+                ok2, err2 = await FileIntegrityChecker.verify_file_async(repaired)
+                if ok2:
+                    if repaired != candidate:
+                        os.replace(repaired, candidate)
+                    self.rich_output.console.print(
+                        f"[green]✓ Repaired container (moov atom) [/]{task.track_title}"
+                    )
+                    return True, None
+                return False, err2
+            except Exception as repair_exc:
+                log.error(f"Repair failed for '{task.track_title}': {repair_exc}")
+        return False, err
+
+    async def _publish_staged(self, task: DownloadTask, staging: Path):
+        """Publish a downloaded staging file to ``task.output_path``.
+
+        Contract: the final path is only ever replaced atomically by a
+        fully-verified candidate, and the known-good local staging is deleted
+        ONLY after a successful publish. A prior valid final file is never removed
+        by a failed publish.
+
+        Returns ``(published, retained_staging)``:
+          * ``(True, None)``    published; staging deleted; output_path is verified.
+          * ``(False, staging)``  the DESTINATION could not be published; the local
+                                  staging is retained (caller must NOT re-download);
+                                  the prior final file and every temp created here
+                                  are left clean.
+          * ``(False, None)``   the local staging itself is invalid; re-download.
+
+        This is a general cross-filesystem safe publish — it protects any
+        destination that can fail or write partially mid-publish (NAS/SMB/NFS,
+        USB/external drives, cloud-synced folders, full/quota disks, AV/indexer
+        locks, a crash mid-copy, silent same-size corruption). The NAS is only the
+        most visible consumer. Same-filesystem publishes use an atomic rename.
+        """
+        task.status = DownloadStatus.VERIFYING
+
+        # 1. Verify (and repair) the LOCAL staging ONCE, before touching the
+        #    destination: a corrupt local download must be re-downloaded, not
+        #    copied to the destination five times.
+        ok, err = await self._verify_or_repair(staging, task)
+        if not ok:
+            task.error_message = f"local file invalid: {err}"
+            _safe_unlink(staging)
+            return False, None
+
+        # 2. Same filesystem: a single atomic rename (no bytes copied). Retry only
+        #    transient locks; if it never happens the staging still exists.
+        if _same_volume(staging, task.output_path.parent):
+            for move_attempt in range(5):
+                try:
+                    os.replace(staging, task.output_path)
+                    return True, None
+                except OSError as e:
+                    task.error_message = f"publish rename failed: {e}"
+                    if move_attempt == 4:
+                        log.warning(f"Failed to publish (rename) after 5 attempts: {e}")
+                        return False, staging
+                    log.warning(f"Publish rename locked (attempt {move_attempt+1}), retrying: {e}")
+                    await asyncio.sleep(1.0 + move_attempt)
+            return False, staging
+
+        # 3. Cross filesystem: copy -> fsync -> verify a dest-side temp, then
+        #    atomically publish it with os.replace().
+        dest_tmp = task.output_path.with_name(
+            task.output_path.name + f".part.{uuid.uuid4().hex[:8]}"
+        )
+        for publish_attempt in range(5):
+            _safe_unlink(dest_tmp)
+            try:
+                await asyncio.to_thread(shutil.copy2, str(staging), str(dest_tmp))
+                await asyncio.to_thread(_fsync_path, dest_tmp)  # commit before verifying
+            except OSError as e:
+                task.error_message = f"copy to destination failed: {e}"
+                log.warning(f"{task.error_message} (attempt {publish_attempt+1})")
+                _safe_unlink(dest_tmp)
+                if publish_attempt == 4:
+                    break
+                await asyncio.sleep(1.0 + publish_attempt)
+                continue
+
+            ok, err = await self._verify_or_repair(dest_tmp, task)
+            if ok:
+                # Atomic publish, with its own retry. A failure here must NEVER
+                # delete the prior final file — only a successful os.replace
+                # overwrites it, atomically.
+                for replace_attempt in range(5):
+                    try:
+                        os.replace(dest_tmp, task.output_path)
+                        await asyncio.to_thread(_fsync_dir, task.output_path.parent)
+                        _safe_unlink(staging)  # only now is the local copy safe to drop
+                        return True, None
+                    except OSError as e:
+                        task.error_message = f"atomic publish failed: {e}"
+                        log.warning(f"{task.error_message} (attempt {replace_attempt+1})")
+                        if replace_attempt == 4:
+                            _safe_unlink(dest_tmp)
+                            return False, staging  # keep staging; prior final untouched
+                        await asyncio.sleep(1.0 + replace_attempt)
+
+            # Destination copy is corrupt (e.g. a NAS that corrupts on flush).
+            # Drop it and re-copy from the surviving staging.
+            task.error_message = err
+            log.warning(f"Destination validation failed (attempt {publish_attempt+1}): {err}")
+            _safe_unlink(dest_tmp)
+            if publish_attempt < 4:
+                await asyncio.sleep(1.0 + publish_attempt)
+
+        # Publish exhausted: clean the dest temp, KEEP the local staging.
+        _safe_unlink(dest_tmp)
+        return False, staging
+
     async def _download_with_retry(
         self,
         task: DownloadTask,
@@ -635,117 +817,70 @@ class Downloader:
                             pass
                     return False
 
-                # Move temporary file to destination with retry logic
-                # This fixes WinError 32 on network shares where file close is not instant
-                move_success = False
-                for move_attempt in range(5):
-                    try:
-                        shutil.move(tmp_path, task.output_path)
-                        move_success = True
-                        break
-                    except OSError as e:
-                        # WinError 32: The process cannot access the file...
-                        if move_attempt == 4:
-                            log.warning(f"Failed to move file after 5 attempts: {e}")
-                            raise e
+                # Publish the downloaded staging to its destination. See
+                # _publish_staged for the copy -> fsync -> verify -> atomic-replace
+                # contract and its cross-filesystem rationale.
+                published, retained = await self._publish_staged(task, tmp_path)
 
-                        log.warning(f"File move locked (attempt {move_attempt+1}), retrying: {e}")
-                        await asyncio.sleep(1.0 + move_attempt)
-
-                tmp_path = None  # No longer exists, moved
-
-                # ===================================================================
-                # Critical validation: ensure the file is not corrupt
-                # ===================================================================
-                task.status = DownloadStatus.VERIFYING
-
-                is_valid, error_msg = await FileIntegrityChecker.verify_file_async(
-                    task.output_path,
-                    expected_size=task.expected_size,
-                    expected_hash=task.expected_hash
-                )
-
-                if not is_valid:
-                    task.status = DownloadStatus.CORRUPTED
-                    log.warning(f"File validation failed for '{task.track_title}': {error_msg}")
-
-                    # Attempt to repair MP4/M4A container using ffmpeg faststart remux
-                    if task.output_path.suffix.lower() in [".m4a", ".mp4", ".m4v"]:
-                        try:
-                            repaired_path = await asyncio.to_thread(fix_mp4_faststart, task.output_path)
-                            # Verify again after repair
-                            is_valid_repaired, error_msg_repaired = await FileIntegrityChecker.verify_file_async(repaired_path)
-
-                            if is_valid_repaired:
-                                self.rich_output.console.print(
-                                    f"[green]✓ Repaired container (moov atom) [/]{task.track_title}"
-                                )
-                                task.status = DownloadStatus.COMPLETED
-                                return True
-                            else:
-                                log.warning(f"Repair validation failed: {error_msg_repaired}")
-                        except Exception as repair_exc:
-                            log.error(f"Repair failed for '{task.track_title}': {repair_exc}")
-
-                    if task.can_retry:
-                        log.warning(
-                            f"File validation failed for '{task.track_title}' "
-                            f"(attempt {attempt}/{task.max_attempts}). Retrying..."
-                        )
+                if published:
+                    tmp_path = None  # staging consumed/deleted by the publisher
+                    task.status = DownloadStatus.COMPLETED
+                    if attempt > 1:
+                        log.info(f"Successfully downloaded '{task.track_title}' on attempt {attempt}")
                         self.rich_output.console.print(
-                            f"[yellow]⚠️  Corrupt file detected ({error_msg}), retrying... "
-                            f"({attempt}/{task.max_attempts})[/] {task.track_title}"
+                            f"[green]✓ Retry successful![/] {task.track_title}"
                         )
+                    return True
 
-                        # Delete corrupt file
-                        if task.output_path.exists():
-                            task.output_path.unlink()
-
-                        # Wait before retrying
-                        await asyncio.sleep(2)
-                        task.status = DownloadStatus.DOWNLOADING
-                        continue
-                    else:
-                        # Final attempt failed
-                        log.error(
-                            f"File validation failed for '{task.track_title}' "
-                            f"after {task.max_attempts} attempts. File is corrupt."
-                        )
-                        self.rich_output.console.print(
-                            f"[red]❌ File corrupt after {task.max_attempts} attempts: {error_msg}[/] {task.track_title}"
-                        )
-                        if task.output_path.exists():
-                            task.output_path.unlink()
-                        task.status = DownloadStatus.FAILED
-                        return False
-
-                # Successful validation
-                task.status = DownloadStatus.COMPLETED
-                if attempt > 1:
-                    log.info(f"Successfully downloaded '{task.track_title}' on attempt {attempt}")
-                    self.rich_output.console.print(
-                        f"[green]✓ Retry successful![/] {task.track_title}"
+                if retained is not None:
+                    # The download is intact but the DESTINATION could not be
+                    # published. Do NOT re-download: keep the local file so it can be
+                    # recovered / re-published later, and stop.
+                    tmp_path = None  # ownership handed to the retained staging
+                    task.status = DownloadStatus.FAILED
+                    task.retained_staging = retained
+                    log.error(
+                        f"Could not publish '{task.track_title}' to destination; kept "
+                        f"local copy at {retained} ({task.error_message})"
                     )
+                    self.rich_output.console.print(
+                        f"[red]❌ Could not publish to destination; kept local copy at "
+                        f"{retained}[/] {task.track_title}"
+                    )
+                    return False
 
-                return True
+                # The local staging itself was invalid -> re-download.
+                tmp_path = None  # already removed by the publisher
+                task.status = DownloadStatus.CORRUPTED
+                if task.can_retry:
+                    self.rich_output.console.print(
+                        f"[yellow]⚠️  Corrupt download ({task.error_message}), retrying... "
+                        f"({attempt}/{task.max_attempts})[/] {task.track_title}"
+                    )
+                    await asyncio.sleep(2)
+                    task.status = DownloadStatus.DOWNLOADING
+                    continue
+                else:
+                    self.rich_output.console.print(
+                        f"[red]❌ Download corrupt after {task.max_attempts} attempts: "
+                        f"{task.error_message}[/] {task.track_title}"
+                    )
+                    task.status = DownloadStatus.FAILED
+                    return False
 
             except Exception as e:
                 task.error_message = str(e)
                 log.error(f"Download error for '{task.track_title}' (attempt {attempt}): {e}")
 
-                # Clean up temporary file if exists
+                # Clean up the partial local staging from this failed attempt.
                 if tmp_path and tmp_path.exists():
                     try:
                         tmp_path.unlink()
-                    except:
+                    except OSError:
                         pass
-
-                # Clean up destination file if partial
-                if task.output_path.exists():
-                    try:
-                        task.output_path.unlink()
-                    except:
-                        pass
+                # NB: never delete task.output_path here. Download errors happen
+                # before publishing, so a prior valid final file must survive a
+                # failed attempt — only a successful atomic publish replaces it.
 
                 if task.can_retry:
                     self.rich_output.console.print(


### PR DESCRIPTION
# fix(download): safe cross-filesystem publish (copy → verify → atomic replace)

## Summary / Resumen

**EN:** Adds a safe, cross-filesystem publish step for downloaded files, replacing an unconditional move with an explicit staging → verify → publish contract that survives NAS/SMB/NFS, USB drives, cloud-synced folders, and other destinations that can fail or write partially mid-publish.

**ES:** Agrega un paso de publicación seguro y cross-filesystem para los archivos descargados, reemplazando un move incondicional por un contrato explícito de staging → verificación → publicación que sobrevive a NAS/SMB/NFS, discos USB, carpetas sincronizadas en la nube, y otros destinos que pueden fallar o escribir parcialmente durante la publicación.

## Contract / Contrato

**EN**
1. Verify (and repair, for MP4/M4A) the local staging file once, before touching the destination.
2. Same filesystem: a single atomic `os.replace`, retried on transient locks, followed by a best-effort `fsync` of the destination directory.
3. Cross filesystem: copy the staging file to a destination-side temp, `fsync` it (best-effort), verify it (size/hash), then atomically `os.replace` it into place (retried independently), `fsync` the destination directory (POSIX), and only then delete the local staging copy.
4. If the destination can't be published after all retries, the local staging file is **retained** (`task.retained_staging`) instead of deleted — the caller does not re-download, and a prior valid final file is never touched by a failed publish.

**ES**
1. Verificar (y reparar, para MP4/M4A) el archivo de staging local una sola vez, antes de tocar el destino.
2. Mismo filesystem: un único `os.replace` atómico, con retry ante locks transitorios, seguido de un `fsync` best-effort del directorio destino.
3. Filesystem distinto: copiar el staging a un temporal del lado del destino, hacer `fsync` (best-effort), verificarlo (tamaño/hash), y recién entonces reemplazarlo atómicamente con `os.replace` (con su propio retry), hacer `fsync` del directorio destino (POSIX), y solo ahí borrar la copia local de staging.
4. Si el destino no puede publicarse tras agotar los reintentos, el staging local se **conserva** (`task.retained_staging`) en vez de borrarse — no se vuelve a descargar, y un archivo final previo válido nunca es tocado por una publicación fallida.

## Declared limitations / Limitaciones declaradas

**EN**
- Cleanup of temporary files (staging and destination-side temp) is **best-effort**: on an AV/indexer lock or a remote filesystem that rejects the unlink, the publish is still reported successful but the leftover is logged and, for the staging file, recorded in `task.retained_staging`.
- A crash or power loss *during* the copy can still leave a destination-side `.part` temp file behind; there is no age-based sweeper yet (planned as a follow-up).
- Silent same-size corruption is only caught when `expected_hash` is provided — size alone can't distinguish two different files of the same length.
- MP4/M4A faststart repair is preserved from the existing code but not covered by dedicated tests yet (planned as a follow-up).

**ES**
- La limpieza de archivos temporales (staging y temporal del lado destino) es **best-effort**: ante un lock de antivirus/indexador o un filesystem remoto que rechaza el unlink, la publicación se sigue reportando exitosa, pero el remanente queda registrado en el log y, para el staging, en `task.retained_staging`.
- Un crash o corte de energía *durante* la copia puede dejar un temporal `.part` del lado del destino; todavía no existe un sweeper por antigüedad (planeado como follow-up).
- La corrupción silenciosa de igual tamaño solo se detecta si se provee `expected_hash` — el tamaño solo no distingue dos archivos distintos de igual longitud.
- La reparación faststart de MP4/M4A se conserva del código existente pero todavía no tiene tests dedicados (planeado como follow-up).

## Verification / Verificación

- `pytest -q` → 76 passed, 0 failed (19 in `tests/test_downloader.py`)
- `ruff check` → clean on changed tests; 33 pre-existing issues in `downloader.py`, 0 new
- `compileall` → clean on Python 3.10, 3.11, 3.13
- Lockfile unchanged (no dependency changes)
- Diff: exactly 2 files, **+717 / −97** (`tiddl/cli/commands/download/downloader.py`, `tests/test_downloader.py`) — confirmed via `git diff --name-only main...HEAD` and independently via the git tree/blob objects

Full audit trail (`AUDIT_cross_volume.md`, both review rounds) kept local — will be pasted as a PR comment, not committed.

## Merge criteria / Criterios de merge

Do not merge until: full green CI matrix (Ubuntu + Windows × Python 3.10–3.13), locked-install job green, lock-drift job green, and zero pending review threads.
