### PR TITLE
docs: add bilingual placeholder reference

### DIFF
--- a/PLACEHOLDERS.md
+++ b/PLACEHOLDERS.md
@@ -1,0 +1,328 @@
+# tiddl-elvigilante template placeholders
+
+> [Versión en español](PLACEHOLDERS_ES.md)
+
+This reference is derived from the current `tiddl-elvigilante` code, primarily `tiddl/core/utils/format.py` and the additional variables supplied by download commands.
+
+Placeholders are written inside braces in a template:
+
+```toml
+[templates]
+default = "{album.artist}/{album.title}/{item.number:02}. {item.title}"
+```
+
+Use `/` to separate directories, including on Windows. tiddl converts and sanitizes the resulting path for the target filesystem.
+
+## Track or video — `{item.*}`
+
+| Placeholder | Description |
+|---|---|
+| `{item.id}` | TIDAL track or video ID. |
+| `{item.title}` | Clean title without the appended version. |
+| `{item.safe_title}` | Title sanitized for use in filenames. |
+| `{item.title_version}` | Title plus the version in parentheses, for example `Song (Remastered 2011)`. |
+| `{item.number}` | Track number. Supports zero padding, for example `{item.number:02}`. |
+| `{item.volume}` | Disc or volume number. |
+| `{item.version}` | Raw version text, for example `Remastered 2011`; parentheses are not added automatically. |
+| `{item.copyright}` | Copyright text. |
+| `{item.bpm}` | Beats per minute. |
+| `{item.isrc}` | ISRC code. |
+| `{item.quality}` | Quality supplied to the formatter for this item. |
+| `{item.artist}` | Primary artist. |
+| `{item.safe_artist}` | Primary artist sanitized for the filesystem. |
+| `{item.artists}` | Primary artists joined with `artist_separator`. |
+| `{item.safe_artists}` | Joined primary artists, sanitized for the filesystem. |
+| `{item.features}` | Featured artists joined with `artist_separator`. |
+| `{item.artists_with_features}` | Primary and featured artists joined with `artist_separator`. |
+| `{item.explicit}` | Explicit-content indicator. Supports the modifiers described below. |
+| `{item.genre}` | Genre obtained from the item's album. |
+| `{item.dolby}` | Conditional value for Dolby Atmos. It prints the supplied format text only for Atmos items. |
+| `{item.releaseDate}` | Release date. Supports `strftime` formatting. |
+| `{item.streamStartDate}` | Streaming availability start date. Supports `strftime` formatting. |
+
+Artist names displayed in paths are limited to the first three. If more artists exist, tiddl appends `& others`. Internal media tags retain the complete artist information.
+
+## Album — `{album.*}`
+
+| Placeholder | Description |
+|---|---|
+| `{album.id}` | TIDAL album ID. |
+| `{album.title}` | Album title. |
+| `{album.safe_title}` | Album title sanitized for the filesystem. |
+| `{album.artist}` | Album's primary artist. |
+| `{album.safe_artist}` | Album's primary artist sanitized for the filesystem. |
+| `{album.artists}` | Album primary artists joined with `artist_separator`. |
+| `{album.safe_artists}` | Joined primary artists, sanitized for the filesystem. |
+| `{album.date}` | Album release date. Supports `strftime` formatting. |
+| `{album.explicit}` | Explicit-content indicator. Supports the same modifiers as `{item.explicit}`. |
+| `{album.master}` | Conditional Master/HiRes quality value. It prints the supplied format text only when applicable. |
+| `{album.release}` | Release type, normally `ALBUM`, `SINGLE`, or `EP`. |
+
+When a video or another item has no album, tiddl builds a fallback album: it uses the item's title and artist, sets `{album.id}` to `0`, sets `{album.release}` to `SINGLE`, and disables `{album.master}`.
+
+## Playlist — `{playlist.*}`
+
+| Placeholder | Description |
+|---|---|
+| `{playlist.uuid}` | Playlist UUID. |
+| `{playlist.title}` | Playlist title. |
+| `{playlist.index}` | Item position within the playlist. |
+| `{playlist.created}` | Creation date. Supports `strftime` formatting. |
+| `{playlist.updated}` | Last update date. Supports `strftime` formatting. |
+
+## Unprefixed global aliases
+
+| Placeholder | Description and availability |
+|---|---|
+| `{title}` | Alias for `{item.title}`. Available only when an item is present. |
+| `{artist}` | Alias for `{item.artist}`. Available only when an item is present. |
+| `{albumartist}` | Alias for `{album.artist}`. Available only when an album is present. |
+| `{artist_initials}` | Initial letter or category for the artist. When an album is present, tiddl prefers the album artist; otherwise it uses the item artist. |
+| `{release_date}` | Alias for `{album.date}`. Available only when an album is present. |
+| `{quality}` | Quality passed to the formatter, such as `MAX`, `HIGH`, or another value from the download flow. |
+| `{now}` | Current date and time. Supports `strftime` formatting. |
+
+## Contextual variables
+
+These variables are not available in every template. The download command supplies them only in specific contexts.
+
+| Placeholder | Availability | Description |
+|---|---|---|
+| `{mix_id}` | Mix and mix M3U templates | Mix ID. |
+| `{type}` | Album, playlist, or mix M3U templates | Resource type: `album`, `playlist`, or `mix`. |
+
+## Date and time formatting
+
+Date fields are `datetime` objects and accept standard `strftime` codes:
+
+| Example | Approximate result |
+|---|---|
+| `{item.releaseDate}` | `2024-03-15 00:00:00` |
+| `{item.releaseDate:%Y}` | `2024` |
+| `{item.releaseDate:%Y-%m}` | `2024-03` |
+| `{item.releaseDate:%Y-%m-%d}` | `2024-03-15` |
+| `{album.date:%B}` | `March` |
+| `{playlist.created:%d-%m-%Y}` | `15-03-2024` |
+| `{now:%Y-%m-%d}` | Current date. |
+| `{now:%H-%M}` | Current hour and minute. |
+
+Other supported codes include `%d` (day), `%m` (month), `%b` (abbreviated month), `%B` (month name), `%A` (weekday), `%H` (hour), `%M` (minute), and `%S` (second).
+
+A missing or invalid date is converted internally to `datetime.min`; verify the result before using dates from incomplete sources in final filenames.
+
+## Number formatting
+
+Numbers use Python's standard format specification mini-language:
+
+```toml
+track = "{album.artist}/{album.title}/{item.number:02}. {item.title}"
+```
+
+Examples:
+
+| Placeholder | Value 5 | Result |
+|---|---:|---:|
+| `{item.number}` | 5 | `5` |
+| `{item.number:02}` | 5 | `05` |
+| `{item.number:03}` | 5 | `005` |
+| `{playlist.index:02}` | 5 | `05` |
+
+## Explicit-content modifiers
+
+When the item or album is not explicit, every format below produces an empty string.
+
+| Placeholder | Result when explicit |
+|---|---|
+| `{item.explicit}` | `E` |
+| `{item.explicit:upper}` | `E` |
+| `{item.explicit:long}` | `explicit` |
+| `{item.explicit:upperlong}` | `EXPLICIT` |
+| `{item.explicit:parens}` | ` (Explicit)` |
+| `{item.explicit:shortparens}` | ` (explicit)` |
+
+The same modifiers work with `{album.explicit}`.
+
+Example:
+
+```toml
+track = "{item.number:02}. {item.title}{item.explicit:parens}"
+```
+
+Result: `01. Song Name (Explicit)` or `01. Song Name`.
+
+## Conditional text for Master and Dolby Atmos
+
+`{album.master}` and `{item.dolby}` are conditional values. Text written after `:` appears only when the condition is true:
+
+```toml
+track = "{item.title} {album.master:MQA}{item.dolby:Dolby Atmos}"
+```
+
+| Placeholder | True condition | False condition |
+|---|---|---|
+| `{album.master:HiRes}` | `HiRes` | empty string |
+| `{album.master:[MASTER]}` | `[MASTER]` | empty string |
+| `{item.dolby:Atmos}` | `Atmos` | empty string |
+| `{item.dolby:[DOLBY ATMOS]}` | `[DOLBY ATMOS]` | empty string |
+
+Without format text, `{album.master}` and `{item.dolby}` produce an empty string even when the condition is true. They should therefore normally be used with `:text`.
+
+## Artist separator
+
+Configure the separator in `config.toml`:
+
+```toml
+[templates]
+artist_separator = " / "
+```
+
+It affects:
+
+- `{item.artists}`
+- `{item.safe_artists}`
+- `{item.features}`
+- `{item.artists_with_features}`
+- `{album.artists}`
+- `{album.safe_artists}`
+- artist tags written to media files
+
+Common values include `" / "`, `", "`, `" & "`, and `"; "`.
+
+## Where templates are configured
+
+```toml
+[templates]
+default = "{album.artist}/{album.title}/{item.title}"
+track = ""
+video = ""
+album = ""
+playlist = ""
+mix = ""
+artist_separator = " / "
+```
+
+Empty `track`, `video`, `album`, `playlist`, and `mix` values inherit from `default`.
+
+Templates are also reused for covers and M3U files:
+
+```toml
+[cover.templates]
+track = ""
+album = ""
+playlist = ""
+
+[m3u.templates]
+album = ""
+playlist = ""
+mix = ""
+```
+
+Placeholder availability depends on the objects passed to the formatter. For example, a mix M3U template receives `{mix_id}` and `{type}`, but does not necessarily receive `{item.*}` or `{album.*}`.
+
+## Complete examples
+
+### Library by initial, artist, and year
+
+```toml
+[templates]
+default = "{artist_initials}/{album.artist}/({album.date:%Y}) {album.title}/{item.number:02}. {item.title}"
+```
+
+```text
+B/The Beatles/(1969) Abbey Road/01. Come Together.flac
+```
+
+### Featured artists and explicit content
+
+```toml
+[templates]
+track = "{album.artist}/{album.title}/{item.number:02}. {item.artists_with_features} - {item.title}{item.explicit:parens}"
+```
+
+### Ordered playlist
+
+```toml
+[templates]
+playlist = "Playlists/{playlist.title}/{playlist.index:03}. {item.artist} - {item.title}"
+```
+
+### Mix
+
+```toml
+[templates]
+mix = "Mixes/{mix_id}/{item.artist} - {item.title}"
+
+[m3u.templates]
+mix = "Mixes/{mix_id}/{type}-{mix_id}"
+```
+
+### Conditional quality indicators
+
+```toml
+[templates]
+album = "{album.artist}/{album.title} {album.master:[HIRES]}/{item.number:02}. {item.title}{item.dolby: [ATMOS]}"
+```
+
+## Summary: all placeholders
+
+```text
+{item.id}
+{item.title}
+{item.safe_title}
+{item.title_version}
+{item.number}
+{item.volume}
+{item.version}
+{item.copyright}
+{item.bpm}
+{item.isrc}
+{item.quality}
+{item.artist}
+{item.safe_artist}
+{item.artists}
+{item.safe_artists}
+{item.features}
+{item.artists_with_features}
+{item.explicit}
+{item.genre}
+{item.dolby}
+{item.releaseDate}
+{item.streamStartDate}
+
+{album.id}
+{album.title}
+{album.safe_title}
+{album.artist}
+{album.safe_artist}
+{album.artists}
+{album.safe_artists}
+{album.date}
+{album.explicit}
+{album.master}
+{album.release}
+
+{playlist.uuid}
+{playlist.title}
+{playlist.index}
+{playlist.created}
+{playlist.updated}
+
+{title}
+{artist}
+{albumartist}
+{artist_initials}
+{release_date}
+{quality}
+{now}
+
+{mix_id}
+{type}
+```
+
+## Technical notes
+
+- If a template contains a missing or context-incompatible placeholder, tiddl does not always raise an error: the segment may become sanitized literal text. Test a new template with a small download first.
+- If an album has multiple discs and the template does not include `{item.volume}`, tiddl automatically inserts a `Disc N` directory before the filename.
+- Names are normalized to Unicode NFC and sanitized to remove filesystem-incompatible characters.
+- Each path component is limited to 255 bytes. The final component reserves space for the extension.
+- `{item.safe_title}`, `{item.safe_artist}`, `{item.safe_artists}`, `{album.safe_title}`, `{album.safe_artist}`, and `{album.safe_artists}` are useful when you want explicit control over sanitized parts, although the complete final path is sanitized as well.

--- a/PLACEHOLDERS_ES.md
+++ b/PLACEHOLDERS_ES.md
@@ -1,5 +1,7 @@
 # Placeholders de plantillas de tiddl-elvigilante
 
+> [English version](PLACEHOLDERS.md)
+
 Referencia extraída del código actual de `tiddl-elvigilante`, principalmente de `tiddl/core/utils/format.py` y de las variables adicionales proporcionadas por los comandos de descarga.
 
 Los placeholders se escriben entre llaves dentro de una plantilla:

--- a/PLACEHOLDERS_ES.md
+++ b/PLACEHOLDERS_ES.md
@@ -1,0 +1,326 @@
+# Placeholders de plantillas de tiddl-elvigilante
+
+Referencia extraída del código actual de `tiddl-elvigilante`, principalmente de `tiddl/core/utils/format.py` y de las variables adicionales proporcionadas por los comandos de descarga.
+
+Los placeholders se escriben entre llaves dentro de una plantilla:
+
+```toml
+[templates]
+default = "{album.artist}/{album.title}/{item.number:02}. {item.title}"
+```
+
+Usa `/` para separar carpetas, incluso en Windows. tiddl convierte y sanea la ruta para el sistema de archivos.
+
+## Track o video — `{item.*}`
+
+| Placeholder | Descripción |
+|---|---|
+| `{item.id}` | ID del track o video en TIDAL. |
+| `{item.title}` | Título limpio, sin la versión añadida. |
+| `{item.safe_title}` | Título saneado para utilizarse en nombres de archivos. |
+| `{item.title_version}` | Título más la versión entre paréntesis, por ejemplo `Song (Remastered 2011)`. |
+| `{item.number}` | Número de pista. Admite relleno con ceros, por ejemplo `{item.number:02}`. |
+| `{item.volume}` | Número de disco o volumen. |
+| `{item.version}` | Texto crudo de la versión, por ejemplo `Remastered 2011`; no incluye automáticamente paréntesis. |
+| `{item.copyright}` | Texto de copyright. |
+| `{item.bpm}` | Pulsaciones por minuto. |
+| `{item.isrc}` | Código ISRC. |
+| `{item.quality}` | Calidad suministrada al formateador para este item. |
+| `{item.artist}` | Artista principal. |
+| `{item.safe_artist}` | Artista principal saneado para el sistema de archivos. |
+| `{item.artists}` | Artistas principales unidos con `artist_separator`. |
+| `{item.safe_artists}` | Artistas principales unidos y saneados para el sistema de archivos. |
+| `{item.features}` | Artistas invitados o featured unidos con `artist_separator`. |
+| `{item.artists_with_features}` | Artistas principales e invitados unidos con `artist_separator`. |
+| `{item.explicit}` | Indicador de contenido explícito. Admite los modificadores descritos más abajo. |
+| `{item.genre}` | Género obtenido del álbum del item. |
+| `{item.dolby}` | Valor condicional para Dolby Atmos. Solo imprime el texto indicado como formato si el item es Atmos. |
+| `{item.releaseDate}` | Fecha de publicación. Admite formatos `strftime`. |
+| `{item.streamStartDate}` | Fecha de inicio de disponibilidad. Admite formatos `strftime`. |
+
+Los nombres de artistas visibles en rutas están limitados a los tres primeros; si existen más, tiddl añade `& others`. Los tags internos conservan la información completa.
+
+## Álbum — `{album.*}`
+
+| Placeholder | Descripción |
+|---|---|
+| `{album.id}` | ID del álbum en TIDAL. |
+| `{album.title}` | Título del álbum. |
+| `{album.safe_title}` | Título del álbum saneado para el sistema de archivos. |
+| `{album.artist}` | Artista principal del álbum. |
+| `{album.safe_artist}` | Artista principal saneado para el sistema de archivos. |
+| `{album.artists}` | Artistas principales del álbum unidos con `artist_separator`. |
+| `{album.safe_artists}` | Artistas principales unidos y saneados. |
+| `{album.date}` | Fecha de publicación del álbum. Admite formatos `strftime`. |
+| `{album.explicit}` | Indicador de contenido explícito. Admite los mismos modificadores que `{item.explicit}`. |
+| `{album.master}` | Valor condicional de calidad Master/HiRes. Imprime el texto indicado solo cuando aplica. |
+| `{album.release}` | Tipo de lanzamiento, normalmente `ALBUM`, `SINGLE` o `EP`. |
+
+Cuando un video u otro item no trae álbum, tiddl construye un álbum de respaldo: usa el título y artista del item, establece `{album.id}` en `0`, `{album.release}` en `SINGLE` y deja `{album.master}` desactivado.
+
+## Playlist — `{playlist.*}`
+
+| Placeholder | Descripción |
+|---|---|
+| `{playlist.uuid}` | UUID de la playlist. |
+| `{playlist.title}` | Título de la playlist. |
+| `{playlist.index}` | Posición del item dentro de la playlist. |
+| `{playlist.created}` | Fecha de creación. Admite formatos `strftime`. |
+| `{playlist.updated}` | Fecha de última actualización. Admite formatos `strftime`. |
+
+## Alias globales sin prefijo
+
+| Placeholder | Descripción y disponibilidad |
+|---|---|
+| `{title}` | Alias de `{item.title}`. Solo existe cuando hay un item. |
+| `{artist}` | Alias de `{item.artist}`. Solo existe cuando hay un item. |
+| `{albumartist}` | Alias de `{album.artist}`. Solo existe cuando hay un álbum. |
+| `{artist_initials}` | Letra o categoría inicial del artista. Con álbum, tiddl prefiere el artista del álbum; de lo contrario usa el artista del item. |
+| `{release_date}` | Alias de `{album.date}`. Solo existe cuando hay un álbum. |
+| `{quality}` | Calidad pasada al formateador, por ejemplo `MAX`, `HIGH` u otro valor del flujo de descarga. |
+| `{now}` | Fecha y hora actuales. Admite formatos `strftime`. |
+
+## Variables contextuales
+
+Estas variables no están disponibles en todas las plantillas; el comando de descarga las proporciona únicamente en contextos específicos.
+
+| Placeholder | Dónde está disponible | Descripción |
+|---|---|---|
+| `{mix_id}` | Plantillas de mix y M3U de mix | ID del mix. |
+| `{type}` | Plantillas M3U de álbum, playlist o mix | Tipo del recurso: `album`, `playlist` o `mix`. |
+
+## Formatos de fecha y hora
+
+Los campos de fecha son objetos `datetime`, por lo que aceptan los códigos estándar de `strftime`:
+
+| Ejemplo | Resultado aproximado |
+|---|---|
+| `{item.releaseDate}` | `2024-03-15 00:00:00` |
+| `{item.releaseDate:%Y}` | `2024` |
+| `{item.releaseDate:%Y-%m}` | `2024-03` |
+| `{item.releaseDate:%Y-%m-%d}` | `2024-03-15` |
+| `{album.date:%B}` | `March` |
+| `{playlist.created:%d-%m-%Y}` | `15-03-2024` |
+| `{now:%Y-%m-%d}` | Fecha actual. |
+| `{now:%H-%M}` | Hora y minuto actuales. |
+
+También pueden utilizarse, entre otros, `%d` (día), `%m` (mes), `%b` (mes abreviado), `%B` (nombre del mes), `%A` (día de la semana), `%H` (hora), `%M` (minuto) y `%S` (segundo).
+
+Una fecha ausente o inválida se convierte internamente en `datetime.min`; por eso conviene comprobar el resultado antes de usar fechas de fuentes incompletas en nombres definitivos.
+
+## Formato de números
+
+Los números utilizan el minilenguaje estándar de formato de Python:
+
+```toml
+track = "{album.artist}/{album.title}/{item.number:02}. {item.title}"
+```
+
+Ejemplos:
+
+| Placeholder | Valor 5 | Resultado |
+|---|---:|---:|
+| `{item.number}` | 5 | `5` |
+| `{item.number:02}` | 5 | `05` |
+| `{item.number:03}` | 5 | `005` |
+| `{playlist.index:02}` | 5 | `05` |
+
+## Modificadores de contenido explícito
+
+Si el item o álbum no es explícito, todos estos formatos producen una cadena vacía.
+
+| Placeholder | Resultado cuando es explícito |
+|---|---|
+| `{item.explicit}` | `E` |
+| `{item.explicit:upper}` | `E` |
+| `{item.explicit:long}` | `explicit` |
+| `{item.explicit:upperlong}` | `EXPLICIT` |
+| `{item.explicit:parens}` | ` (Explicit)` |
+| `{item.explicit:shortparens}` | ` (explicit)` |
+
+Los mismos modificadores funcionan con `{album.explicit}`.
+
+Ejemplo:
+
+```toml
+track = "{item.number:02}. {item.title}{item.explicit:parens}"
+```
+
+Resultado: `01. Song Name (Explicit)` o `01. Song Name`.
+
+## Texto condicional para Master y Dolby Atmos
+
+`{album.master}` y `{item.dolby}` son valores condicionales. El texto escrito después de `:` aparece únicamente cuando la condición es verdadera:
+
+```toml
+track = "{item.title} {album.master:MQA}{item.dolby:Dolby Atmos}"
+```
+
+| Placeholder | Condición verdadera | Condición falsa |
+|---|---|---|
+| `{album.master:HiRes}` | `HiRes` | cadena vacía |
+| `{album.master:[MASTER]}` | `[MASTER]` | cadena vacía |
+| `{item.dolby:Atmos}` | `Atmos` | cadena vacía |
+| `{item.dolby:[DOLBY ATMOS]}` | `[DOLBY ATMOS]` | cadena vacía |
+
+Sin texto de formato, `{album.master}` y `{item.dolby}` producen una cadena vacía incluso cuando la condición es verdadera. Por eso deben usarse normalmente con `:texto`.
+
+## Separador de artistas
+
+El valor se configura en `config.toml`:
+
+```toml
+[templates]
+artist_separator = " / "
+```
+
+Afecta a:
+
+- `{item.artists}`
+- `{item.safe_artists}`
+- `{item.features}`
+- `{item.artists_with_features}`
+- `{album.artists}`
+- `{album.safe_artists}`
+- tags de artistas escritos en los archivos multimedia
+
+Valores comunes: `" / "`, `", "`, `" & "` y `"; "`.
+
+## Dónde se configuran las plantillas
+
+```toml
+[templates]
+default = "{album.artist}/{album.title}/{item.title}"
+track = ""
+video = ""
+album = ""
+playlist = ""
+mix = ""
+artist_separator = " / "
+```
+
+Los campos vacíos `track`, `video`, `album`, `playlist` y `mix` heredan de `default`.
+
+Las plantillas también se reutilizan para portadas y M3U:
+
+```toml
+[cover.templates]
+track = ""
+album = ""
+playlist = ""
+
+[m3u.templates]
+album = ""
+playlist = ""
+mix = ""
+```
+
+La disponibilidad de cada placeholder depende de los objetos entregados al formateador. Por ejemplo, una plantilla M3U de mix recibe `{mix_id}` y `{type}`, pero no necesariamente `{item.*}` o `{album.*}`.
+
+## Ejemplos completos
+
+### Biblioteca por inicial, artista y año
+
+```toml
+[templates]
+default = "{artist_initials}/{album.artist}/({album.date:%Y}) {album.title}/{item.number:02}. {item.title}"
+```
+
+```text
+B/The Beatles/(1969) Abbey Road/01. Come Together.flac
+```
+
+### Artistas invitados y contenido explícito
+
+```toml
+[templates]
+track = "{album.artist}/{album.title}/{item.number:02}. {item.artists_with_features} - {item.title}{item.explicit:parens}"
+```
+
+### Playlist ordenada
+
+```toml
+[templates]
+playlist = "Playlists/{playlist.title}/{playlist.index:03}. {item.artist} - {item.title}"
+```
+
+### Mix
+
+```toml
+[templates]
+mix = "Mixes/{mix_id}/{item.artist} - {item.title}"
+
+[m3u.templates]
+mix = "Mixes/{mix_id}/{type}-{mix_id}"
+```
+
+### Indicadores condicionales de calidad
+
+```toml
+[templates]
+album = "{album.artist}/{album.title} {album.master:[HIRES]}/{item.number:02}. {item.title}{item.dolby: [ATMOS]}"
+```
+
+## Resumen: todos los placeholders
+
+```text
+{item.id}
+{item.title}
+{item.safe_title}
+{item.title_version}
+{item.number}
+{item.volume}
+{item.version}
+{item.copyright}
+{item.bpm}
+{item.isrc}
+{item.quality}
+{item.artist}
+{item.safe_artist}
+{item.artists}
+{item.safe_artists}
+{item.features}
+{item.artists_with_features}
+{item.explicit}
+{item.genre}
+{item.dolby}
+{item.releaseDate}
+{item.streamStartDate}
+
+{album.id}
+{album.title}
+{album.safe_title}
+{album.artist}
+{album.safe_artist}
+{album.artists}
+{album.safe_artists}
+{album.date}
+{album.explicit}
+{album.master}
+{album.release}
+
+{playlist.uuid}
+{playlist.title}
+{playlist.index}
+{playlist.created}
+{playlist.updated}
+
+{title}
+{artist}
+{albumartist}
+{artist_initials}
+{release_date}
+{quality}
+{now}
+
+{mix_id}
+{type}
+```
+
+## Observaciones técnicas
+
+- Si una plantilla contiene un placeholder inexistente o incompatible con el contexto, tiddl no siempre genera un error: el segmento puede convertirse en texto saneado. Es preferible probar una plantilla nueva con una descarga pequeña.
+- Si un álbum tiene varios discos y la plantilla no contiene `{item.volume}`, tiddl inserta automáticamente una carpeta `Disc N` antes del nombre del archivo.
+- Los nombres se normalizan en Unicode NFC y se sanean para eliminar caracteres incompatibles con el sistema de archivos.
+- Cada componente de ruta se limita a 255 bytes. El último componente reserva espacio para la extensión.
+- `{item.safe_title}`, `{item.safe_artist}`, `{item.safe_artists}`, `{album.safe_title}`, `{album.safe_artist}` y `{album.safe_artists}` son útiles cuando se desea controlar explícitamente qué partes quedan saneadas, aunque la ruta final completa también pasa por saneamiento.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ artist_separator = " / "
 
 ### 📖 Getting Started
 - **[COMPLETE_COMMAND_REFERENCE.md](COMPLETE_COMMAND_REFERENCE.md)** ⭐ **START HERE** - Complete command and placeholder reference (734 lines)
+- **[PLACEHOLDERS.md](PLACEHOLDERS.md)** - Complete template placeholder reference with formatting rules and examples
 - **[PLACEHOLDERS_ES.md](PLACEHOLDERS_ES.md)** 🇪🇸 - Referencia completa de placeholders para plantillas, con formatos y ejemplos
 - **[QUICK_INDEX.md](QUICK_INDEX.md)** - Quick index and navigation guide
 - **[TUTORIAL_ES.md](TUTORIAL_ES.md)** 🇪🇸 - Guía paso a paso en español (instalación y configuración)

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ artist_separator = " / "
 
 ### 📖 Getting Started
 - **[COMPLETE_COMMAND_REFERENCE.md](COMPLETE_COMMAND_REFERENCE.md)** ⭐ **START HERE** - Complete command and placeholder reference (734 lines)
+- **[PLACEHOLDERS_ES.md](PLACEHOLDERS_ES.md)** 🇪🇸 - Referencia completa de placeholders para plantillas, con formatos y ejemplos
 - **[QUICK_INDEX.md](QUICK_INDEX.md)** - Quick index and navigation guide
 - **[TUTORIAL_ES.md](TUTORIAL_ES.md)** 🇪🇸 - Guía paso a paso en español (instalación y configuración)
 


### PR DESCRIPTION
## Español

Añade dos páginas dedicadas a los placeholders de plantillas:

- `PLACEHOLDERS.md`: referencia completa en inglés.
- `PLACEHOLDERS_ES.md`: referencia completa en español.

Ambas versiones documentan placeholders de tracks, videos, álbumes, playlists, mixes, portadas y M3U; incluyen formatos numéricos y de fecha, modificadores de contenido explícito, valores condicionales Master/Dolby Atmos, disponibilidad contextual y ejemplos completos. Las páginas se enlazan entre sí y aparecen en la sección de documentación del README.

La lista fue contrastada con `tiddl/core/utils/format.py` y con los argumentos adicionales usados en los comandos de descarga (`mix_id` y `type`).

## English

Adds two dedicated template-placeholder pages:

- `PLACEHOLDERS.md`: complete English reference.
- `PLACEHOLDERS_ES.md`: complete Spanish reference.

Both versions document placeholders for tracks, videos, albums, playlists, mixes, covers, and M3U files, including numeric/date formatting, explicit-content modifiers, Master/Dolby Atmos conditional values, contextual availability, and complete examples. The pages link to each other and are listed in the README documentation section.

The list was checked against `tiddl/core/utils/format.py` and the extra arguments supplied by download command call sites (`mix_id` and `type`).

## Validation

- English and Spanish pages expose the same placeholder set.
- Placeholder fields checked against `ItemTemplate`, `AlbumTemplate`, and `PlaylistTemplate`.
- Contextual keys checked across all `format_template()` call sites.
- Cross-language links and README links verified locally.
- `git diff --check` passes.
- Documentation-only change; no runtime tests required.

## Summary by Sourcery

Add bilingual documentation for configuring and using template placeholders.

New Features:
- Add comprehensive English and Spanish references for template placeholders, formatting options, contextual variables, and usage examples.

Enhancements:
- Link the bilingual placeholder references from each other and from the README documentation section.

Documentation:
- Document placeholders for tracks, videos, albums, playlists, mixes, covers, and M3U templates, including date and number formatting, explicit-content modifiers, and conditional quality values.