### PR TITLE
feat(recovery): persistent recovery of retained_staging across app restarts

### DIFF
--- a/tests/test_app_startup_notice.py
+++ b/tests/test_app_startup_notice.py
@@ -1,0 +1,116 @@
+"""[P2, audit finding #14] Regression coverage for the root callback's
+retained-staging startup notice (`tiddl/cli/app.py`).
+
+An earlier version of this code's comment claimed the notice was "safe on
+every invocation, including --help" — that claim was never actually tested,
+and is false: Click/Typer's `--help` is an eager option that exits during
+parameter processing, before the group callback's body (where this notice
+lives) ever runs. This file pins the VERIFIED behavior instead of the
+previously-unverified claim: the notice fires for an ordinary subcommand
+invocation, but not for `--help`.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import tiddl.core.utils.retained_registry as reg
+from tiddl.cli.app import app
+
+runner = CliRunner()
+
+
+def _write_registry_with_one_entry(app_path):
+    app_path.mkdir(parents=True, exist_ok=True)
+    (app_path / "retained_staging.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "id": "abc123",
+                        "reason": "publish_pending",
+                        "staging_path": "/tmp/x.bin",
+                        "output_path": "/tmp/y.bin",
+                        "observed_size": 1,
+                        "observed_hash": "aa",
+                        "hash_algorithm": "sha256",
+                        "track_title": "t",
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                        "quarantined": True,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def _isolated_tiddl_path(tmp_path, monkeypatch):
+    # `tiddl.cli.const.APP_PATH` is resolved once at import time and consumed
+    # by name in each module that needs it (see test_recover_cli.py's
+    # equivalent fixture) — patching the retained_registry module's own copy
+    # directly, rather than the TIDDL_PATH env var, is what actually affects
+    # `retained_registry.startup_status()` as called from `app.py`'s
+    # callback.
+    app_path = tmp_path / "_app"
+    _write_registry_with_one_entry(app_path)
+    monkeypatch.setattr(reg, "APP_PATH", app_path)
+    return app_path
+
+
+def test_startup_notice_appears_on_ordinary_subcommand(_isolated_tiddl_path):
+    result = runner.invoke(app, ["recover"])
+    assert result.exit_code == 0
+    assert "retained from a previous" in result.output
+
+
+def test_startup_notice_does_not_appear_on_help(_isolated_tiddl_path):
+    """This is the specific claim the audit found unverified/false: --help
+    exits eagerly and never reaches the root callback's notice code."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "retained from a previous" not in result.output
+
+
+def test_startup_notice_warns_on_unreadable_registry(tmp_path, monkeypatch):
+    """[P2, fourth audit finding #1] 'unreadable' is MORE serious than
+    'corrupt'/'unsupported_version' (any mutating `tiddl recover` command
+    refuses outright until it's resolved — see RegistryReadError), but an
+    earlier version of the root callback only warned for the two
+    less-serious statuses. A user who never proactively runs
+    `tiddl recover` would get no signal at all, on any ordinary command,
+    that persistence is currently inaccessible. This must warn too — still
+    read-only/lightweight, no deep verification, no destination I/O."""
+    app_path = tmp_path / "_app"
+    app_path.mkdir(parents=True, exist_ok=True)
+    registry_path = app_path / "retained_staging.json"
+    registry_path.write_text('{"version": 1, "entries": []}', encoding="utf-8")
+    monkeypatch.setattr(reg, "APP_PATH", app_path)
+
+    real_read_bytes = Path.read_bytes
+
+    def _boom_read_bytes(self, *a, **kw):
+        if self == registry_path:
+            raise OSError("simulated permission/sharing-violation error")
+        return real_read_bytes(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_bytes", _boom_read_bytes)
+
+    result = runner.invoke(app, ["recover"])
+    assert result.exit_code == 0
+    # `tiddl recover`'s own read-only listing ALSO prints a distinct
+    # "could not be read" warning for 'unreadable' (see
+    # `_print_registry_status_warning` in recover.py) — checking for "for
+    # details" alongside it specifically pins the root callback's OWN
+    # message (app.py's corrupt/unsupported_version/unreadable branches are
+    # the only ones that say "for details"; recover.py's own messages never
+    # do), so this genuinely proves the startup notice fired, not just that
+    # SOME warning about the registry appeared somewhere in the output.
+    normalized_output = " ".join(result.output.split()).lower()
+    assert "could not be read" in normalized_output
+    assert "for details" in normalized_output

--- a/tests/test_auth_core.py
+++ b/tests/test_auth_core.py
@@ -1,0 +1,78 @@
+"""Regression coverage for `save_auth_data`/`load_auth_data` after extracting
+the temp+fsync+replace dance into `tiddl.core.utils.fsio.atomic_write_bytes`
+(see tests/test_fsio.py for the generic helper coverage). This file exists to
+prove the extraction changed nothing observable about the auth file: still
+atomic, still owner-only on POSIX, still leaves no temp litter, still
+survives a corrupt/missing file on read.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tiddl.cli.utils.auth.core import load_auth_data, save_auth_data
+from tiddl.cli.utils.auth.models import AuthData
+
+
+def test_save_then_load_roundtrip(tmp_path):
+    f = tmp_path / "auth.json"
+    data = AuthData(token="t", refresh_token="r", expires_at=123, user_id="u", country_code="US")
+    save_auth_data(data, file=f)
+    loaded = load_auth_data(file=f)
+    assert loaded == data
+
+
+def test_load_missing_file_returns_empty_auth_data(tmp_path):
+    loaded = load_auth_data(file=tmp_path / "does_not_exist.json")
+    assert loaded == AuthData()
+
+
+def test_load_corrupt_file_returns_empty_auth_data_not_raise(tmp_path):
+    f = tmp_path / "auth.json"
+    f.write_text("{not valid json")
+    loaded = load_auth_data(file=f)
+    assert loaded == AuthData()
+
+
+def test_save_creates_parent_directory(tmp_path):
+    f = tmp_path / "nested" / "dir" / "auth.json"
+    save_auth_data(AuthData(token="t"), file=f)
+    assert f.exists()
+
+
+def test_save_no_temp_file_left_behind(tmp_path):
+    f = tmp_path / "auth.json"
+    save_auth_data(AuthData(token="t"), file=f)
+    leftovers = [p for p in tmp_path.iterdir() if p != f]
+    assert leftovers == []
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only chmod semantics")
+def test_save_applies_owner_only_permissions_on_posix(tmp_path):
+    f = tmp_path / "auth.json"
+    save_auth_data(AuthData(token="secret-token"), file=f)
+    mode = f.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_save_failure_does_not_corrupt_existing_file(tmp_path, monkeypatch):
+    """A crash/failure mid-save must never leave a truncated auth.json — the
+    exact regression atomic_write_bytes exists to prevent (see its docstring:
+    'which used to wipe the user's session and force a re-login')."""
+    f = tmp_path / "auth.json"
+    original = AuthData(token="original-token", refresh_token="orig-refresh")
+    save_auth_data(original, file=f)
+
+    def boom_replace(src, dst):
+        raise OSError("simulated failure")
+
+    monkeypatch.setattr(os, "replace", boom_replace)
+    with pytest.raises(OSError):
+        save_auth_data(AuthData(token="new-token"), file=f)
+
+    # The file on disk must still be the ORIGINAL, fully-formed data.
+    reloaded = load_auth_data(file=f)
+    assert reloaded == original
+    leftovers = [p for p in tmp_path.iterdir() if p != f]
+    assert leftovers == []  # temp file cleaned up despite the failure

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -18,6 +18,9 @@ from aiohttp import web
 from aiohttp.test_utils import TestServer
 
 import tiddl.cli.commands.download.downloader as dlmod
+import tiddl.core.utils.fsio as fsiomod
+import tiddl.core.utils.publish as publishmod
+import tiddl.core.utils.retained_registry as registrymod
 from tiddl.cli.commands.download.downloader import (
     CHUNK_SIZE,
     Downloader,
@@ -95,6 +98,13 @@ def _reset_cancel():
     cancel.clear()
     yield
     cancel.clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_retained_registry(tmp_path, monkeypatch):
+    """Every test in this module gets its own retained-staging registry +
+    quarantine dir under pytest's tmp_path, never the real ~/.tiddl."""
+    monkeypatch.setattr(registrymod, "APP_PATH", tmp_path / "_app")
 
 
 @pytest.fixture
@@ -249,7 +259,7 @@ async def test_cancellation_midstream_aborts_without_retry(tmp_path, monkeypatch
 
 @pytest.fixture
 def cross_volume(monkeypatch):
-    monkeypatch.setattr(dlmod, "_same_volume", lambda a, b: False)
+    monkeypatch.setattr(publishmod, "_same_volume", lambda a, b: False)
 
 
 def _dest_leftovers(dest_dir):
@@ -321,7 +331,7 @@ async def test_cross_volume_retries_transient_copy_error(
     tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
 ):
     fake, calls = _scripted_copy2(["oserror", "oserror", "ok"])
-    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    monkeypatch.setattr(publishmod.shutil, "copy2", fake)
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
     try:
@@ -343,7 +353,7 @@ async def test_cross_volume_bad_copy_is_reverified_and_recopied(
     tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
 ):
     fake, calls = _scripted_copy2(["short", "ok"])   # first copy lands corrupt, second good
-    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    monkeypatch.setattr(publishmod.shutil, "copy2", fake)
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
     try:
@@ -366,7 +376,7 @@ async def test_cross_volume_hash_mismatch_is_detected(
 ):
     good_hash = hashlib.md5(b"\x00" * 5000).hexdigest()
     fake, calls = _scripted_copy2(["corrupt-hash", "ok"])  # right size, wrong content, then good
-    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    monkeypatch.setattr(publishmod.shutil, "copy2", fake)
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
     try:
@@ -387,7 +397,7 @@ async def test_cross_volume_exhausted_keeps_staging_no_partial_final(
     tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
 ):
     fake, _ = _scripted_copy2(["short"])   # every copy corrupts -> never publishes
-    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
+    monkeypatch.setattr(publishmod.shutil, "copy2", fake)
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
     try:
@@ -401,17 +411,25 @@ async def test_cross_volume_exhausted_keeps_staging_no_partial_final(
     assert task.status == DownloadStatus.FAILED
     assert not dest.exists()              # no incomplete final file
     assert not _dest_leftovers(tmp_path)  # no dest-side .part temp left
-    # The verified local download is RETAINED for recovery, recorded on the task.
-    kept = _staging_leftovers(stage_dir)
-    assert len(kept) == 1
-    assert task.retained_staging == kept[0]
+    # The verified local download is RETAINED for recovery. It is moved out of
+    # the OS temp staging dir into the retained-staging quarantine dir (so it
+    # survives an OS temp cleanup) and recorded on the task + the registry.
+    assert _no_staging_leftovers(stage_dir)
+    assert task.retained_staging is not None
+    assert task.retained_staging.exists()
+    assert task.retained_staging.parent == registrymod.quarantine_dir()
+    report = await registrymod.reconcile()
+    assert len(report.entries) == 1
+    assert report.entries[0].status == "ok"
+    assert report.entries[0].entry.reason == registrymod.RetainReason.PUBLISH_PENDING
+    assert report.entries[0].entry.output_path == str(dest)
 
 
 async def test_cross_volume_replace_retries_then_succeeds(
     tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
 ):
     rfake, rcalls = _scripted_replace(["oserror", "ok"])
-    monkeypatch.setattr(dlmod.os, "replace", rfake)
+    monkeypatch.setattr(publishmod.os, "replace", rfake)
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
     try:
@@ -436,7 +454,7 @@ async def test_cross_volume_replace_exhausted_keeps_prior_final(
     dest = tmp_path / "out.bin"
     dest.write_bytes(b"P" * 4000)          # a prior, valid final file
     rfake, _ = _scripted_replace(["oserror"])   # the atomic publish always fails
-    monkeypatch.setattr(dlmod.os, "replace", rfake)
+    monkeypatch.setattr(publishmod.os, "replace", rfake)
     server = await _start([("ok", 5000)])
     try:
         task = DownloadTask(url="x", output_path=dest, expected_size=5000)
@@ -461,7 +479,7 @@ async def test_corrupt_local_staging_detected_before_copy(
         copy_calls["n"] += 1
         return real(src, dst)
 
-    monkeypatch.setattr(dlmod.shutil, "copy2", counting_copy)
+    monkeypatch.setattr(publishmod.shutil, "copy2", counting_copy)
     server = await _start([("ok", 3000)])   # short download -> local staging invalid (size)
     dest = tmp_path / "out.bin"
     try:
@@ -482,7 +500,7 @@ async def test_publication_order_copy_fsync_verify_replace(
 ):
     order = []
     real_copy = shutil.copy2
-    real_fsync = dlmod._fsync_path
+    real_fsync = publishmod._fsync_path
     real_verify = dlmod.FileIntegrityChecker.verify_file_async
     real_replace = os.replace
 
@@ -502,10 +520,10 @@ async def test_publication_order_copy_fsync_verify_replace(
         order.append("replace")
         return real_replace(src, dst)
 
-    monkeypatch.setattr(dlmod.shutil, "copy2", _copy)
-    monkeypatch.setattr(dlmod, "_fsync_path", _fsync)
+    monkeypatch.setattr(publishmod.shutil, "copy2", _copy)
+    monkeypatch.setattr(publishmod, "_fsync_path", _fsync)
     monkeypatch.setattr(dlmod.FileIntegrityChecker, "verify_file_async", staticmethod(_verify))
-    monkeypatch.setattr(dlmod.os, "replace", _replace)
+    monkeypatch.setattr(publishmod.os, "replace", _replace)
 
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
@@ -523,9 +541,9 @@ async def test_publication_order_copy_fsync_verify_replace(
 async def test_same_volume_replace_retries_then_succeeds(
     tmp_path, fast_sleep, stage_dir, monkeypatch
 ):
-    monkeypatch.setattr(dlmod, "_same_volume", lambda a, b: True)
+    monkeypatch.setattr(publishmod, "_same_volume", lambda a, b: True)
     rfake, rcalls = _scripted_replace(["oserror", "ok"])
-    monkeypatch.setattr(dlmod.os, "replace", rfake)
+    monkeypatch.setattr(publishmod.os, "replace", rfake)
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
     try:
@@ -545,10 +563,10 @@ async def test_same_volume_replace_retries_then_succeeds(
 async def test_same_volume_fsyncs_dest_dir_after_rename(
     tmp_path, fast_sleep, stage_dir, monkeypatch
 ):
-    monkeypatch.setattr(dlmod, "_same_volume", lambda a, b: True)
+    monkeypatch.setattr(publishmod, "_same_volume", lambda a, b: True)
     order = []
     real_replace = os.replace
-    real_fsync_dir = dlmod._fsync_dir
+    real_fsync_dir = publishmod._fsync_dir
 
     def _replace(src, dst, *a, **k):
         order.append("replace")
@@ -558,8 +576,8 @@ async def test_same_volume_fsyncs_dest_dir_after_rename(
         order.append("fsync_dir")
         return real_fsync_dir(p)
 
-    monkeypatch.setattr(dlmod.os, "replace", _replace)
-    monkeypatch.setattr(dlmod, "_fsync_dir", _fsync_dir)
+    monkeypatch.setattr(publishmod.os, "replace", _replace)
+    monkeypatch.setattr(publishmod, "_fsync_dir", _fsync_dir)
 
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
@@ -583,7 +601,7 @@ async def test_publish_success_survives_staging_unlink_failure(
     AV/indexer lock, or a remote filesystem that rejects the unlink). The final
     file must be correct, and the leftover staging must be surfaced via
     task.retained_staging (+ a warning) rather than silently dropped."""
-    monkeypatch.setattr(dlmod, "_safe_unlink", lambda p: False)
+    monkeypatch.setattr(publishmod, "_safe_unlink", lambda p: False)
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
     try:
@@ -608,8 +626,8 @@ async def test_dest_tmp_unlink_failure_is_warned_not_fatal(
     warning) but must never turn an otherwise-successful copy retry into a
     failure — only the leftover surfaces, nothing silently disappears."""
     fake, calls = _scripted_copy2(["short", "ok"])  # first copy corrupt, then good
-    monkeypatch.setattr(dlmod.shutil, "copy2", fake)
-    real_unlink = dlmod._safe_unlink
+    monkeypatch.setattr(publishmod.shutil, "copy2", fake)
+    real_unlink = fsiomod._safe_unlink
 
     def flaky_unlink(path):
         # Fail only the dest-side ".part." cleanup (the corrupt first copy);
@@ -618,7 +636,12 @@ async def test_dest_tmp_unlink_failure_is_warned_not_fatal(
             return False
         return real_unlink(path)
 
-    monkeypatch.setattr(dlmod, "_safe_unlink", flaky_unlink)
+    # `_safe_unlink_warn` (which logs the "Could not remove leftover..."
+    # warning under test) is defined in fsio.py and calls `_safe_unlink` via
+    # fsio's OWN module globals — patch it there, not on `publishmod` (which
+    # only affects publish.py's *direct* `_safe_unlink` call, a different
+    # call site: dropping the local staging copy after a successful publish).
+    monkeypatch.setattr(fsiomod, "_safe_unlink", flaky_unlink)
 
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
@@ -642,12 +665,12 @@ async def test_dest_tmp_unlink_failure_is_warned_not_fatal(
 async def test_same_volume_uses_atomic_rename_not_copy(
     tmp_path, fast_sleep, stage_dir, monkeypatch
 ):
-    monkeypatch.setattr(dlmod, "_same_volume", lambda a, b: True)
+    monkeypatch.setattr(publishmod, "_same_volume", lambda a, b: True)
 
     def _boom(*a, **k):
         raise AssertionError("copy2 must not be called on the same-volume fast path")
 
-    monkeypatch.setattr(dlmod.shutil, "copy2", _boom)
+    monkeypatch.setattr(publishmod.shutil, "copy2", _boom)
     server = await _start([("ok", 5000)])
     dest = tmp_path / "out.bin"
     try:

--- a/tests/test_fsio.py
+++ b/tests/test_fsio.py
@@ -1,0 +1,154 @@
+"""Coverage for `tiddl.core.utils.fsio.atomic_write_bytes`, extracted from
+`save_auth_data` (see `tests/test_auth_core.py` for the auth-specific
+regression coverage this extraction must not change) so it can be reused by
+the retained-staging registry."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tiddl.core.utils.fsio import atomic_write_bytes
+
+
+def test_writes_new_file(tmp_path):
+    target = tmp_path / "f.txt"
+    atomic_write_bytes(target, b"hello")
+    assert target.read_bytes() == b"hello"
+
+
+def test_creates_parent_directories(tmp_path):
+    target = tmp_path / "a" / "b" / "c" / "f.txt"
+    atomic_write_bytes(target, b"hello")
+    assert target.read_bytes() == b"hello"
+
+
+def test_replaces_existing_content(tmp_path):
+    target = tmp_path / "f.txt"
+    atomic_write_bytes(target, b"old")
+    atomic_write_bytes(target, b"new-content")
+    assert target.read_bytes() == b"new-content"
+
+
+def test_no_temp_file_left_behind_on_success(tmp_path):
+    target = tmp_path / "f.txt"
+    atomic_write_bytes(target, b"hello")
+    leftovers = [p for p in tmp_path.iterdir() if p != target]
+    assert leftovers == []
+
+
+def test_temp_file_cleaned_up_on_write_failure(tmp_path, monkeypatch):
+    """The fake below must accurately model real `os.fdopen` behavior: once
+    `os.fdopen(fd, ...)` returns successfully, the resulting object OWNS the
+    raw fd — its `close()` is what releases it. An earlier version of this
+    fake never closed the real underlying fd in `close()`, which hid a real
+    production bug (see `test_temp_fd_closed_when_fdopen_itself_raises`
+    below and `fsio.atomic_write_bytes`'s fd-ownership tracking): on
+    Windows, `os.unlink()`/`os.replace()` cannot touch a file that is still
+    open, so a leaked fd would silently make the except-block's temp-file
+    cleanup fail every time a write failed mid-flight."""
+    target = tmp_path / "f.txt"
+
+    class _BoomFile:
+        def __init__(self, fd):
+            self._fd = fd
+
+        def write(self, data):
+            raise OSError("simulated disk-full mid-write")
+
+        def flush(self):
+            pass
+
+        def fileno(self):
+            return self._fd
+
+        def close(self):
+            os.close(self._fd)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            self.close()
+            return False
+
+    monkeypatch.setattr(os, "fdopen", lambda fd, *a, **k: _BoomFile(fd))
+    with pytest.raises(OSError):
+        atomic_write_bytes(target, b"hello")
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []  # temp file removed, not left behind
+
+
+def test_temp_fd_closed_when_fdopen_itself_raises(tmp_path, monkeypatch):
+    """[Windows correctness, P1 finding #9] If `os.fdopen()` itself raises
+    before the file object ever takes ownership of the raw fd (`mkstemp`'s
+    fd is still just a bare descriptor at that point), `atomic_write_bytes`
+    must close that raw fd directly in its except-handler. Otherwise, on
+    Windows, the subsequent `os.unlink(tmp_name)` cleanup attempt fails
+    outright (Windows refuses to unlink a file that's still open) and is
+    swallowed by `except OSError: pass` — silently leaking both the fd and
+    the temp file forever."""
+    target = tmp_path / "f.txt"
+    real_close = os.close
+    closed_fds = []
+
+    def _tracking_close(fd):
+        closed_fds.append(fd)
+        real_close(fd)
+
+    def _boom_fdopen(fd, *a, **k):
+        raise OSError("simulated fdopen failure")
+
+    monkeypatch.setattr(os, "fdopen", _boom_fdopen)
+    monkeypatch.setattr(os, "close", _tracking_close)
+
+    with pytest.raises(OSError):
+        atomic_write_bytes(target, b"hello")
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []  # temp file removed, not left behind
+    assert len(closed_fds) == 1  # the raw fd was explicitly closed exactly once
+
+
+def test_original_file_untouched_on_replace_failure(tmp_path, monkeypatch):
+    target = tmp_path / "f.txt"
+    atomic_write_bytes(target, b"original")
+
+    def boom_replace(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(os, "replace", boom_replace)
+    with pytest.raises(OSError):
+        atomic_write_bytes(target, b"new")
+
+    assert target.read_bytes() == b"original"          # untouched
+    leftovers = [p for p in tmp_path.iterdir() if p != target]
+    assert leftovers == []                              # temp cleaned up
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only chmod semantics")
+def test_chmod_posix_applied_to_temp_before_publish(tmp_path):
+    target = tmp_path / "f.txt"
+    atomic_write_bytes(target, b"secret", chmod_posix=0o600)
+    mode = target.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_chmod_posix_none_leaves_default_mode(tmp_path):
+    target = tmp_path / "f.txt"
+    # Should not raise even on non-POSIX platforms / when omitted.
+    atomic_write_bytes(target, b"hello", chmod_posix=None)
+    assert target.read_bytes() == b"hello"
+
+
+def test_fsync_dir_false_by_default_does_not_raise(tmp_path):
+    target = tmp_path / "f.txt"
+    atomic_write_bytes(target, b"hello")  # fsync_dir defaults to False
+    assert target.read_bytes() == b"hello"
+
+
+def test_fsync_dir_true_is_best_effort_and_does_not_raise(tmp_path):
+    target = tmp_path / "f.txt"
+    atomic_write_bytes(target, b"hello", fsync_dir=True)
+    assert target.read_bytes() == b"hello"

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -1,0 +1,106 @@
+"""Focused unit coverage for `tiddl.core.utils.publish.publish_verified_file`,
+independent of the full download/CLI machinery that exercises it indirectly
+elsewhere (`test_downloader.py`, `test_recover_cli.py`). Each test here pins
+one specific finding from the third audit review of the retained-staging-
+recovery branch.
+"""
+from __future__ import annotations
+
+import tiddl.core.utils.publish as publishmod
+from tiddl.core.utils.publish import publish_verified_file
+
+
+async def _ok_reverify(_candidate):
+    return True, None
+
+
+def test_missing_destination_parent_refuses_without_creating_anything(tmp_path):
+    """[P1, third audit finding #2] `publish_verified_file` must NOT create
+    the destination directory at any depth — a missing destination parent
+    is refused outright rather than guessed to be safe to (re)create, since
+    directory depth says nothing about whether the real filesystem (e.g. a
+    NAS share) is actually mounted."""
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"hello")
+    destination = tmp_path / "does-not-exist-yet" / "dest.bin"
+
+    import asyncio
+
+    published, retained = asyncio.run(
+        publish_verified_file(source, destination, reverify=_ok_reverify)
+    )
+
+    assert published is False
+    assert retained == source
+    assert source.exists()  # untouched
+    assert not destination.parent.exists()  # NOT created
+    assert not destination.exists()
+
+
+def test_reverify_exception_does_not_leak_destination_temp(tmp_path, monkeypatch):
+    """[P1, third audit finding #4] If `reverify` raises (e.g. the dest-side
+    temp vanishes mid-hash due to an unrelated concurrent process, or a
+    flaky network share raises on read), `publish_verified_file` must not
+    let that propagate straight out — skipping every bit of its own
+    cleanup and leaking the `destination.part.*` temp file on disk forever.
+    The exception must be treated the same as a failed verification: the
+    temp is cleaned up, the source is preserved untouched, and any prior
+    destination content is left exactly as it was."""
+    monkeypatch.setattr(publishmod, "_same_volume", lambda a, b: False)
+
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"hello world")
+    destination = tmp_path / "dest" / "track.bin"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    prior_content = b"PRIOR FINAL CONTENT - MUST SURVIVE"
+    destination.write_bytes(prior_content)
+
+    async def _boom_reverify(_candidate):
+        raise OSError("simulated: dest temp vanished mid-verify")
+
+    import asyncio
+
+    published, retained = asyncio.run(
+        publish_verified_file(source, destination, reverify=_boom_reverify)
+    )
+
+    assert published is False
+    assert retained == source
+    assert source.exists() and source.read_bytes() == b"hello world"  # source untouched
+    assert destination.read_bytes() == prior_content  # prior final NEVER touched
+    # No destination.part.* temp left behind anywhere under tmp_path.
+    leftovers = list(tmp_path.rglob("*.part.*"))
+    assert leftovers == [], f"leaked temp file(s): {leftovers}"
+
+
+def test_reverify_exception_on_one_attempt_still_recovers_on_retry(tmp_path, monkeypatch):
+    """A reverify failure (exception or a plain False) is retried like any
+    other destination-validation failure — it isn't a fatal, un-retryable
+    condition by itself. This proves the exception path feeds into the
+    SAME retry loop as a normal `(False, "reason")` return, not a dead end."""
+    monkeypatch.setattr(publishmod, "_same_volume", lambda a, b: False)
+
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"hello world")
+    destination = tmp_path / "dest" / "track.bin"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    calls = {"n": 0}
+
+    async def _flaky_reverify(_candidate):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise OSError("simulated transient failure on the first attempt")
+        return True, None
+
+    import asyncio
+
+    published, retained = asyncio.run(
+        publish_verified_file(source, destination, reverify=_flaky_reverify)
+    )
+
+    assert published is True
+    assert retained is None
+    assert destination.read_bytes() == b"hello world"
+    assert not source.exists()  # cleaned up after a successful publish
+    assert calls["n"] == 2  # first attempt raised, second attempt succeeded

--- a/tests/test_recover_cli.py
+++ b/tests/test_recover_cli.py
@@ -1,0 +1,413 @@
+"""End-to-end coverage for `tiddl recover` — the offline recovery CLI over
+`tiddl.core.utils.retained_registry` + `tiddl.core.utils.publish`.
+
+Uses Typer's CliRunner against the real `app`, isolated to a tmp_path-backed
+APP_PATH (via `TIDDL_PATH`, see `tiddl/cli/const.py`) so nothing here ever
+touches the real ~/.tiddl. No TIDAL auth/network is involved anywhere in
+this file — that is itself the point of `tiddl recover` being a top-level
+command (see cli/commands/recover.py's module docstring).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import tiddl.core.utils.retained_registry as reg
+from tiddl.cli.app import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_app_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(reg, "APP_PATH", tmp_path / "_app")
+    # cli/const.py's APP_PATH is resolved at import time (module-level
+    # create_app_path()) and consumed by name in a couple of other modules;
+    # recover.py only ever reaches the registry through `reg.*`, so
+    # patching the registry module's own APP_PATH (as above) is sufficient
+    # for everything this test file exercises.
+    return tmp_path / "_app"
+
+
+def _run(coro):
+    import asyncio
+    return asyncio.run(coro)
+
+
+def _make_retained(
+    tmp_path, reason, *, content=b"\x00" * 5000, track_title="T", create_dest_dir=True
+):
+    """`create_dest_dir=True` (the default) pre-creates `dest`'s parent
+    directory, mirroring what the live download path always does before
+    ever staging a download — this is realistic test setup, not a
+    convenience shortcut, since [P1, third audit finding #2]
+    `publish_verified_file` deliberately no longer creates the destination
+    directory itself (see `tiddl/core/utils/publish.py`). Pass
+    `create_dest_dir=False` for tests that specifically exercise that
+    refusal behavior."""
+    staging = tmp_path / f"src-{track_title}.bin"
+    staging.write_bytes(content)
+    dest = tmp_path / "dest" / f"{track_title}.bin"
+    if create_dest_dir:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+    result = _run(reg.register_retained_file(staging, dest, reason, track_title=track_title))
+    assert result.persisted, "test setup expects registration to succeed"
+    return result.entry, dest
+
+
+def test_recover_offline_no_entries_lists_nothing():
+    result = runner.invoke(app, ["recover"])
+    assert result.exit_code == 0
+    assert "Nothing retained" in result.output
+
+
+def test_recover_list_shows_ok_entry(tmp_path):
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Alpha")
+    result = runner.invoke(app, ["recover"])
+    assert result.exit_code == 0
+    assert entry.id[:8] in result.output
+    assert "publish_pending" in result.output
+    assert "Alpha" in result.output
+
+
+def test_recover_publish_pending_success_removes_entry(tmp_path):
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Beta")
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    assert result.exit_code == 0
+    assert dest.exists()
+    assert dest.stat().st_size == 5000
+    assert reg.read_entries().entries == []
+
+
+def test_recover_publish_success_but_source_cleanup_fails_is_not_fully_resolved(
+    tmp_path, monkeypatch
+):
+    """[P1, fourth audit finding #3] A publish that succeeds but can't clean
+    up the now-redundant local copy afterward (a best-effort delete
+    failure) is a "needs a later retry" outcome, not a fully-resolved
+    success. An earlier version of `_recover_one_inner` printed a green
+    checkmark and returned True for exactly this case regardless — letting
+    a single `--publish` or a batch `--all` report success (exit 0) while
+    real `cleanup_pending` work was silently left outstanding in the
+    registry, with nothing in the exit code telling the caller anything
+    still needed attention."""
+    import tiddl.core.utils.publish as publishmod
+
+    # Force the cross-volume branch (only that branch can independently
+    # fail to delete `source` after a successful publish — the same-volume
+    # branch is a single atomic rename with no separate cleanup step) and
+    # make the post-publish source deletion fail.
+    monkeypatch.setattr(publishmod, "_same_volume", lambda a, b: False)
+    monkeypatch.setattr(publishmod, "_safe_unlink", lambda path: False)
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Delta")
+    staging_path = Path(entry.staging_path)
+
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+
+    assert result.exit_code != 0  # not fully resolved -> non-zero
+    assert dest.exists() and dest.stat().st_size == 5000  # destination WAS published
+    assert staging_path.exists()  # local copy retained (best-effort cleanup failed)
+
+    remaining = reg.read_entries().entries
+    assert len(remaining) == 1
+    assert remaining[0].reason == reg.RetainReason.CLEANUP_PENDING  # demoted, not dropped
+
+    normalized_output = " ".join(result.output.split())
+    assert "published" in normalized_output.lower()
+    assert "cleanup" in normalized_output.lower()
+
+
+def test_recover_publish_pending_destination_dir_missing_is_refused_not_created(tmp_path):
+    """[P1, third audit finding #2] `publish_verified_file` must NOT create
+    the destination directory — an earlier version tried a single-level
+    `mkdir` as a "safe enough" middle ground, but directory depth says
+    nothing about whether the expected filesystem (e.g. a NAS share) is
+    actually mounted; a missing destination folder could just as easily
+    mean an unmounted share as a genuinely-safe-to-recreate reorganized
+    library folder. Recovery must refuse and leave everything untouched
+    rather than guess. The retained copy must survive this refusal
+    (nothing is lost — just not auto-published) so a later retry, once the
+    real destination is confirmed available, can still succeed."""
+    entry, dest = _make_retained(
+        tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Gamma", create_dest_dir=False
+    )
+    assert not dest.parent.exists()
+    quarantined_path = Path(entry.staging_path)
+
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+
+    # [P2, third audit finding #7] Not fully resolved -> non-zero exit.
+    assert result.exit_code != 0
+    assert not dest.exists()  # nothing was published...
+    # Rich word-wraps output at the detected console width, which varies
+    # with how the test runner is invoked and can split a literal phrase
+    # like "does not exist" across a line break — normalize whitespace
+    # before substring-checking so this isn't flaky across environments.
+    normalized_output = " ".join(result.output.split())
+    assert "does not exist" in normalized_output  # ...and it says why...
+    assert quarantined_path.exists()  # ...and the retained copy is untouched.
+    assert len(reg.read_entries().entries) == 1  # still recoverable later
+
+
+def test_recover_cleanup_pending_destination_matches_deletes_local_copy(tmp_path):
+    content = b"\x22" * 3000
+    dest = tmp_path / "dest.bin"
+    dest.write_bytes(content)
+    entry, _ = _make_retained(
+        tmp_path, reg.RetainReason.CLEANUP_PENDING, content=content, track_title="Delta"
+    )
+    # register_retained_file always computes a fresh dest under tmp_path/dest/<title>.bin;
+    # override the entry's output_path to point at our pre-existing correct dest.
+    reg.update_entry(entry.id, output_path=str(dest))
+
+    quarantined_path = Path(entry.staging_path)
+    assert quarantined_path.exists()
+
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    assert result.exit_code == 0
+    assert "removed the redundant local copy" in result.output
+    assert not quarantined_path.exists()  # local copy deleted
+    assert dest.read_bytes() == content   # destination untouched/correct
+    assert reg.read_entries().entries == []
+
+
+def test_recover_cleanup_pending_destination_missing_is_promoted_to_publish_pending(tmp_path):
+    """[P1] cleanup_pending must never blindly delete the retained copy when
+    the destination is missing/invalid — it must promote to publish_pending
+    instead and require an explicit publish."""
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.CLEANUP_PENDING, track_title="Epsilon")
+    assert not dest.exists()  # destination was never actually created in this test
+
+    quarantined_path = Path(entry.staging_path)
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    # [P2, third audit finding #7] Promoted, not fully resolved -> non-zero.
+    assert result.exit_code != 0
+    assert "promoted to publish_pending" in result.output
+    assert quarantined_path.exists()  # local copy NEVER deleted
+
+    updated = reg.read_entries().entries[0]
+    assert updated.reason == reg.RetainReason.PUBLISH_PENDING
+
+    # And a second recovery pass now actually publishes it.
+    result2 = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    assert result2.exit_code == 0
+    assert dest.exists()
+    assert reg.read_entries().entries == []
+
+
+def test_recover_cleanup_pending_destination_corrupted_is_promoted_not_deleted(tmp_path):
+    dest = tmp_path / "dest.bin"
+    dest.write_bytes(b"WRONG CONTENT ENTIRELY")
+    entry, _ = _make_retained(tmp_path, reg.RetainReason.CLEANUP_PENDING, track_title="Zeta")
+    reg.update_entry(entry.id, output_path=str(dest))
+    quarantined_path = Path(entry.staging_path)
+
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    # [P2, third audit finding #7] Promoted, not fully resolved -> non-zero.
+    assert result.exit_code != 0
+    assert "promoted to publish_pending" in result.output
+    assert quarantined_path.exists()
+    assert dest.read_bytes() == b"WRONG CONTENT ENTIRELY"  # never overwritten by this step
+
+
+def test_recover_all_without_yes_is_refused(tmp_path):
+    _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Eta")
+    result = runner.invoke(app, ["recover", "--all"])
+    assert result.exit_code != 0
+    assert "--yes" in result.output
+    # nothing touched:
+    assert len(reg.read_entries().entries) == 1
+
+
+def test_recover_all_with_yes_recovers_every_ok_entry(tmp_path):
+    e1, d1 = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Theta1")
+    e2, d2 = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Theta2")
+    result = runner.invoke(app, ["recover", "--all", "--yes"])
+    assert result.exit_code == 0
+    assert d1.exists() and d2.exists()
+    assert reg.read_entries().entries == []
+
+
+def test_recover_publish_unknown_id_errors(tmp_path):
+    result = runner.invoke(app, ["recover", "--publish", "doesnotexist"])
+    assert result.exit_code != 0
+
+
+def _entry_for_ambiguity(entry_id):
+    return reg.RetainedEntry(
+        id=entry_id, reason=reg.RetainReason.PUBLISH_PENDING,
+        staging_path="/tmp/x", output_path="/tmp/y",
+        observed_size=1, observed_hash="a",
+    )
+
+
+def test_recover_publish_ambiguous_prefix_errors(tmp_path):
+    reg.add_entry(_entry_for_ambiguity("aaaaaaaa1"))
+    reg.add_entry(_entry_for_ambiguity("aaaaaaaa2"))
+    result = runner.invoke(app, ["recover", "--publish", "aaaaaaaa"])
+    assert result.exit_code != 0
+
+
+def test_recover_purge_gone_entry(tmp_path):
+    reg.add_entry(reg.RetainedEntry(
+        id="ghost1", reason=reg.RetainReason.PUBLISH_PENDING,
+        staging_path=str(tmp_path / "nope.bin"), output_path=str(tmp_path / "dest.bin"),
+        observed_size=1, observed_hash="a",
+    ))
+    result = runner.invoke(app, ["recover", "--purge", "ghost1"])
+    assert result.exit_code == 0
+    assert reg.read_entries().entries == []
+
+
+def test_recover_purge_ok_entry_is_refused(tmp_path):
+    """[P2] Purge must never silently discard a still-recoverable entry."""
+    entry, _dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Iota")
+    result = runner.invoke(app, ["recover", "--purge", entry.id[:8]])
+    assert result.exit_code != 0
+    assert len(reg.read_entries().entries) == 1  # untouched
+
+
+def test_recover_purge_already_published_entry_is_refused(tmp_path):
+    """[P1, finding #4 follow-through] An 'already_published' entry (a prior
+    recovery attempt already succeeded but crashed before updating the
+    registry — see test_retained_registry.py's idempotency test) is still
+    recoverable via --publish (a no-op registry drop). Purge must refuse it
+    the same way it refuses 'ok', not silently allow a second path to the
+    same outcome that skips the recoverable-status check."""
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Lambda")
+    quarantined_path = Path(entry.staging_path)
+    # Reproduce the "already_published" on-disk state: destination matches,
+    # quarantined copy is gone, registry untouched.
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(quarantined_path.read_bytes())
+    quarantined_path.unlink()
+
+    result = runner.invoke(app, ["recover", "--purge", entry.id[:8]])
+    assert result.exit_code != 0
+    assert len(reg.read_entries().entries) == 1  # untouched
+
+
+def test_recover_purge_corrupt_entry_deletes_only_files_under_quarantine_root(tmp_path):
+    """[P2] Auto-delete on purge is limited to resolved paths beneath the
+    quarantine root with the expected naming convention."""
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="Kappa")
+    quarantined_path = Path(entry.staging_path)
+    quarantined_path.write_bytes(b"tampered, now fails hash check")  # -> corrupt
+
+    result = runner.invoke(app, ["recover", "--purge", entry.id[:8]])
+    assert result.exit_code == 0
+    assert not quarantined_path.exists()  # safe to delete: under quarantine root, matches <id><ext>
+    assert reg.read_entries().entries == []
+
+
+def test_recover_purge_non_quarantined_fallback_path_is_never_auto_deleted(tmp_path, monkeypatch):
+    """[P2] A fallback (non-quarantined) temp path must never be auto-deleted
+    by purge — only the registry entry is removed; the file is left for
+    manual handling."""
+    fallback_file = tmp_path / "somewhere-else.bin"
+    fallback_file.write_bytes(b"data")
+    reg.add_entry(reg.RetainedEntry(
+        id="fallbackid", reason=reg.RetainReason.PUBLISH_PENDING,
+        staging_path=str(fallback_file), output_path=str(tmp_path / "dest.bin"),
+        observed_size=999, observed_hash="doesnotmatch",  # forces "corrupt" on reconcile
+        quarantined=False,
+    ))
+    result = runner.invoke(app, ["recover", "--purge", "fallbackid"])
+    assert result.exit_code == 0
+    assert fallback_file.exists()  # never auto-deleted
+    assert reg.read_entries().entries == []  # registry entry still removed
+
+
+def test_recover_shows_orphaned_quarantine_files():
+    qdir = reg.quarantine_dir()
+    qdir.mkdir(parents=True, exist_ok=True)
+    (qdir / "orphan.bin").write_bytes(b"x")
+    result = runner.invoke(app, ["recover"])
+    assert result.exit_code == 0
+    assert "no matching registry entry" in result.output
+
+
+def test_recover_warns_on_corrupt_registry_but_does_not_crash(tmp_path):
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_text("{not json")
+    result = runner.invoke(app, ["recover"])
+    assert result.exit_code == 0
+    assert "corrupt" in result.output.lower()
+
+
+def test_recover_warns_on_unreadable_registry_but_does_not_crash(tmp_path, monkeypatch):
+    """[P1, third audit finding #1] A registry that can't even be READ
+    (distinct from 'corrupt' — see RegistryReadError) must be reported,
+    not crash the listing."""
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_text('{"version": 1, "entries": []}')
+
+    real_read_bytes = Path.read_bytes
+
+    def _boom_read_bytes(self, *a, **kw):
+        if self == reg.registry_path():
+            raise OSError("simulated permission/sharing-violation error")
+        return real_read_bytes(self, *a, **kw)
+
+    # [P1, fourth audit finding #1] Patching `read_bytes`, not `read_text` —
+    # `read_entries()` now reads raw bytes first, decoding as a separate
+    # step (see retained_registry.py), so `read_bytes` is the call that
+    # must fail to simulate an actual unreadable-file I/O error here.
+    monkeypatch.setattr(Path, "read_bytes", _boom_read_bytes)
+
+    result = runner.invoke(app, ["recover"])
+    assert result.exit_code == 0
+    assert "could not be read" in result.output.lower()
+
+
+def test_recover_purge_refuses_on_unreadable_registry_without_crashing(tmp_path, monkeypatch):
+    """[P1, third audit finding #1] A mutating command against a registry
+    that becomes unreadable partway through (a TOCTOU race: readable when
+    `reconcile()` first looked, unreadable by the time the mutation itself
+    tries to read-lock-mutate-write it — e.g. another process/permissions
+    change in between) must refuse cleanly via `RegistryReadError` caught
+    at the CLI layer, not crash with an unhandled traceback, and not
+    silently write a fresh registry over whatever's actually on disk.
+
+    The read succeeds for the app's root-callback startup notice AND for
+    `reconcile()`'s own read (both needed to reach a purge attempt at all),
+    then fails starting on the THIRD read — the one inside `remove_entry`'s
+    `_transaction()` — which is exactly the read that must abort instead of
+    proceeding to write a fresh registry."""
+    reg.add_entry(reg.RetainedEntry(
+        id="ghost-purge-test", reason=reg.RetainReason.PUBLISH_PENDING,
+        staging_path=str(tmp_path / "nope.bin"), output_path=str(tmp_path / "dest.bin"),
+        observed_size=1, observed_hash="a",
+    ))
+    original = reg.registry_path().read_bytes()
+
+    real_read_bytes = Path.read_bytes
+    calls = {"n": 0}
+
+    def _flaky_read_bytes(self, *a, **kw):
+        if self == reg.registry_path():
+            calls["n"] += 1
+            if calls["n"] > 2:
+                raise OSError("simulated permission/sharing-violation error")
+        return real_read_bytes(self, *a, **kw)
+
+    # [P1, fourth audit finding #1] Patching `read_bytes`, not `read_text` —
+    # `read_entries()` now reads raw bytes first (see retained_registry.py),
+    # so that's the call that must fail on the 3rd invocation to simulate
+    # the registry becoming unreadable partway through this sequence.
+    monkeypatch.setattr(Path, "read_bytes", _flaky_read_bytes)
+
+    result = runner.invoke(app, ["recover", "--purge", "ghost-purge-test"])
+    assert result.exit_code != 0
+    assert "could not be read" in result.output.lower()
+
+    # Read via the builtin open(), not Path.read_bytes() — the latter is
+    # still patched above (only the registry_path() call count matters,
+    # not this verification read), and this avoids needing an early
+    # monkeypatch.undo(), which would also undo this test's autouse
+    # APP_PATH-isolation patch (same fixture instance).
+    with open(reg.registry_path(), "rb") as f:
+        assert f.read() == original  # untouched

--- a/tests/test_retained_registry.py
+++ b/tests/test_retained_registry.py
@@ -1,0 +1,977 @@
+"""Coverage for `tiddl.core.utils.retained_registry` — persistent recovery of
+`task.retained_staging` across app restarts.
+
+Each test here is written to pin one specific finding from the audit review
+of `PROPOSAL_retained_staging_recovery.md` (kept local/untracked, not part of
+this diff) — see the test names and docstrings for the mapping. This module
+has no dependency on Downloader/TIDAL, matching the design goal that
+`tiddl recover` works fully offline.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from filelock import FileLock
+
+import tiddl.core.utils.retained_registry as reg
+from tiddl.core.utils.retained_registry import (
+    RegistryLockTimeout,
+    RegistryReadError,
+    RetainedEntry,
+    RetainReason,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_app_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(reg, "APP_PATH", tmp_path / "_app")
+    return tmp_path / "_app"
+
+
+def _entry(**overrides) -> RetainedEntry:
+    defaults = dict(
+        id="abc123",
+        reason=RetainReason.PUBLISH_PENDING,
+        staging_path="/tmp/x.bin",
+        output_path="/mnt/nas/x.bin",
+        observed_size=100,
+        observed_hash="deadbeef",
+    )
+    defaults.update(overrides)
+    return RetainedEntry(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Basic round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_missing_registry_reads_as_missing_with_no_entries():
+    result = reg.read_entries()
+    assert result.status == "missing"
+    assert result.entries == []
+
+
+def test_add_then_read_round_trip():
+    e = _entry()
+    reg.add_entry(e)
+    result = reg.read_entries()
+    assert result.status == "valid"
+    assert len(result.entries) == 1
+    assert result.entries[0] == e
+
+
+def test_add_multiple_preserves_all():
+    reg.add_entry(_entry(id="a"))
+    reg.add_entry(_entry(id="b"))
+    reg.add_entry(_entry(id="c"))
+    ids = {e.id for e in reg.read_entries().entries}
+    assert ids == {"a", "b", "c"}
+
+
+def test_remove_entry_by_id():
+    reg.add_entry(_entry(id="a"))
+    reg.add_entry(_entry(id="b"))
+    removed = reg.remove_entry("a")
+    assert removed is True
+    ids = {e.id for e in reg.read_entries().entries}
+    assert ids == {"b"}
+
+
+def test_remove_nonexistent_entry_returns_false():
+    reg.add_entry(_entry(id="a"))
+    assert reg.remove_entry("does-not-exist") is False
+    assert len(reg.read_entries().entries) == 1
+
+
+def test_update_entry_changes_fields_and_persists():
+    reg.add_entry(_entry(id="a", reason=RetainReason.PUBLISH_PENDING))
+    updated = reg.update_entry("a", reason=RetainReason.CLEANUP_PENDING, staging_path="/new/path")
+    assert updated.reason == RetainReason.CLEANUP_PENDING
+    reread = reg.read_entries().entries[0]
+    assert reread.reason == RetainReason.CLEANUP_PENDING
+    assert reread.staging_path == "/new/path"
+
+
+def test_registry_file_is_valid_json_with_version():
+    reg.add_entry(_entry())
+    raw = json.loads(reg.registry_path().read_text())
+    assert raw["version"] == reg.REGISTRY_VERSION
+    assert isinstance(raw["entries"], list)
+
+
+# ---------------------------------------------------------------------------
+# [P2, third audit finding #5] hash_algorithm schema validation: only
+# fixed-length algorithms that `_hash_and_size`'s no-argument
+# `hexdigest()` actually works with are accepted.
+# ---------------------------------------------------------------------------
+
+
+def test_entry_with_unsupported_hash_algorithm_makes_registry_corrupt():
+    """`shake_128`/`shake_256` are real, valid `hashlib` algorithm names —
+    `hashlib.algorithms_available` would have accepted them — but they
+    require a `length` argument to `hexdigest()`, which `_hash_and_size`
+    never supplies, so hashing one raises `TypeError` the moment it's
+    actually used. Registry version 1 only ever writes `sha256`; a
+    hand-edited or foreign-tool-written entry claiming a variable-length
+    algorithm must be rejected at schema-validation time, not discovered
+    via a crash the first time something tries to reconcile it."""
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_text(json.dumps({
+        "version": 1,
+        "entries": [{
+            "id": "abc123", "reason": "publish_pending",
+            "staging_path": "/tmp/x.bin", "output_path": "/tmp/y.bin",
+            "observed_size": 1, "observed_hash": "aa",
+            "hash_algorithm": "shake_128",
+            "created_at": "2026-01-01T00:00:00+00:00", "quarantined": True,
+        }],
+    }))
+    result = reg.read_entries()
+    assert result.status == "corrupt"
+    assert result.entries == []
+
+
+def test_entry_with_supported_hash_algorithm_parses_fine():
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_text(json.dumps({
+        "version": 1,
+        "entries": [{
+            "id": "abc123", "reason": "publish_pending",
+            "staging_path": "/tmp/x.bin", "output_path": "/tmp/y.bin",
+            "observed_size": 1, "observed_hash": "aa",
+            "hash_algorithm": "sha256",
+            "created_at": "2026-01-01T00:00:00+00:00", "quarantined": True,
+        }],
+    }))
+    result = reg.read_entries()
+    assert result.status == "valid"
+    assert len(result.entries) == 1
+    assert result.entries[0].hash_algorithm == "sha256"
+
+
+# ---------------------------------------------------------------------------
+# [P1] Corrupt / unsupported-version registries must be preserved, not
+# silently overwritten as if they were empty.
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_registry_is_read_as_corrupt_not_missing():
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_text("{not valid json at all")
+    result = reg.read_entries()
+    assert result.status == "corrupt"
+    assert result.entries == []
+
+
+def test_reading_corrupt_registry_does_not_overwrite_it():
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    original = "{not valid json at all"
+    reg.registry_path().write_text(original)
+    reg.read_entries()  # read-only: must never write
+    assert reg.registry_path().read_text() == original
+
+
+def test_mutation_on_corrupt_registry_preserves_a_backup_before_overwriting():
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    original = "{not valid json at all"
+    reg.registry_path().write_text(original)
+
+    reg.add_entry(_entry(id="a"))  # mutation must not silently destroy `original`
+
+    backups = list(reg.registry_path().parent.glob("retained_staging.json.corrupt-*.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_text() == original
+    # And the mutation itself succeeded on a fresh registry.
+    assert [e.id for e in reg.read_entries().entries] == ["a"]
+
+
+def test_mutation_on_corrupt_registry_aborts_if_backup_write_lies_about_success(monkeypatch):
+    """[P2, third audit finding #9] The backup write is not trusted just
+    because it didn't raise — it's read back and compared byte-for-byte
+    against what should have been written. A write that silently corrupts
+    (e.g. a flaky filesystem that reports success but truncates/garbles the
+    content) must still abort the mutation rather than proceed to overwrite
+    the original corrupt registry believing a good backup now exists."""
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    original = "{not valid json at all"
+    reg.registry_path().write_text(original)
+
+    def _lying_atomic_write_bytes(path, data, **kwargs):
+        # Writes something OTHER than what was asked for, but doesn't
+        # raise — simulating a filesystem that reports success while
+        # silently corrupting the write.
+        path.write_bytes(b"corrupted-on-write")
+
+    monkeypatch.setattr(reg, "atomic_write_bytes", _lying_atomic_write_bytes)
+
+    with pytest.raises(reg.RegistryPreservationError):
+        reg.add_entry(_entry(id="should-not-be-added"))
+
+    # The ORIGINAL corrupt registry must still be exactly as it was — the
+    # mutation must never have reached _write_entries().
+    assert reg.registry_path().read_text() == original
+
+
+def test_unsupported_future_version_is_read_as_unsupported_not_missing():
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_text(json.dumps({"version": 999, "entries": []}))
+    result = reg.read_entries()
+    assert result.status == "unsupported_version"
+    assert result.entries == []
+
+
+def test_mutation_on_unsupported_version_preserves_a_backup_before_overwriting():
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    future_payload = json.dumps({"version": 999, "entries": [{"future": "schema"}]})
+    reg.registry_path().write_text(future_payload)
+
+    reg.add_entry(_entry(id="a"))
+
+    backups = list(
+        reg.registry_path().parent.glob("retained_staging.json.unsupported_version-*.bak")
+    )
+    assert len(backups) == 1
+    assert backups[0].read_text() == future_payload
+
+
+def test_registry_unreadable_due_to_io_error_is_reported_distinctly_from_corrupt(monkeypatch):
+    """[P1, third audit finding #1] A read that fails with an OSError
+    (permissions, a sharing violation, a transient network-share hiccup)
+    must be distinguished from 'corrupt' (content that WAS read but is
+    invalid) — there's no raw_bytes to back up and no way to know the file
+    still holds what it held a moment ago."""
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_text('{"version": 1, "entries": []}')
+
+    real_read_bytes = Path.read_bytes
+
+    def _boom_read_bytes(self, *a, **kw):
+        if self == reg.registry_path():
+            raise OSError("simulated permission/sharing-violation error")
+        return real_read_bytes(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_bytes", _boom_read_bytes)
+    result = reg.read_entries()
+    assert result.status == "unreadable"
+    assert result.entries == []
+    assert result.raw_bytes is None
+
+
+def test_registry_with_invalid_utf8_is_reported_as_corrupt_not_crashed(monkeypatch):
+    """[P1, fourth audit finding #1] A registry file containing bytes that
+    are not valid UTF-8 must be reported as 'corrupt' (the bytes WERE read
+    successfully; they just aren't valid text — the same category as
+    invalid JSON), not raise an uncaught `UnicodeDecodeError` straight out
+    of `read_entries()`. An earlier version called
+    `Path.read_text(encoding="utf-8")` directly, which let the decode
+    failure propagate past every one of the controlled status checks this
+    module promises to make (missing/corrupt/unsupported_version/
+    unreadable) and crash every caller, including `tiddl recover`, with a
+    raw traceback."""
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    invalid_utf8 = b"\xff\xfe not valid utf-8 at all"
+    reg.registry_path().write_bytes(invalid_utf8)
+
+    result = reg.read_entries()
+
+    assert result.status == "corrupt"
+    assert result.entries == []
+    assert result.raw_bytes == invalid_utf8
+
+
+def test_mutation_on_invalid_utf8_registry_preserves_exact_original_bytes():
+    """[P1, fourth audit finding #1] A mutation against an invalid-UTF-8
+    registry must back it up byte-for-byte before writing a fresh one —
+    proving the fix doesn't just avoid crashing, but actually preserves the
+    original unreadable-as-text content losslessly (no decode/re-encode
+    round trip, which would be impossible for bytes that aren't valid UTF-8
+    in the first place)."""
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    invalid_utf8 = b"\xff\xfe garbage \x00\x01"
+    reg.registry_path().write_bytes(invalid_utf8)
+
+    reg.add_entry(_entry(id="a"))  # mutation must not silently destroy the original
+
+    backups = list(reg.registry_path().parent.glob("retained_staging.json.corrupt-*.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == invalid_utf8
+    # And the mutation itself succeeded on a fresh registry.
+    assert [e.id for e in reg.read_entries().entries] == ["a"]
+
+
+def test_mutation_refuses_when_registry_cannot_be_read_not_just_when_corrupt(monkeypatch):
+    """[P1, third audit finding #1] The prior fail-closed fix
+    (`RegistryPreservationError`) only covered corrupt/unsupported-version
+    registries whose content WAS successfully read. A registry that could
+    not be read at all must ALSO refuse to mutate — not fall through to
+    `_preserve_unreadable` (which no-ops when `raw_bytes is None`) and then
+    silently write a fresh, effectively empty registry over whatever is
+    actually on disk. This proves the original bytes on disk are completely
+    untouched by a mutation attempt, using a targeted patch of `Path.read_bytes`
+    that leaves `os.replace` (and every other path) working normally — so if
+    the mutation DID silently succeed by writing a fresh registry, this test
+    would catch it via the byte-for-byte comparison below, not just via the
+    exception type."""
+    reg.add_entry(_entry(id="pre-existing"))
+    original_bytes = reg.registry_path().read_bytes()
+
+    real_read_bytes = Path.read_bytes
+
+    def _boom_read_bytes(self, *a, **kw):
+        if self == reg.registry_path():
+            raise OSError("simulated permission/sharing-violation error")
+        return real_read_bytes(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "read_bytes", _boom_read_bytes)
+
+    with pytest.raises(RegistryReadError):
+        reg.add_entry(_entry(id="should-not-be-added"))
+
+    # NOTE: patching `Path.read_bytes` (not `read_text`) since `read_entries()`
+    # now reads bytes first and decodes as a separate step (see the fourth
+    # audit finding #1 fix) — this is the call that must actually fail to
+    # exercise the mutation-refuses path. The read-back below deliberately
+    # uses the builtin `open()`, not `Path.read_bytes()` — the patch above
+    # is still active at this point in the test, so going through
+    # `Path.read_bytes()` here would hit the same simulated failure. This
+    # avoids needing an early `monkeypatch.undo()`, which would also undo
+    # this test's autouse APP_PATH-isolation patch since both share the
+    # same `monkeypatch` fixture instance.
+    with open(reg.registry_path(), "rb") as f:
+        assert f.read() == original_bytes
+
+
+# ---------------------------------------------------------------------------
+# [P1] Lock the complete registry transaction, not individual load/save
+# calls — two concurrent writers must both survive, not lose an update.
+# ---------------------------------------------------------------------------
+
+
+def test_two_concurrent_add_operations_both_survive():
+    """Two threads each running the full add_entry() transaction concurrently
+    must both end up in the registry — proves the lock guards the WHOLE
+    read -> mutate -> write sequence, not just the final write (which would
+    let both threads read the same empty snapshot and clobber each other)."""
+    barrier = threading.Barrier(2)
+
+    def worker(entry_id):
+        barrier.wait()
+        reg.add_entry(_entry(id=entry_id))
+
+    t1 = threading.Thread(target=worker, args=("first",))
+    t2 = threading.Thread(target=worker, args=("second",))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    ids = {e.id for e in reg.read_entries().entries}
+    assert ids == {"first", "second"}
+
+
+def test_lock_timeout_raises_and_leaves_registry_untouched(monkeypatch):
+    """[P2] A synchronous FileLock wait must have a finite timeout; on
+    timeout the registry file itself is left exactly as it was (best-effort:
+    the caller's current-run in-memory state is unaffected either way)."""
+    monkeypatch.setattr(reg, "DEFAULT_LOCK_TIMEOUT", 0.3)
+    reg.add_entry(_entry(id="pre-existing"))
+    before = reg.registry_path().read_text()
+
+    held = threading.Event()
+    release = threading.Event()
+
+    def hold_lock():
+        lock = FileLock(str(reg._lock_path()))
+        with lock:
+            held.set()
+            # Held well past the 0.3s transaction timeout below, so the
+            # timeout below is deterministic rather than a race.
+            release.wait(timeout=10)
+
+    t = threading.Thread(target=hold_lock)
+    t.start()
+    assert held.wait(timeout=5)
+
+    try:
+        with pytest.raises(RegistryLockTimeout):
+            reg.add_entry(_entry(id="should-not-be-added"))
+    finally:
+        release.set()
+        t.join(timeout=10)
+
+    assert reg.registry_path().read_text() == before
+    assert [e.id for e in reg.read_entries().entries] == ["pre-existing"]
+
+
+def test_lock_timeout_is_configurable_and_does_not_hang_forever(monkeypatch):
+    held = threading.Event()
+    release = threading.Event()
+
+    def hold_lock():
+        lock = FileLock(str(reg._lock_path()))
+        with lock:
+            held.set()
+            release.wait(timeout=10)
+
+    t = threading.Thread(target=hold_lock)
+    t.start()
+    assert held.wait(timeout=5)
+
+    start = time.monotonic()
+    try:
+        with pytest.raises(RegistryLockTimeout):
+            with reg._transaction(timeout=0.3):
+                pass  # pragma: no cover - should never enter, lock is held
+        elapsed = time.monotonic() - start
+        assert elapsed < 5  # bounded, not an indefinite hang
+    finally:
+        release.set()
+        t.join(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# Quarantine relocation + orphan detection.
+# ---------------------------------------------------------------------------
+
+
+def test_quarantine_file_preserves_output_extension_not_part_suffix(tmp_path):
+    """[P2] The quarantine filename must derive its extension from the
+    intended output (e.g. `.flac`), not from staging's own `.part.<random>`
+    suffix — otherwise downstream magic/container checks that branch on
+    filename extension would silently stop working on a recovered file."""
+    staging = tmp_path / "tiddl-abc123.flac.part.9f8e7d6c"
+    staging.write_bytes(b"fake flac bytes")
+
+    final_path, quarantined = reg.quarantine_file(
+        staging, output_suffix=".flac", entry_id="myid"
+    )
+    assert quarantined is True
+    assert final_path.name == "myid.flac"
+    assert final_path.suffix == ".flac"
+    assert final_path.read_bytes() == b"fake flac bytes"
+    assert not staging.exists()  # moved, not copied-and-left
+
+
+@pytest.mark.parametrize("suffix", [".flac", ".m4a", ".mp4", ".mp3"])
+def test_quarantine_file_preserves_various_output_extensions(tmp_path, suffix):
+    staging = tmp_path / f"tiddl-xyz{suffix}.part.aaaaaaaa"
+    staging.write_bytes(b"data")
+    final_path, quarantined = reg.quarantine_file(
+        staging, output_suffix=suffix, entry_id="eid"
+    )
+    assert quarantined is True
+    assert final_path.suffix == suffix
+
+
+def test_quarantine_file_degrades_gracefully_on_relocation_failure(tmp_path, monkeypatch):
+    staging = tmp_path / "tiddl-abc.bin.part.1"
+    staging.write_bytes(b"data")
+
+    def boom_mkdir(*a, **k):
+        raise OSError("simulated permission error")
+
+    monkeypatch.setattr(type(reg.quarantine_dir()), "mkdir", boom_mkdir)
+    final_path, quarantined = reg.quarantine_file(staging, output_suffix=".bin", entry_id="eid")
+    assert quarantined is False
+    assert final_path == staging
+    assert staging.exists()  # left in place, not lost
+
+
+# ---------------------------------------------------------------------------
+# [P2, third audit finding #6] Cross-filesystem quarantine (`_same_volume`
+# forced False) — the copy/verify/publish/delete-source sequence, not just
+# the same-volume atomic-rename fast path every other quarantine test above
+# exercises. `staging` is the ONLY verified copy at this point, so getting
+# this sequencing wrong risks destroying the only good bytes.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_volume_quarantine_copies_verifies_then_deletes_source(tmp_path, monkeypatch):
+    """The success path: source is copied to a quarantine-side temp,
+    verified byte-for-byte, published as the final quarantined path, and
+    ONLY THEN is the source deleted."""
+    monkeypatch.setattr(reg, "_same_volume", lambda a, b: False)
+    staging = tmp_path / "tiddl-abc.flac.part.1"
+    content = b"cross-volume payload" * 100
+    staging.write_bytes(content)
+
+    final_path, quarantined = reg.quarantine_file(staging, output_suffix=".flac", entry_id="xv1")
+
+    assert quarantined is True
+    assert final_path.name == "xv1.flac"
+    assert final_path.read_bytes() == content
+    assert not staging.exists()  # only deleted AFTER the verified copy landed
+    # No leftover .part.* temp in the quarantine dir either.
+    leftovers = [p for p in reg.quarantine_dir().iterdir() if ".part." in p.name]
+    assert leftovers == []
+
+
+def test_cross_volume_quarantine_silent_copy_corruption_leaves_source_untouched(
+    tmp_path, monkeypatch
+):
+    """[P1] If the copy silently corrupts (shutil.copy2 doesn't raise, but
+    the bytes that land don't match the source), the mismatch must be
+    caught by the byte-for-byte re-hash BEFORE the source is ever deleted —
+    a copy is not trusted just because the copy call didn't raise."""
+    monkeypatch.setattr(reg, "_same_volume", lambda a, b: False)
+    staging = tmp_path / "tiddl-abc.bin.part.1"
+    staging.write_bytes(b"the real content")
+
+    def _corrupting_copy2(src, dst):
+        Path(dst).write_bytes(b"SILENTLY CORRUPTED, WRONG BYTES ENTIRELY")
+
+    monkeypatch.setattr(reg.shutil, "copy2", _corrupting_copy2)
+
+    final_path, quarantined = reg.quarantine_file(staging, output_suffix=".bin", entry_id="xv2")
+
+    assert quarantined is False
+    assert final_path == staging
+    assert staging.exists()
+    assert staging.read_bytes() == b"the real content"  # untouched
+    # The corrupted quarantine-side temp must not be left behind either.
+    leftovers = list(reg.quarantine_dir().glob("xv2*")) if reg.quarantine_dir().is_dir() else []
+    assert leftovers == []
+
+
+def test_cross_volume_quarantine_copy_failure_keeps_source_and_cleans_temp(tmp_path, monkeypatch):
+    """A copy that raises outright (disk full, permission error) must leave
+    the source exactly as it was and not leak a partial temp file."""
+    monkeypatch.setattr(reg, "_same_volume", lambda a, b: False)
+    staging = tmp_path / "tiddl-abc.bin.part.1"
+    staging.write_bytes(b"data")
+
+    def _boom_copy2(src, dst):
+        raise OSError("simulated disk-full mid-copy")
+
+    monkeypatch.setattr(reg.shutil, "copy2", _boom_copy2)
+
+    final_path, quarantined = reg.quarantine_file(staging, output_suffix=".bin", entry_id="xv3")
+
+    assert quarantined is False
+    assert final_path == staging
+    assert staging.exists()
+    leftovers = list(reg.quarantine_dir().glob("xv3*")) if reg.quarantine_dir().is_dir() else []
+    assert leftovers == []
+
+
+def test_cross_volume_quarantine_publish_replace_failure_keeps_source_and_cleans_temp(
+    tmp_path, monkeypatch
+):
+    """The copy succeeds and verifies, but the final `os.replace()` of the
+    verified temp into place fails — the source must still be preserved
+    (it's the only known-good copy at that point) and the temp cleaned up."""
+    monkeypatch.setattr(reg, "_same_volume", lambda a, b: False)
+    staging = tmp_path / "tiddl-abc.bin.part.1"
+    staging.write_bytes(b"data")
+
+    real_replace = reg.os.replace
+
+    def _boom_replace(src, dst):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(reg.os, "replace", _boom_replace)
+
+    final_path, quarantined = reg.quarantine_file(staging, output_suffix=".bin", entry_id="xv4")
+
+    assert quarantined is False
+    assert final_path == staging
+    assert staging.exists()
+    assert staging.read_bytes() == b"data"
+    # Nothing quarantine-side named after this entry should survive (the
+    # verified temp is cleaned up on a failed publish).
+    monkeypatch.setattr(reg.os, "replace", real_replace)  # restore before globbing
+    leftovers = list(reg.quarantine_dir().glob("xv4*")) if reg.quarantine_dir().is_dir() else []
+    assert leftovers == []
+
+
+def test_cross_volume_quarantine_source_delete_failure_still_returns_verified_target(
+    tmp_path, monkeypatch
+):
+    """[P1] Once the quarantine copy is verified and published, it is
+    authoritative — a best-effort failure to delete the now-redundant
+    source must NOT be treated as an overall failure: the function still
+    returns the verified target with `quarantined=True`, just with a
+    logged warning about the harmless leftover duplicate."""
+    monkeypatch.setattr(reg, "_same_volume", lambda a, b: False)
+    staging = tmp_path / "tiddl-abc.bin.part.1"
+    staging.write_bytes(b"data")
+
+    monkeypatch.setattr(reg, "_safe_unlink_warn", lambda path, ctx: False)
+
+    final_path, quarantined = reg.quarantine_file(staging, output_suffix=".bin", entry_id="xv5")
+
+    assert quarantined is True
+    assert final_path.name == "xv5.bin"
+    assert final_path.read_bytes() == b"data"
+    assert staging.exists()  # best-effort delete failed; redundant copy remains (harmless)
+
+
+def test_orphaned_quarantine_file_is_detected_not_silently_ignored():
+    """[P1] A crash between relocating a file into quarantine and publishing
+    the registry entry for it must leave a DETECTABLE orphan, never an
+    invisible leftover."""
+    qdir = reg.quarantine_dir()
+    qdir.mkdir(parents=True, exist_ok=True)
+    orphan = qdir / "no-matching-entry.bin"
+    orphan.write_bytes(b"data")
+
+    orphans = reg.find_orphaned_quarantine_files()
+    assert orphans == [orphan]
+
+
+def test_known_quarantine_file_is_not_reported_as_orphan():
+    qdir = reg.quarantine_dir()
+    qdir.mkdir(parents=True, exist_ok=True)
+    known = qdir / "known.bin"
+    known.write_bytes(b"data")
+    reg.add_entry(_entry(id="known", staging_path=str(known)))
+
+    assert reg.find_orphaned_quarantine_files() == []
+
+
+def test_no_quarantine_dir_yields_no_orphans():
+    assert reg.find_orphaned_quarantine_files() == []
+
+
+# ---------------------------------------------------------------------------
+# register_retained_file: the end-to-end "just retained a file" call.
+# ---------------------------------------------------------------------------
+
+
+async def test_register_retained_file_quarantines_and_records_observed_hash(tmp_path):
+    staging = tmp_path / "tiddl-abc.flac.part.1"
+    content = b"\x00" * 5000
+    staging.write_bytes(content)
+
+    result = await reg.register_retained_file(
+        staging, tmp_path / "dest" / "track.flac", RetainReason.PUBLISH_PENDING,
+        track_title="My Track",
+    )
+
+    assert result.persisted
+    entry = result.entry
+    assert result.actual_path == Path(entry.staging_path)
+    assert entry.reason == RetainReason.PUBLISH_PENDING
+    assert entry.track_title == "My Track"
+    assert entry.quarantined is True
+    quarantined_path = Path(entry.staging_path)
+    assert quarantined_path.exists()
+    assert quarantined_path.suffix == ".flac"
+    assert not staging.exists()
+
+    assert entry.observed_size == len(content)
+    assert entry.observed_hash == hashlib.sha256(content).hexdigest()
+    assert entry.hash_algorithm == "sha256"
+
+    # And it round-trips through the registry.
+    reread = reg.read_entries().entries[0]
+    assert reread.id == entry.id
+
+
+async def test_register_retained_file_degrades_to_unpersisted_result_on_lock_timeout(monkeypatch):
+    """[Failure handling] A registry persistence failure must never raise out
+    of the download path — it degrades to a RegisterResult with entry=None
+    (result.persisted is False), logged, but `result.actual_path` still
+    reflects where the file physically ended up (quarantine still happened),
+    so the caller (downloader.py) can keep task.retained_staging accurate
+    even though this attempt won't be listed by `tiddl recover` until a
+    later successful registry write."""
+    staging_dir = reg.APP_PATH.parent / "stage"
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    staging = staging_dir / "tiddl-x.bin.part.1"
+    staging.write_bytes(b"data")
+
+    def boom_add_entry(entry):
+        raise RegistryLockTimeout("simulated")
+
+    monkeypatch.setattr(reg, "add_entry", boom_add_entry)
+    result = await reg.register_retained_file(
+        staging, staging_dir / "dest.bin", RetainReason.PUBLISH_PENDING
+    )
+    assert result.entry is None  # never raises
+    assert not result.persisted
+    # The file was still quarantined (that step succeeded); actual_path must
+    # point at its real, current location — not the stale original staging
+    # path, which no longer exists.
+    assert result.actual_path.exists()
+    assert not staging.exists()
+
+
+# ---------------------------------------------------------------------------
+# reconcile(): ok / gone / corrupt, and never auto-deletes.
+# ---------------------------------------------------------------------------
+
+
+async def test_reconcile_reports_ok_for_untouched_entry(tmp_path):
+    qdir = reg.quarantine_dir()
+    qdir.mkdir(parents=True, exist_ok=True)
+    f = qdir / "e1.bin"
+    content = b"hello world"
+    f.write_bytes(content)
+    import hashlib
+    reg.add_entry(_entry(
+        id="e1", staging_path=str(f),
+        observed_size=len(content), observed_hash=hashlib.sha256(content).hexdigest(),
+    ))
+
+    report = await reg.reconcile()
+    assert report.status == "valid"
+    assert len(report.entries) == 1
+    assert report.entries[0].status == "ok"
+
+
+async def test_reconcile_reports_gone_for_missing_file_and_does_not_remove_entry():
+    """[P2] The stale-entry policy: a `gone` file is reported, not silently
+    dropped from the registry — retain a bounded tombstone so the user can
+    see what was lost, per the audit's recommendation."""
+    reg.add_entry(_entry(id="e1", staging_path="/does/not/exist.bin"))
+
+    report = await reg.reconcile()
+    assert len(report.entries) == 1
+    assert report.entries[0].status == "gone"
+
+    # Tombstone retained: still present on a second reconcile, not dropped.
+    still_there = reg.read_entries().entries
+    assert len(still_there) == 1
+    assert still_there[0].id == "e1"
+
+
+async def test_reconcile_reports_corrupt_when_content_changed_but_keeps_entry(tmp_path):
+    """[P1] Recovery must compare exact observed size/hash, not just
+    existence — a file that changed on disk since it was retained must be
+    flagged, never treated as still valid."""
+    qdir = reg.quarantine_dir()
+    qdir.mkdir(parents=True, exist_ok=True)
+    f = qdir / "e1.bin"
+    f.write_bytes(b"original content")
+    import hashlib
+    reg.add_entry(_entry(
+        id="e1", staging_path=str(f),
+        observed_size=len(b"original content"),
+        observed_hash=hashlib.sha256(b"original content").hexdigest(),
+    ))
+
+    f.write_bytes(b"tampered content!!")  # changed after retention
+
+    report = await reg.reconcile()
+    assert report.entries[0].status == "corrupt"
+    # Never auto-deleted:
+    assert f.exists()
+    assert len(reg.read_entries().entries) == 1
+
+
+async def test_reconcile_never_writes_when_registry_is_valid(tmp_path):
+    reg.add_entry(_entry(id="e1", staging_path=str(tmp_path / "gone.bin")))
+    before_mtime = reg.registry_path().stat().st_mtime_ns
+    await reg.reconcile()
+    after_mtime = reg.registry_path().stat().st_mtime_ns
+    assert before_mtime == after_mtime  # reconcile() is read-only
+
+
+async def test_reconcile_surfaces_orphans_alongside_entries():
+    qdir = reg.quarantine_dir()
+    qdir.mkdir(parents=True, exist_ok=True)
+    orphan = qdir / "orphan.bin"
+    orphan.write_bytes(b"x")
+
+    report = await reg.reconcile()
+    assert report.orphans == [orphan]
+    assert report.entries == []
+
+
+# ---------------------------------------------------------------------------
+# startup_status(): lightweight, no hashing, no destination I/O.
+# ---------------------------------------------------------------------------
+
+
+def test_startup_status_empty_registry():
+    status = reg.startup_status()
+    assert status.status == "missing"
+    assert status.count == 0
+
+
+def test_startup_status_counts_entries_without_hashing(tmp_path, monkeypatch):
+    reg.add_entry(_entry(id="a", staging_path=str(tmp_path / "does-not-exist.bin")))
+    reg.add_entry(_entry(id="b", staging_path=str(tmp_path / "also-missing.bin")))
+
+    def boom_hash(*a, **k):
+        raise AssertionError("startup_status must never hash a file")
+
+    monkeypatch.setattr(reg, "_hash_and_size", boom_hash)  # sync helper used by hash_and_size_async
+    status = reg.startup_status()
+    assert status.status == "valid"
+    assert status.count == 2  # counted despite files not existing - no existence check either
+
+
+def test_startup_status_never_touches_fs_beyond_the_registry_itself(tmp_path, monkeypatch):
+    """[P1] Startup reconciliation must be lightweight: registry status/count
+    only, no destination access. Simulate `Path.exists` blowing up for
+    anything under a fake "destination" to prove it's never called."""
+    reg.add_entry(_entry(id="a", output_path="/mnt/nas/should-not-be-touched.bin"))
+
+    from pathlib import Path
+    real_exists = Path.exists
+
+    def guarded_exists(self):
+        if "should-not-be-touched" in str(self):
+            raise AssertionError("startup_status must not touch destination paths")
+        return real_exists(self)
+
+    monkeypatch.setattr(Path, "exists", guarded_exists)
+    status = reg.startup_status()
+    assert status.count == 1
+
+
+# ---------------------------------------------------------------------------
+# TIDDL_PATH / APP_PATH resolution honored (factual correction from the audit).
+# ---------------------------------------------------------------------------
+
+
+def test_registry_path_follows_app_path(tmp_path, monkeypatch):
+    custom = tmp_path / "custom-app-dir"
+    monkeypatch.setattr(reg, "APP_PATH", custom)
+    assert reg.registry_path() == custom / "retained_staging.json"
+    assert reg.quarantine_dir() == custom / "retained"
+
+
+def test_env_tiddl_path_is_honored_end_to_end(tmp_path, monkeypatch):
+    """[Factual correction from the audit] APP_PATH is not always ~/.tiddl —
+    `TIDDL_PATH` always wins (see tiddl/cli/const.py:get_app_path). Exercise
+    the REAL resolution function (not just the registry's own APP_PATH
+    attribute) to prove the registry ends up wherever TIDDL_PATH points."""
+    from tiddl.cli.const import get_app_path
+
+    custom = tmp_path / "custom-via-env"
+    monkeypatch.setenv("TIDDL_PATH", str(custom))
+    assert get_app_path() == custom
+
+    # retained_registry imports APP_PATH once at module load time (like every
+    # other consumer, e.g. auth/core.py's AUTH_DATA_FILE) — simulate a process
+    # that started with this env var set by pointing the module at the same
+    # freshly-resolved path, and confirm the registry/quarantine paths follow.
+    monkeypatch.setattr(reg, "APP_PATH", get_app_path())
+    assert reg.registry_path() == custom / "retained_staging.json"
+    assert reg.quarantine_dir() == custom / "retained"
+
+
+# ---------------------------------------------------------------------------
+# [P2] Synchronous FileLock waits must not block the asyncio event loop.
+# ---------------------------------------------------------------------------
+
+
+async def test_registry_transaction_does_not_block_the_event_loop_when_used_via_to_thread():
+    """The synchronous FileLock-guarded transaction (`_transaction`, used by
+    `add_entry`/`update_entry`/`remove_entry`) must be run via
+    `asyncio.to_thread` from async call sites — exactly what
+    `register_retained_file` does. Prove a concurrent asyncio task keeps
+    making progress (ticking a counter) while a slow, lock-held mutation is
+    in flight in a thread, rather than the whole event loop stalling."""
+    ticks = []
+
+    async def ticker():
+        for _ in range(20):
+            ticks.append(1)
+            await asyncio.sleep(0.01)
+
+    def slow_mutation():
+        # Simulate a slow disk / contended lock inside the transaction body
+        # by holding the lock for a while via a direct, blocking call.
+        with reg._transaction() as box:
+            time.sleep(0.3)
+            box["entries"].append(_entry(id="slow"))
+
+    ticker_task = asyncio.create_task(ticker())
+    await asyncio.to_thread(slow_mutation)
+    await ticker_task
+
+    # If the event loop had been blocked for the ~0.3s the mutation took, far
+    # fewer than 20 ticks (0.01s apart) would have landed by the time we get
+    # here — the ticker would have been starved instead of interleaved.
+    assert len(ticks) == 20
+    assert [e.id for e in reg.read_entries().entries] == ["slow"]
+
+
+# ---------------------------------------------------------------------------
+# [Minimum additional test, per audit] Idempotent recovery: a crash between a
+# successful destination publish and the registry's remove_entry() call must
+# not corrupt anything, and a re-run must still converge cleanly.
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_converges_via_reconcile_and_cli_if_interrupted_after_publish(
+    tmp_path,
+):
+    """[Minimum additional test, per audit] Idempotent recovery: a crash
+    between a successful destination publish and the registry's
+    `remove_entry()` call must not corrupt anything, and a re-run must
+    still converge cleanly.
+
+    The second audit review specifically flagged an earlier version of this
+    test for FAKING convergence (calling `remove_entry()` manually) instead
+    of exercising the real recovery path. This version instead reproduces
+    the exact ON-DISK STATE such a crash leaves behind — using real
+    `publish_verified_file` semantics (destination holds the verified
+    bytes, the quarantined source is gone, the registry is untouched and
+    still says `publish_pending`) — and then drives the actual production
+    code (`reconcile()`, then the real `tiddl recover --publish` CLI
+    command) to confirm IT detects and converges this on its own, with no
+    manual registry surgery standing in for what the code is supposed to
+    do."""
+    content = b"\x33" * 4000
+    source = tmp_path / "src.bin"
+    source.write_bytes(content)
+    dest = tmp_path / "dest.bin"
+
+    # This test invokes the CliRunner below, which internally does its own
+    # `asyncio.run()` — so, unlike the rest of this file, it must NOT itself
+    # be an `async def` test (that would already have a loop running, and
+    # nested `asyncio.run()` calls raise). Drive the async registry calls
+    # explicitly instead.
+    result = asyncio.run(reg.register_retained_file(
+        source, dest, RetainReason.PUBLISH_PENDING, track_title="Idempotent"
+    ))
+    assert result.persisted
+    entry = result.entry
+    quarantined = Path(entry.staging_path)
+    assert quarantined.exists()
+
+    # Reproduce the on-disk state a crash AFTER a successful publish but
+    # BEFORE the registry's remove_entry() call would leave behind: the
+    # destination holds the verified bytes and the quarantined copy is
+    # gone (that's what a real publish_verified_file success does — see
+    # tiddl.core.utils.publish), but the registry was never updated.
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(content)
+    quarantined.unlink()
+    assert reg.read_entries().entries[0].id == entry.id  # registry still stale
+
+    # reconcile() (the real deep-check used by `tiddl recover`) must
+    # recognize this WITHOUT hashing/touching either file a second time in
+    # a way that could disturb it: the retained copy is gone, but the
+    # destination independently matches what was observed at retention
+    # time, so this is stale bookkeeping from an already-converged recovery
+    # -- not data loss.
+    report = asyncio.run(reg.reconcile())
+    assert len(report.entries) == 1
+    assert report.entries[0].status == "already_published"
+    assert report.entries[0].entry.id == entry.id
+
+    # And the real CLI path must be able to drop the stale entry — no
+    # manual remove_entry() call standing in for it.
+    from typer.testing import CliRunner
+
+    from tiddl.cli.app import app
+
+    runner = CliRunner()
+    cli_result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    assert cli_result.exit_code == 0, cli_result.output
+    assert "already converged" in cli_result.output
+    assert dest.read_bytes() == content  # untouched by the convergence
+    assert reg.read_entries().entries == []

--- a/tiddl/cli/app.py
+++ b/tiddl/cli/app.py
@@ -138,6 +138,50 @@ def callback(
         api_omit_cache=OMIT_CACHE, console=console, debug_path=debug_path
     )
 
+    # Lightweight, read-only: registry status + entry count only, no hashing,
+    # no destination I/O. Deep verification and any recovery only happen via
+    # the explicit `tiddl recover` command. See
+    # tiddl.core.utils.retained_registry.
+    #
+    # [P2, finding #14] Verified (not just claimed) via a CliRunner check:
+    # this notice runs for ordinary subcommand invocations (e.g. `tiddl
+    # recover`, `tiddl auth`), but NOT for `--help` — Click/Typer treats
+    # `--help` as an eager option that prints help and exits during
+    # parameter processing, before this group callback's body ever runs. An
+    # earlier version of this comment claimed "safe on every invocation
+    # including --help", which was never actually tested and is false.
+    try:
+        from tiddl.core.utils import retained_registry
+        _retained_status = retained_registry.startup_status()
+        if _retained_status.count:
+            console.print(
+                f"[yellow]{_retained_status.count} file(s) retained from a previous "
+                "session's incomplete publish — run [bold]tiddl recover[/] to review.[/]"
+            )
+        elif _retained_status.status in ("corrupt", "unsupported_version"):
+            console.print(
+                f"[yellow]The retained-staging registry is {_retained_status.status} — "
+                "run [bold]tiddl recover[/] for details.[/]"
+            )
+        elif _retained_status.status == "unreadable":
+            # [P2, fourth audit finding #1] 'unreadable' is MORE serious
+            # than 'corrupt'/'unsupported_version' (see
+            # retained_registry.RegistryStatus's docstring: any mutating
+            # `tiddl recover` command will refuse outright until this is
+            # resolved), but an earlier version of this callback only
+            # warned for the two less-serious statuses — a user who never
+            # proactively runs `tiddl recover` would get no signal at all
+            # that persistence is currently inaccessible. This stays
+            # read-only/lightweight, same as the branches above: no deep
+            # verification, no destination I/O, just surfacing what
+            # `startup_status()` (itself lightweight) already found.
+            console.print(
+                "[red]The retained-staging registry could not be read — run "
+                "[bold]tiddl recover[/] for details.[/]"
+            )
+    except Exception as e:
+        log.debug(f"Skipping retained-staging startup notice: {e}")
+
     if not is_ffmpeg_installed:
         ctx.obj.console.print(
             "[yellow]WARNING ffmpeg is not installed, tiddl might not work properly, "

--- a/tiddl/cli/commands/__init__.py
+++ b/tiddl/cli/commands/__init__.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
+
 from typer import Typer
 
 from .auth import auth_command
 from .download import download_command
 from .info import info_command
+from .recover import recover_command
+
 # from .export import export_command
 
 COMMANDS = [
     auth_command,
     download_command,
     info_command,
+    recover_command,
     # export_command
 ]
 

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import asyncio
-import shutil
 import hashlib
 import uuid
 import sqlite3
@@ -31,6 +30,9 @@ from tiddl.core.utils.const import (
 )
 from tiddl.core.utils.ffmpeg import convert_to_mp4, extract_flac, fix_mp4_faststart, is_mp4_container
 from tiddl.core.api.playback import report_playback
+from tiddl.core.utils.fsio import _safe_unlink
+from tiddl.core.utils.publish import publish_verified_file
+from tiddl.core.utils import retained_registry
 
 from .output import RichOutput
 
@@ -54,84 +56,17 @@ def _normalize_dir(path: Path) -> str:
     return os.path.normcase(os.path.normpath(s))
 
 
-def _safe_unlink(path: Optional[Path]) -> bool:
-    """Delete a file if it exists, swallowing OS errors (best-effort cleanup).
-
-    Returns True if `path` is gone once this returns (deleted here, or it never
-    existed) and False if an existing file could NOT be removed (e.g. locked by
-    an antivirus/indexer, or a remote filesystem that rejects the unlink).
-    Callers that must not silently claim "no orphan left behind" — i.e. after a
-    successful publish, when the leftover would otherwise go unreported — should
-    check this return value instead of treating cleanup as unconditional."""
-    if path is None:
-        return True
-    try:
-        Path(path).unlink()
-        return True
-    except FileNotFoundError:
-        return True
-    except OSError:
-        return False
-
-
-def _safe_unlink_warn(path: Path, context: str) -> bool:
-    """`_safe_unlink` plus an honest log warning when an existing file could
-    not be removed. Cleanup here is always best-effort: a failure logged by
-    this helper never turns an otherwise-successful publish into a failure —
-    it only makes an otherwise-silent leftover observable."""
-    ok = _safe_unlink(path)
-    if not ok:
-        log.warning(
-            f"Could not remove leftover destination-side temp file at {path} "
-            f"({context}); left in place (best-effort cleanup)."
-        )
-    return ok
-
-
-def _same_volume(a: Path, b: Path) -> bool:
-    """True if paths `a` and `b` live on the same filesystem (st_dev match).
-
-    Used by the safe-publish step to pick the atomic-rename fast path. Kept as a
-    module-level function so tests can force the cross-filesystem path."""
-    try:
-        return os.stat(a).st_dev == os.stat(b).st_dev
-    except OSError:
-        return False
-
-
-def _fsync_path(path: Path) -> None:
-    """Best-effort flush of a file's data to storage before it is verified.
-
-    shutil.copy2 only closes the file; on a network share the bytes may still sit
-    in a write cache, so an immediate verify could read cache rather than what
-    actually landed. Filesystems that don't support fsync just no-op."""
-    try:
-        fd = os.open(str(path), os.O_RDWR)
-    except OSError:
-        return
-    try:
-        os.fsync(fd)
-    except OSError:
-        pass
-    finally:
-        os.close(fd)
-
-
-def _fsync_dir(path: Path) -> None:
-    """Best-effort fsync of a directory (POSIX only) so a rename into it is
-    durable across a power loss. A no-op on Windows / unsupported filesystems."""
-    if os.name != "posix":
-        return
-    try:
-        fd = os.open(str(path), os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(fd)
-    except OSError:
-        pass
-    finally:
-        os.close(fd)
+# `_safe_unlink`, `_safe_unlink_warn`, `_same_volume`, `_fsync_path` and
+# `_fsync_dir` used to be defined here (PR #12). They moved to
+# `tiddl.core.utils.fsio`, and the actual same-volume/cross-volume publish
+# mechanics that used them moved to `tiddl.core.utils.publish` (see
+# `_publish_staged` below) — so the retained-staging registry and the offline
+# `tiddl recover` command can reuse the exact same primitives and publish
+# contract without depending on this module / a full `Downloader`. Only
+# `_safe_unlink` is still called directly here (step 1 of `_publish_staged`,
+# below); tests that used to monkeypatch `dlmod.shutil`/`dlmod.os.replace`/
+# `dlmod._same_volume`/`dlmod._fsync_*` for the publish mechanics now target
+# `tiddl.core.utils.publish` instead — see `tests/test_downloader.py`.
 
 # ====================================================================
 # IMPROVEMENT 1: Enums for download states
@@ -675,88 +610,37 @@ class Downloader:
             _safe_unlink(staging)
             return False, None
 
-        # 2. Same filesystem: a single atomic rename (no bytes copied). Retry only
-        #    transient locks; if it never happens the staging still exists.
-        if _same_volume(staging, task.output_path.parent):
-            for move_attempt in range(5):
-                try:
-                    os.replace(staging, task.output_path)
-                    await asyncio.to_thread(_fsync_dir, task.output_path.parent)
-                    task.error_message = None
-                    return True, None
-                except OSError as e:
-                    task.error_message = f"publish rename failed: {e}"
-                    if move_attempt == 4:
-                        log.warning(f"Failed to publish (rename) after 5 attempts: {e}")
-                        return False, staging
-                    log.warning(f"Publish rename locked (attempt {move_attempt+1}), retrying: {e}")
-                    await asyncio.sleep(1.0 + move_attempt)
-            return False, staging
+        # 2/3. Same-volume atomic rename, or cross-filesystem copy -> fsync ->
+        #      verify -> atomic replace. Extracted to `publish_verified_file`
+        #      (tiddl.core.utils.publish) so the offline `tiddl recover`
+        #      command can reuse the identical contract without a Downloader.
+        async def _reverify(candidate: Path) -> tuple[bool, Optional[str]]:
+            return await self._verify_or_repair(candidate, task)
 
-        # 3. Cross filesystem: copy -> fsync -> verify a dest-side temp, then
-        #    atomically publish it with os.replace().
-        dest_tmp = task.output_path.with_name(
-            task.output_path.name + f".part.{uuid.uuid4().hex[:8]}"
+        def _warn(msg: str) -> None:
+            task.error_message = msg
+
+        published, retained = await publish_verified_file(
+            staging, task.output_path, reverify=_reverify, on_warning=_warn,
         )
-        for publish_attempt in range(5):
-            _safe_unlink_warn(dest_tmp, "stale temp from a previous attempt")
-            try:
-                await asyncio.to_thread(shutil.copy2, str(staging), str(dest_tmp))
-                await asyncio.to_thread(_fsync_path, dest_tmp)  # commit before verifying
-            except OSError as e:
-                task.error_message = f"copy to destination failed: {e}"
-                log.warning(f"{task.error_message} (attempt {publish_attempt+1})")
-                _safe_unlink_warn(dest_tmp, "cleanup after a failed copy")
-                if publish_attempt == 4:
-                    break
-                await asyncio.sleep(1.0 + publish_attempt)
-                continue
-
-            ok, err = await self._verify_or_repair(dest_tmp, task)
-            if ok:
-                # Atomic publish, with its own retry. A failure here must NEVER
-                # delete the prior final file — only a successful os.replace
-                # overwrites it, atomically.
-                for replace_attempt in range(5):
-                    try:
-                        os.replace(dest_tmp, task.output_path)
-                        await asyncio.to_thread(_fsync_dir, task.output_path.parent)
-                        task.error_message = None
-                        # Only now is the local copy safe to drop. This is a
-                        # best-effort delete: report it, don't lie about it — if
-                        # it fails (AV/indexer lock, remote fs), the publish is
-                        # still a success, but the leftover must not go unnoticed.
-                        if await asyncio.to_thread(_safe_unlink, staging):
-                            return True, None
-                        log.warning(
-                            f"Published '{task.track_title}' but could not delete "
-                            f"the local staging copy at {staging}; left in place "
-                            "(best-effort cleanup)."
-                        )
-                        self.rich_output.console.print(
-                            f"[yellow]⚠️  Published, but couldn't remove local "
-                            f"staging copy at {staging}[/] {task.track_title}"
-                        )
-                        return True, staging
-                    except OSError as e:
-                        task.error_message = f"atomic publish failed: {e}"
-                        log.warning(f"{task.error_message} (attempt {replace_attempt+1})")
-                        if replace_attempt == 4:
-                            _safe_unlink_warn(dest_tmp, "replace exhausted its retries")
-                            return False, staging  # keep staging; prior final untouched
-                        await asyncio.sleep(1.0 + replace_attempt)
-
-            # Destination copy is corrupt (e.g. a NAS that corrupts on flush).
-            # Drop it and re-copy from the surviving staging.
-            task.error_message = err
-            log.warning(f"Destination validation failed (attempt {publish_attempt+1}): {err}")
-            _safe_unlink_warn(dest_tmp, "cleanup after a corrupt destination copy")
-            if publish_attempt < 4:
-                await asyncio.sleep(1.0 + publish_attempt)
-
-        # Publish exhausted: best-effort clean the dest temp, KEEP the local staging.
-        _safe_unlink_warn(dest_tmp, "cleanup after publish exhausted its retries")
-        return False, staging
+        if published:
+            task.error_message = None
+            if retained is not None:
+                # Published — output_path is verified and correct — but the
+                # local staging copy could not be deleted (best-effort
+                # cleanup failure). Already logged inside publish_verified_file
+                # via on_warning; surface it to the console too, with the
+                # track title publish_verified_file doesn't know about.
+                log.warning(
+                    f"Published '{task.track_title}' but could not delete "
+                    f"the local staging copy at {retained}; left in place "
+                    "(best-effort cleanup)."
+                )
+                self.rich_output.console.print(
+                    f"[yellow]⚠️  Published, but couldn't remove local "
+                    f"staging copy at {retained}[/] {task.track_title}"
+                )
+        return published, retained
 
     async def _download_with_retry(
         self,
@@ -883,6 +767,20 @@ class Downloader:
                     # None unless _publish_staged could not delete the local
                     # staging copy after a successful publish (see its docstring).
                     task.retained_staging = retained
+                    if retained is not None:
+                        # Destination is already correct — only the redundant
+                        # local copy remains. Persist so this survives a
+                        # restart; see tiddl.core.utils.retained_registry.
+                        # `actual_path` reflects the file's real location
+                        # (quarantined or not) even if persistence itself
+                        # failed — task.retained_staging must never point at
+                        # a path the file has already moved away from.
+                        result = await retained_registry.register_retained_file(
+                            retained, task.output_path,
+                            retained_registry.RetainReason.CLEANUP_PENDING,
+                            track_title=task.track_title,
+                        )
+                        task.retained_staging = result.actual_path
                     if attempt > 1:
                         log.info(f"Successfully downloaded '{task.track_title}' on attempt {attempt}")
                         self.rich_output.console.print(
@@ -897,13 +795,24 @@ class Downloader:
                     tmp_path = None  # ownership handed to the retained staging
                     task.status = DownloadStatus.FAILED
                     task.retained_staging = retained
+                    # Destination still needs to be published. Persist so this
+                    # survives a restart; see tiddl.core.utils.retained_registry.
+                    # `actual_path` reflects the file's real location even if
+                    # persistence itself failed — never leave
+                    # task.retained_staging pointing at a moved-away-from path.
+                    result = await retained_registry.register_retained_file(
+                        retained, task.output_path,
+                        retained_registry.RetainReason.PUBLISH_PENDING,
+                        track_title=task.track_title,
+                    )
+                    task.retained_staging = result.actual_path
                     log.error(
                         f"Could not publish '{task.track_title}' to destination; kept "
-                        f"local copy at {retained} ({task.error_message})"
+                        f"local copy at {task.retained_staging} ({task.error_message})"
                     )
                     self.rich_output.console.print(
                         f"[red]❌ Could not publish to destination; kept local copy at "
-                        f"{retained}[/] {task.track_title}"
+                        f"{task.retained_staging}[/] {task.track_title}"
                     )
                     return False
 

--- a/tiddl/cli/commands/recover.py
+++ b/tiddl/cli/commands/recover.py
@@ -1,0 +1,527 @@
+"""`tiddl recover` — list, recover or purge files retained from a previous
+session's failed/incomplete publish (see `tiddl.core.utils.retained_registry`
+and PR "safe cross-filesystem publish", #12).
+
+Deliberately a TOP-LEVEL command, not nested under `tiddl download`.
+
+Correction (second audit review): an earlier version of this docstring
+claimed nesting under `download` was technically impossible because
+`download_callback` unconditionally constructs a `Downloader`/triggers TIDAL
+auth. That claim was checked against the actual code and is FALSE:
+`download_callback` does register `ctx.call_on_close(run)` unconditionally,
+but `run()` itself (in `cli/commands/download/__init__.py`) starts with
+`if not ctx.obj.resources: return` — when no subcommand added a resource,
+`run()` returns immediately and never touches `ctx.obj.api` or constructs a
+`Downloader`. Nesting `recover` under `download` would in fact still work
+offline.
+
+The real reason `recover` is top-level is a deliberate UX/discoverability
+choice, not a technical necessity: recovery is meant to be reachable and
+runnable independent of whether a user has ever touched `download` in a
+given session, and keeping it top-level makes the "this never talks to
+TIDAL" property obvious from `tiddl --help` rather than resting on an
+internal guard clause elsewhere that could change in future refactors.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import typer
+from filelock import Timeout as FileLockTimeout
+from typing_extensions import Annotated
+
+from tiddl.cli.ctx import Context
+from tiddl.core.utils import retained_registry as registry
+from tiddl.core.utils.publish import publish_verified_file
+
+recover_command = typer.Typer(
+    name="recover",
+    no_args_is_help=False,
+)
+
+
+def _age(created_at: str) -> str:
+    try:
+        created = datetime.fromisoformat(created_at)
+        delta = datetime.now(timezone.utc) - created
+    except (ValueError, TypeError):
+        # TypeError covers a naive (tz-less) timestamp, which can't be
+        # subtracted from an aware `now()` — defense in depth only; entries
+        # reaching this point should already have a validated, tz-aware
+        # `created_at` (see RetainedEntry.from_json_dict), but this display
+        # helper must never crash the whole `recover` listing over it.
+        return "?"
+    seconds = int(delta.total_seconds())
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    if seconds < 86400:
+        return f"{seconds // 3600}h"
+    return f"{seconds // 86400}d"
+
+
+def _resolve(id_or_prefix: str, entries: list) -> Optional[object]:
+    exact = [e for e in entries if e.entry.id == id_or_prefix]
+    if exact:
+        return exact[0]
+    prefix_matches = [e for e in entries if e.entry.id.startswith(id_or_prefix)]
+    if len(prefix_matches) == 1:
+        return prefix_matches[0]
+    return None
+
+
+def _print_registry_status_warning(console, status: str) -> None:
+    # NOTE: `report.status` here comes from `registry.reconcile()`'s
+    # READ-ONLY pass (`read_entries()`) — nothing has been reset, rewritten,
+    # or backed up just because this command ran. A corrupt/unsupported
+    # registry is only ever replaced with a backup+fresh-file as part of an
+    # actual MUTATION (add/update/remove_entry, e.g. via --publish/--purge).
+    # This message must describe only what has verifiably happened, not
+    # what a future mutation (if any) would do.
+    if status == "corrupt":
+        console.print(
+            "[yellow]⚠️  The retained-staging registry could not be parsed "
+            f"(see {registry.registry_path()}). It has NOT been modified or "
+            "reset by this listing. If you next run a command that mutates "
+            "the registry (--publish/--all/--purge), the unreadable file will "
+            "be backed up alongside it before a fresh one is written — see "
+            f"the logs for the exact backup path. Quarantined files under "
+            f"{registry.quarantine_dir()}, if any, are untouched.[/]"
+        )
+    elif status == "unsupported_version":
+        console.print(
+            "[yellow]⚠️  The retained-staging registry is from a newer/unknown "
+            "version of tiddl. It has NOT been modified by this listing, and "
+            "any future mutation will back it up before writing a fresh one "
+            "(same as for a corrupt registry). Quarantined files, if any, are "
+            "untouched.[/]"
+        )
+    elif status == "unreadable":
+        # [P1, third audit finding #1] Distinct from 'corrupt': the file
+        # could not even be READ (permissions, a sharing lock, a transient
+        # network-share error) — there is no content to back up, so a
+        # mutation will REFUSE outright rather than replace it (see
+        # RegistryReadError). This is not a transient "nothing to worry
+        # about" state; recovery is blocked until it's resolved.
+        console.print(
+            f"[red]⚠️  The retained-staging registry at {registry.registry_path()} "
+            "could not be read (see the logs for the exact I/O error). It has "
+            "NOT been modified. Any command that needs to mutate it "
+            "(--publish/--all/--purge) will refuse until this is resolved — "
+            "check file permissions and that nothing else has it locked.[/]"
+        )
+
+
+def _print_list(console, report) -> None:
+    from rich.table import Table
+
+    _print_registry_status_warning(console, report.status)
+
+    if not report.entries and not report.orphans:
+        console.print("[green]Nothing retained from a previous session.[/]")
+        return
+
+    table = Table(title="Retained files")
+    table.add_column("id")
+    table.add_column("status")
+    table.add_column("reason")
+    table.add_column("track")
+    table.add_column("destination")
+    table.add_column("age")
+
+    status_colors = {
+        "ok": "green", "already_published": "cyan", "gone": "red", "corrupt": "red",
+    }
+    for re in report.entries:
+        status_color = status_colors[re.status]
+        table.add_row(
+            re.entry.id[:8],
+            f"[{status_color}]{re.status}[/]",
+            re.entry.reason.value,
+            re.entry.track_title or "?",
+            re.entry.output_path,
+            _age(re.entry.created_at),
+        )
+    console.print(table)
+
+    if report.orphans:
+        console.print(
+            f"[yellow]⚠️  {len(report.orphans)} file(s) in the quarantine dir with "
+            "no matching registry entry (an interrupted relocation or an already-"
+            "cleaned-up recovery). Left in place — inspect manually:[/]"
+        )
+        for p in report.orphans:
+            console.print(f"    {p}")
+
+    recoverable = [re for re in report.entries if re.status in ("ok", "already_published")]
+    if recoverable:
+        console.print(
+            f"\n{len(recoverable)} recoverable. Run [bold]tiddl recover --publish <id>[/] "
+            "for one, or [bold]tiddl recover --all --yes[/] for all of them."
+        )
+
+
+async def _reverify_against_entry(entry, candidate: Path) -> tuple[bool, Optional[str]]:
+    size, digest = await registry.hash_and_size_async(candidate, entry.hash_algorithm)
+    if size != entry.observed_size:
+        return False, f"size mismatch: expected {entry.observed_size}, got {size}"
+    if digest != entry.observed_hash:
+        return False, f"{entry.hash_algorithm} mismatch: content differs from what was retained"
+    return True, None
+
+
+async def _recover_one(console, re) -> bool:
+    """[P2, third audit finding #7] Wraps `_recover_one_inner` so a single
+    entry's unexpected I/O failure (e.g. a file vanishing mid-hash due to an
+    unrelated concurrent process, a transient network-share error) can't
+    abort the rest of an `--all` batch — it's reported and the loop moves
+    on, same spirit as `reconcile()`'s own per-entry error isolation.
+
+    Returns True only when this entry reached a fully-resolved, no-further-
+    action-needed outcome (a green ✓). Anything that still needs attention
+    — a red ✗ error, or a yellow ⚠️ "left for a retry" outcome like a
+    best-effort delete failure or a cleanup_pending→publish_pending
+    demotion — returns False, so callers (`--publish`/`--all`) can exit
+    non-zero instead of silently reporting overall success when something
+    didn't fully complete."""
+    entry = re.entry
+    try:
+        return await _recover_one_inner(console, re)
+    except OSError as e:
+        console.print(f"[red]✗[/] {entry.id[:8]}: unexpected I/O error during recovery: {e}")
+        return False
+
+
+async def _recover_one_inner(console, re) -> bool:
+    entry = re.entry
+    warnings: list = []
+
+    if re.status == "already_published":
+        # See retained_registry.reconcile(): the retained copy is already
+        # gone AND the destination independently matches what was observed
+        # at retention time — a prior recovery attempt already succeeded but
+        # crashed/was killed before it could remove this registry entry.
+        # There is no file I/O left to do; only the stale bookkeeping needs
+        # to be dropped.
+        await asyncio.to_thread(registry.remove_entry, entry.id)
+        console.print(
+            f"[green]✓[/] {entry.id[:8]}: already converged (a previous recovery "
+            "attempt succeeded before it could update the registry); removed "
+            "the stale entry. No file was touched."
+        )
+        return True
+
+    if entry.reason == registry.RetainReason.CLEANUP_PENDING:
+        dest = Path(entry.output_path)
+        if dest.exists():
+            ok, detail = await _reverify_against_entry(entry, dest)
+        else:
+            ok, detail = False, "destination missing"
+        if ok:
+            removed_file = await asyncio.to_thread(
+                registry.delete_quarantined_file,
+                Path(entry.staging_path),
+                "recover cleanup-pending",
+            )
+            if removed_file:
+                await asyncio.to_thread(registry.remove_entry, entry.id)
+                console.print(
+                    f"[green]✓[/] {entry.id[:8]}: destination already correct; "
+                    "removed the redundant local copy."
+                )
+                return True
+            console.print(
+                f"[yellow]⚠️[/] {entry.id[:8]}: destination is correct, but the local "
+                f"copy at {entry.staging_path} could not be deleted (best-effort); "
+                "left in the registry, try again later."
+            )
+            return False
+        await asyncio.to_thread(
+            registry.update_entry, entry.id,
+            reason=registry.RetainReason.PUBLISH_PENDING,
+        )
+        console.print(
+            f"[yellow]⚠️[/] {entry.id[:8]}: the destination no longer matches what was "
+            f"published ({detail}) — promoted to publish_pending. Run "
+            f"'tiddl recover --publish {entry.id[:8]}' to publish it."
+        )
+        return False
+
+    # PUBLISH_PENDING
+    source = Path(entry.staging_path)
+    destination = Path(entry.output_path)
+
+    def _on_warning(msg: str) -> None:
+        warnings.append(msg)
+
+    async def _reverify(candidate: Path):
+        return await _reverify_against_entry(entry, candidate)
+
+    published, retained = await publish_verified_file(
+        source, destination, reverify=_reverify, on_warning=_on_warning
+    )
+    if published and retained is None:
+        await asyncio.to_thread(registry.remove_entry, entry.id)
+        console.print(f"[green]✓[/] {entry.id[:8]}: published to {destination}.")
+        return True
+    elif published:
+        # [P1, fourth audit finding #3] The destination WAS published, but
+        # the redundant local copy could not be removed (best-effort
+        # cleanup failure) — that's exactly the "needs a later retry"
+        # outcome this function's own contract (see `_recover_one`'s
+        # docstring) says must return False, not True. An earlier version
+        # printed a green checkmark and returned True here, contradicting
+        # that contract: a single `--publish` or a batch `--all` could exit
+        # 0 while still leaving unresolved cleanup work sitting in the
+        # registry as `cleanup_pending`, with nothing telling the caller
+        # that anything was still outstanding.
+        await asyncio.to_thread(
+            registry.update_entry, entry.id,
+            reason=registry.RetainReason.CLEANUP_PENDING,
+            staging_path=str(retained),
+        )
+        console.print(
+            f"[yellow]⚠[/] {entry.id[:8]}: published to {destination}, but could not "
+            f"remove the now-redundant local copy at {retained} (best-effort); "
+            "run recover again later to retry cleanup."
+        )
+        return False
+    else:
+        last = warnings[-1] if warnings else "unknown error"
+        console.print(
+            f"[red]✗[/] {entry.id[:8]}: still could not publish to {destination} ({last})."
+        )
+        return False
+
+
+def _is_safe_to_auto_delete(entry) -> bool:
+    """Only ever auto-delete a file resolved beneath the quarantine root with
+    the expected `<id><ext>` naming — never an arbitrary recorded path (a
+    tampered/corrupt registry entry must not be able to trigger deletion of
+    something outside tiddl's own quarantine dir)."""
+    if not entry.quarantined:
+        return False
+    try:
+        p = Path(entry.staging_path).resolve()
+        qdir = registry.quarantine_dir().resolve()
+    except OSError:
+        return False
+    return p.parent == qdir and p.stem == entry.id
+
+
+@recover_command.callback(invoke_without_command=True)
+def recover(
+    ctx: Context,
+    do_publish: Annotated[
+        Optional[str],
+        typer.Option("--publish", help="Recover a single entry by id (or id prefix)."),
+    ] = None,
+    do_all: Annotated[
+        bool,
+        typer.Option("--all", help="Recover every entry currently in 'ok' status."),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes", "-y",
+            help="Required together with --all (confirms destination-touching recovery).",
+        ),
+    ] = False,
+    do_purge: Annotated[
+        Optional[str],
+        typer.Option(
+            "--purge",
+            help=(
+                "Remove one 'gone' or 'corrupt' entry from the registry "
+                "(id or id prefix). Refused for 'ok' entries."
+            ),
+        ),
+    ] = None,
+):
+    """List retained files from a previous session, or recover/purge them.
+
+    Runs entirely offline — no TIDAL login required. With no options, lists
+    every retained entry and its status (ok / already_published / corrupt /
+    gone) without touching any file. `--publish <id>`/`--all --yes` recover
+    `ok` entries using the exact same safe-publish contract as a normal
+    download (`tiddl.core.utils.publish.publish_verified_file`), and simply
+    drop the registry bookkeeping for `already_published` entries (a prior
+    recovery attempt already succeeded but crashed before it could update
+    the registry — see `retained_registry.reconcile`). `--purge <id>`
+    removes one acknowledged `gone`/`corrupt` entry from the registry —
+    never an `ok` or `already_published` one.
+    """
+    console = ctx.obj.console
+
+    async def _run() -> None:
+        if do_purge is None and do_publish is None and not do_all:
+            # Read-only listing: no mutation, no need for the cross-process
+            # recovery lock — reconcile and print against a single snapshot.
+            _print_list(console, await registry.reconcile())
+            return
+
+        # [P2, finding #12] Everything below this point can touch files
+        # and/or the registry, and must be serialized against any other
+        # `tiddl recover` process doing the same — see
+        # `registry.recovery_operation_lock`'s docstring for why this is a
+        # dedicated lock file rather than reusing the registry's own
+        # transaction lock. The reconcile() snapshot used to decide what's
+        # safe to act on is taken AFTER acquiring the lock, not before, so
+        # a concurrent process's changes can't be acted on using stale
+        # status information.
+        try:
+            lock_cm = registry.recovery_operation_lock()
+            with lock_cm:
+                await _run_mutating(console)
+        except FileLockTimeout as e:
+            console.print(
+                "[red]Could not start recovery: another `tiddl recover` process "
+                f"appears to be running against the same retained-staging data "
+                f"({e}). Wait for it to finish and try again.[/]"
+            )
+            raise typer.Exit(1)
+        except registry.RegistryLockTimeout as e:
+            # A registry mutation (add/update/remove_entry) couldn't get the
+            # registry's own transaction lock in time — surface this instead
+            # of an unhandled traceback. Shouldn't normally happen while we
+            # hold `recovery_operation_lock`, but the registry lock can still
+            # be briefly contended by an unrelated concurrent download
+            # registering a newly-retained file.
+            console.print(
+                f"[red]Could not complete this operation: the retained-staging "
+                f"registry was locked by something else and did not become "
+                f"available in time ({e}). Try again.[/]"
+            )
+            raise typer.Exit(1)
+        except registry.RegistryPreservationError as e:
+            # A registry mutation (add/update/remove_entry) refused to
+            # proceed because the registry was corrupt/unsupported AND its
+            # backup copy could not be written either (see
+            # `retained_registry._preserve_unreadable`'s fail-closed
+            # behavior) — surface this instead of letting an unhandled
+            # exception crash the command with a raw traceback.
+            console.print(
+                f"[red]Could not complete this operation: the retained-staging "
+                f"registry needed to be backed up before it could be safely "
+                f"rewritten, and that backup failed ({e}). Nothing was changed. "
+                "Resolve the underlying problem (disk full, permissions) and "
+                "try again.[/]"
+            )
+            raise typer.Exit(1)
+        except registry.RegistryReadError as e:
+            # [P1, third audit finding #1] A registry mutation refused to
+            # proceed because the registry file could not even be READ
+            # (distinct from corrupt content — see RegistryReadError's
+            # docstring). Nothing was written; surface this instead of an
+            # unhandled traceback.
+            console.print(
+                f"[red]Could not complete this operation: the retained-staging "
+                f"registry at {registry.registry_path()} could not be read "
+                f"({e}). Nothing was changed. Resolve the underlying problem "
+                "(permissions, a sharing lock, a network-share hiccup) and try "
+                "again.[/]"
+            )
+            raise typer.Exit(1)
+
+    async def _run_mutating(console) -> None:
+        report = await registry.reconcile()
+
+        if do_purge is not None:
+            match = _resolve(do_purge, report.entries)
+            if match is None:
+                console.print(f"[red]No unique retained entry matches id '{do_purge}'.[/]")
+                raise typer.Exit(1)
+            if match.status in ("ok", "already_published"):
+                console.print(
+                    f"[red]{match.entry.id[:8]} is still recoverable (status "
+                    f"'{match.status}') — refusing to purge it. Use --publish or "
+                    "--all instead.[/]"
+                )
+                raise typer.Exit(1)
+
+            file_path = Path(match.entry.staging_path)
+            if match.status == "corrupt" and _is_safe_to_auto_delete(match.entry):
+                deleted = await asyncio.to_thread(
+                    registry.delete_quarantined_file,
+                    file_path,
+                    "recover --purge",
+                )
+                if not deleted and file_path.exists():
+                    # Deletion failed and the file is still there: do NOT
+                    # remove the registry entry — that would orphan the file
+                    # with no record of it anywhere. Leave both in place so
+                    # the user (or a retry) can act on accurate information.
+                    console.print(
+                        f"[red]✗[/] {match.entry.id[:8]}: could not delete the "
+                        f"quarantined file at {file_path} (best-effort delete "
+                        "failed); the registry entry was NOT removed — try "
+                        "again, or delete the file manually and re-run purge."
+                    )
+                    raise typer.Exit(1)
+                await asyncio.to_thread(registry.remove_entry, match.entry.id)
+                console.print(f"[green]✓[/] Purged {match.entry.id[:8]} ({match.status}).")
+                return
+
+            # Either the file is already gone (nothing to delete), or it's a
+            # non-quarantined fallback path that purge must never auto-delete
+            # (see _is_safe_to_auto_delete) — only the registry entry itself
+            # is removed. Say exactly which of these happened.
+            await asyncio.to_thread(registry.remove_entry, match.entry.id)
+            if file_path.exists():
+                console.print(
+                    f"[green]✓[/] Purged {match.entry.id[:8]} ({match.status}) from the "
+                    f"registry. NOTE: {file_path} was NOT auto-deleted (not a "
+                    "recognized quarantine path) — left in place for manual review."
+                )
+            else:
+                console.print(f"[green]✓[/] Purged {match.entry.id[:8]} ({match.status}).")
+            return
+
+        if do_publish is not None or do_all:
+            if do_all and not yes:
+                console.print(
+                    "[red]--all requires --yes (bulk publication touches destinations).[/]"
+                )
+                raise typer.Exit(1)
+
+            if do_publish is not None:
+                match = _resolve(do_publish, report.entries)
+                if match is None:
+                    console.print(f"[red]No unique retained entry matches id '{do_publish}'.[/]")
+                    raise typer.Exit(1)
+                if match.status not in ("ok", "already_published"):
+                    console.print(
+                        f"[red]{match.entry.id[:8]} is not recoverable right now (status "
+                        f"'{match.status}'); run 'tiddl recover' to see why.[/]"
+                    )
+                    raise typer.Exit(1)
+                targets = [match]
+            else:
+                targets = [re for re in report.entries if re.status in ("ok", "already_published")]
+                if not targets:
+                    console.print("[green]Nothing to recover.[/]")
+                    return
+
+            # [P2, third audit finding #7] Process every target regardless
+            # of earlier failures (same as before), but track whether ANY
+            # of them didn't fully succeed, so the command's exit code
+            # reflects that instead of always reporting 0 as long as it
+            # didn't crash. A single `--publish <id>` that fails must also
+            # exit non-zero — not just `--all` batches.
+            all_ok = True
+            for re in targets:
+                ok = await _recover_one(console, re)
+                all_ok = all_ok and ok
+            if not all_ok:
+                console.print(
+                    "[red]One or more entries were not fully recovered — see the "
+                    "output above for details.[/]"
+                )
+                raise typer.Exit(1)
+            return
+
+    asyncio.run(_run())

--- a/tiddl/cli/utils/auth/core.py
+++ b/tiddl/cli/utils/auth/core.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
+
 import os
-import tempfile
-from pathlib import Path
 from logging import getLogger
+from pathlib import Path
 
 from tiddl.cli.config import APP_PATH
-from .models import AuthData
+from tiddl.core.utils.fsio import atomic_write_bytes
 
+from .models import AuthData
 
 AUTH_DATA_FILE = APP_PATH / "auth.json"
 # Segundo token para el modo hibrido: cliente TV (lossless) que cubre los tracks
@@ -41,27 +42,17 @@ def save_auth_data(auth_data: AuthData, file: Path = AUTH_DATA_FILE):
     log.debug(f"saving to '{file}'")
 
     payload = auth_data.json()
-    file.parent.mkdir(parents=True, exist_ok=True)
 
     # Write to a temp file in the same directory, then publish with os.replace()
     # so a crash or full disk mid-write can never leave a truncated auth.json
-    # (which used to wipe the user's session and force a re-login).
-    fd, tmp_name = tempfile.mkstemp(
-        dir=str(file.parent), prefix=f".{file.name}.", suffix=".tmp"
+    # (which used to wipe the user's session and force a re-login). These
+    # tokens are secrets — restrict to owner-only on POSIX (chmod_posix=0o600
+    # is a no-op on Windows; ACLs already default to the user profile there).
+    # Extracted into `tiddl.core.utils.fsio.atomic_write_bytes` (same behavior,
+    # now shared with the retained-staging registry) — see that function's
+    # docstring for the exact contract.
+    atomic_write_bytes(
+        file,
+        payload.encode("utf-8"),
+        chmod_posix=0o600 if os.name == "posix" else None,
     )
-    try:
-        # These tokens are secrets — restrict to owner-only on POSIX. On Windows
-        # os.fchmod is unavailable and ACLs already default to the user profile.
-        if os.name == "posix":
-            os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.write(payload)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_name, file)
-    except BaseException:
-        try:
-            os.unlink(tmp_name)
-        except OSError:
-            pass
-        raise

--- a/tiddl/core/utils/fsio.py
+++ b/tiddl/core/utils/fsio.py
@@ -1,0 +1,176 @@
+"""Shared, Downloader-independent filesystem primitives.
+
+Extracted from ``tiddl/cli/commands/download/downloader.py`` (PR #12, safe
+cross-filesystem publish) so they can be reused by code that must not depend
+on constructing a full ``Downloader`` (TIDAL auth, SQLite DB, HTTP session) —
+notably the retained-staging registry and the offline `tiddl recover`
+command. Behavior is unchanged from the original: this is a pure extraction,
+not a rewrite. `downloader.py` imports these names instead of defining them.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+from logging import getLogger
+from pathlib import Path
+from typing import Optional
+
+log = getLogger(__name__)
+
+
+def _safe_unlink(path: Optional[Path]) -> bool:
+    """Delete a file if it exists, swallowing OS errors (best-effort cleanup).
+
+    Returns True if `path` is gone once this returns (deleted here, or it never
+    existed) and False if an existing file could NOT be removed (e.g. locked by
+    an antivirus/indexer, or a remote filesystem that rejects the unlink).
+    Callers that must not silently claim "no orphan left behind" — i.e. after a
+    successful publish, when the leftover would otherwise go unreported — should
+    check this return value instead of treating cleanup as unconditional."""
+    if path is None:
+        return True
+    try:
+        Path(path).unlink()
+        return True
+    except FileNotFoundError:
+        return True
+    except OSError:
+        return False
+
+
+def _safe_unlink_warn(path: Path, context: str) -> bool:
+    """`_safe_unlink` plus an honest log warning when an existing file could
+    not be removed. Cleanup here is always best-effort: a failure logged by
+    this helper never turns an otherwise-successful publish into a failure —
+    it only makes an otherwise-silent leftover observable."""
+    ok = _safe_unlink(path)
+    if not ok:
+        log.warning(
+            f"Could not remove leftover destination-side temp file at {path} "
+            f"({context}); left in place (best-effort cleanup)."
+        )
+    return ok
+
+
+def _same_volume(a: Path, b: Path) -> bool:
+    """True if paths `a` and `b` live on the same filesystem (st_dev match).
+
+    Used by the safe-publish step to pick the atomic-rename fast path. Kept as a
+    module-level function so tests can force the cross-filesystem path."""
+    try:
+        return os.stat(a).st_dev == os.stat(b).st_dev
+    except OSError:
+        return False
+
+
+def _fsync_path(path: Path) -> None:
+    """Best-effort flush of a file's data to storage before it is verified.
+
+    shutil.copy2 only closes the file; on a network share the bytes may still sit
+    in a write cache, so an immediate verify could read cache rather than what
+    actually landed. Filesystems that don't support fsync just no-op."""
+    try:
+        fd = os.open(str(path), os.O_RDWR)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def _fsync_dir(path: Path) -> None:
+    """Best-effort fsync of a directory (POSIX only) so a rename into it is
+    durable across a power loss. A no-op on Windows / unsupported filesystems."""
+    if os.name != "posix":
+        return
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def atomic_write_bytes(
+    path: Path,
+    data: bytes,
+    *,
+    chmod_posix: Optional[int] = None,
+    fsync_dir: bool = False,
+) -> None:
+    """Write `data` to `path` so a crash or full disk mid-write can never leave
+    a truncated/partial file: a temp file in the SAME directory is written,
+    flushed, fsynced, then published with `os.replace` (atomic on every
+    platform this project supports). The temp file is removed on any failure.
+
+    `chmod_posix`, when given, is applied to the temp file's descriptor
+    *before* it is written and published — matching the original
+    `save_auth_data` behavior exactly (mode is set on the still-private temp
+    file, not on the final path after replace, so the data is never briefly
+    world-readable). Ignored on non-POSIX platforms (no `os.fchmod`).
+
+    `fsync_dir`, when True, best-effort fsyncs `path.parent` after the
+    replace (POSIX only, no-op elsewhere) for directory-entry durability
+    across a power loss. Default False to keep this a pure extraction of the
+    existing `save_auth_data` behavior, which does not fsync its directory.
+
+    This is a plain extraction of `save_auth_data`'s temp+fsync+replace
+    dance (see `tiddl/cli/utils/auth/core.py`) into a shared helper — same
+    contract, so it can be reused by the retained-staging registry without
+    a second copy of this logic."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    # `fd` is a raw OS-level file descriptor from mkstemp. Once `os.fdopen(fd,
+    # ...)` returns successfully, the resulting file object OWNS `fd` — its
+    # `close()`/context-manager exit will close the descriptor, and closing
+    # `fd` a second time via `os.close` would be an error (or, worse, could
+    # silently close some *other* unrelated fd the OS has since reused the
+    # same number for). But if `os.fdopen` itself raises (or anything
+    # between `mkstemp` and a successful `fdopen` raises) BEFORE ownership
+    # transfers, nothing else will ever close `fd` — and on Windows,
+    # `os.unlink`/`os.replace` on a still-open file fails outright (unlike
+    # POSIX, which allows unlinking an open file), so the leftover temp file
+    # would silently survive the `except OSError: pass` below. Track
+    # ownership explicitly so the except-block always closes whichever of
+    # (raw fd) or (file object) is still open, in the right order.
+    fd_owned_by_file_object = False
+    f = None
+    try:
+        if chmod_posix is not None and os.name == "posix":
+            os.fchmod(fd, chmod_posix)
+        f = os.fdopen(fd, "wb")
+        fd_owned_by_file_object = True
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())
+        f.close()
+        os.replace(tmp_name, path)
+    except BaseException:
+        if fd_owned_by_file_object:
+            try:
+                f.close()
+            except OSError:
+                pass
+        else:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+    if fsync_dir:
+        _fsync_dir(path.parent)

--- a/tiddl/core/utils/publish.py
+++ b/tiddl/core/utils/publish.py
@@ -1,0 +1,200 @@
+"""Cross-filesystem safe publish of an already-verified local file.
+
+Extracted from `Downloader._publish_staged` (PR #12, safe cross-filesystem
+publish; see `AUDIT_cross_volume.md`) into a free function with no
+dependency on `Downloader` — no TIDAL auth, no SQLite DB, no HTTP session —
+so both the live download path and the offline `tiddl recover` command share
+the exact same publish contract instead of two implementations drifting
+apart. Behavior for the download path is unchanged: `Downloader._publish_staged`
+now verifies/repairs locally, then delegates the move/copy/replace mechanics
+here.
+
+Contract (unchanged from PR #12): `source` MUST already be verified once by
+the caller before calling this — this function only re-verifies the
+DESTINATION-side copy after each cross-filesystem attempt, via `reverify`.
+Returns `(published, retained)`:
+  * `(True, None)`     — published; `source` deleted.
+  * `(True, source')`  — published, but `source` (or the original path it
+                          was passed as) could not be deleted afterward
+                          (best-effort cleanup failure). Safe to delete
+                          manually once noticed.
+  * `(False, source')` — the destination could not be published; `source` is
+                          retained untouched — caller must not delete it or
+                          re-derive it, and the prior `destination` (if any)
+                          is never touched by a failed publish.
+
+This function never returns `(False, None)` — unlike `_publish_staged`'s
+full four-outcome contract, there is no "local file is invalid" outcome here
+because verifying `source` is the caller's job, not this function's.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import uuid
+from logging import getLogger
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+
+from .fsio import _fsync_dir, _fsync_path, _safe_unlink, _safe_unlink_warn, _same_volume
+
+log = getLogger(__name__)
+
+# (ok, error_message_if_any)
+ReverifyFn = Callable[[Path], Awaitable[tuple[bool, Optional[str]]]]
+WarnFn = Callable[[str], None]
+
+
+async def publish_verified_file(
+    source: Path,
+    destination: Path,
+    *,
+    reverify: ReverifyFn,
+    on_warning: Optional[WarnFn] = None,
+) -> tuple[bool, Optional[Path]]:
+    warn: WarnFn = on_warning or (lambda _msg: None)
+
+    # [P1, third audit finding #2] This function does NOT create the
+    # destination directory, at any depth, ever. An earlier version tried a
+    # single-level (non-recursive) `mkdir` as a middle ground, reasoning
+    # that a missing single leaf directory (parent exists) was a safe,
+    # common case while a missing *chain* (what an unmounted network share
+    # looks like on POSIX) was not. The third audit review correctly
+    # rejected that as still heuristic: directory DEPTH says nothing about
+    # whether the expected filesystem is actually mounted. If the mount
+    # point itself is present as an ordinary local directory (common right
+    # after an unmount) and one level of the old library tree still exists
+    # below it, single-level creation can still land a "successful" publish
+    # entirely on local disk with no data ever reaching the real
+    # destination.
+    #
+    # The safe, fail-closed behavior instead: NEVER create the destination
+    # directory here. If `destination.parent` doesn't already exist, refuse
+    # immediately and let the caller decide what to do about it (nothing
+    # about this decision is filesystem-specific or recoverable by retrying
+    # the copy). This does mean a live download whose destination folder
+    # hasn't been created yet must create it BEFORE calling this function —
+    # which `cli/commands/download` already does unconditionally for the
+    # live download path — and it means `tiddl recover`, running long after
+    # the original attempt, will refuse to recreate a reorganized/missing
+    # destination folder rather than silently guessing it's safe to do so.
+    # A future explicit `--create-destination` recovery flag, requiring the
+    # user to confirm the destination is actually mounted first, is the
+    # right place to relax this — not an automatic heuristic here.
+    #
+    # [P2, fourth audit finding #4 — residual limitation, not fixed here]
+    # This "existing parent" check is a fail-closed improvement over
+    # recursive auto-creation, but it does NOT prove the expected
+    # filesystem (e.g. a NAS share) is actually mounted — only that SOME
+    # directory with the expected path already exists. A directory tree can
+    # remain present as an ordinary local directory after the real mount
+    # disappears (common right after an unmount on POSIX), and the live
+    # download path currently creates its destination parents unconditionally
+    # before ever calling this function — so a publish can still land
+    # entirely on local disk in that specific scenario. Closing this
+    # properly needs an explicit destination-root identity check (a
+    # configured expected mount/volume identity, not a directory-depth or
+    # existence heuristic), applied consistently to both the live download
+    # path and offline recovery — tracked as follow-up work, deliberately
+    # out of scope for this fail-closed-on-a-missing-parent fix.
+    if not destination.parent.exists():
+        msg = (
+            f"destination directory {destination.parent} does not exist "
+            "(refusing to create it — this could silently land the file on "
+            "the wrong filesystem if a network share/mount is actually just "
+            "unmounted; create the directory yourself once you've confirmed "
+            "the real destination is available, then retry)"
+        )
+        warn(msg)
+        log.warning(f"Publish refused: {msg}")
+        return False, source
+
+    # Same filesystem: a single atomic rename (no bytes copied). Retry only
+    # transient locks; if it never happens the source still exists.
+    if _same_volume(source, destination.parent):
+        for move_attempt in range(5):
+            try:
+                os.replace(source, destination)
+                await asyncio.to_thread(_fsync_dir, destination.parent)
+                return True, None
+            except OSError as e:
+                msg = f"publish rename failed: {e}"
+                warn(msg)
+                if move_attempt == 4:
+                    log.warning(f"Failed to publish (rename) after 5 attempts: {e}")
+                    return False, source
+                log.warning(f"Publish rename locked (attempt {move_attempt+1}), retrying: {e}")
+                await asyncio.sleep(1.0 + move_attempt)
+        return False, source
+
+    # Cross filesystem: copy -> fsync -> verify a dest-side temp, then
+    # atomically publish it with os.replace().
+    dest_tmp = destination.with_name(destination.name + f".part.{uuid.uuid4().hex[:8]}")
+    for publish_attempt in range(5):
+        _safe_unlink_warn(dest_tmp, "stale temp from a previous attempt")
+        try:
+            await asyncio.to_thread(shutil.copy2, str(source), str(dest_tmp))
+            await asyncio.to_thread(_fsync_path, dest_tmp)  # commit before verifying
+        except OSError as e:
+            msg = f"copy to destination failed: {e}"
+            warn(msg)
+            log.warning(f"{msg} (attempt {publish_attempt+1})")
+            _safe_unlink_warn(dest_tmp, "cleanup after a failed copy")
+            if publish_attempt == 4:
+                break
+            await asyncio.sleep(1.0 + publish_attempt)
+            continue
+
+        # [P1, third audit finding #4] `reverify` does real file I/O
+        # (typically hashing `dest_tmp`) and can raise `OSError` — e.g. the
+        # temp vanishes mid-verify due to an unrelated concurrent process,
+        # an antivirus/indexer lock, a flaky network share. An earlier
+        # version let that propagate straight out of this function,
+        # skipping every bit of cleanup below and leaking `dest_tmp` on
+        # disk forever (catching the exception at the CLI layer, as
+        # `tiddl recover` now does, stops the traceback but does NOT
+        # recover the publisher's own cleanup contract). Treat a reverify
+        # exception the same as a failed verification: it flows into the
+        # exact same "corrupt destination copy" cleanup/retry path below.
+        try:
+            ok, err = await reverify(dest_tmp)
+        except OSError as e:
+            ok, err = False, f"reverify raised an unexpected error: {e}"
+        if ok:
+            # Atomic publish, with its own retry. A failure here must NEVER
+            # delete the prior final file — only a successful os.replace
+            # overwrites it, atomically.
+            for replace_attempt in range(5):
+                try:
+                    os.replace(dest_tmp, destination)
+                    await asyncio.to_thread(_fsync_dir, destination.parent)
+                    # Only now is the source copy safe to drop. Best-effort:
+                    # report it, don't lie about it.
+                    if await asyncio.to_thread(_safe_unlink, source):
+                        return True, None
+                    warn(
+                        f"Published, but could not delete the local copy at "
+                        f"{source}; left in place (best-effort cleanup)."
+                    )
+                    return True, source
+                except OSError as e:
+                    msg = f"atomic publish failed: {e}"
+                    warn(msg)
+                    log.warning(f"{msg} (attempt {replace_attempt+1})")
+                    if replace_attempt == 4:
+                        _safe_unlink_warn(dest_tmp, "replace exhausted its retries")
+                        return False, source  # keep source; prior final untouched
+                    await asyncio.sleep(1.0 + replace_attempt)
+
+        # Destination copy is corrupt (e.g. a NAS that corrupts on flush).
+        # Drop it and re-copy from the surviving source.
+        warn(err or "destination validation failed")
+        log.warning(f"Destination validation failed (attempt {publish_attempt+1}): {err}")
+        _safe_unlink_warn(dest_tmp, "cleanup after a corrupt destination copy")
+        if publish_attempt < 4:
+            await asyncio.sleep(1.0 + publish_attempt)
+
+    # Publish exhausted: best-effort clean the dest temp, KEEP the source.
+    _safe_unlink_warn(dest_tmp, "cleanup after publish exhausted its retries")
+    return False, source

--- a/tiddl/core/utils/retained_registry.py
+++ b/tiddl/core/utils/retained_registry.py
@@ -1,0 +1,901 @@
+"""Persistent recovery of retained staging files across app restarts.
+
+Background: `Downloader._publish_staged` (PR #12) already keeps a verified
+local file instead of deleting it when the destination can't be published,
+or when it can be published but the local copy can't be cleaned up
+afterward (`task.retained_staging`). That fact used to live only in memory —
+lost on any restart, and the file itself sat in the OS temp directory, which
+is not a place anything promises to leave alone.
+
+This module closes that gap:
+
+* `quarantine_file` moves a retained file out of the OS temp directory into
+  `APP_PATH / "retained"`, a directory this project already treats as
+  durable (it's the same tree `auth.json` lives in).
+* A small JSON registry (`APP_PATH / "retained_staging.json"`) records enough
+  to recover or safely discard each entry later, written atomically
+  (`tiddl.core.utils.fsio.atomic_write_bytes`) and mutated only inside a
+  `FileLock`-guarded read -> validate -> mutate -> write transaction, so two
+  concurrent writers (two downloads failing at once, or two `tiddl`
+  processes) can't lose an update.
+* `reconcile()` (deep, explicit-only — called by `tiddl recover`, never at
+  plain startup) and `startup_status()` (lightweight, no hashing, no
+  destination I/O — called from the app's root callback) let a later run
+  discover what's pending.
+
+Entries are never silently dropped: a retained file that has disappeared, or
+a registry that turned out to be corrupt/from a future version, is reported
+and preserved (a backup copy for a corrupt/unsupported registry; a bounded
+tombstone entry for a `gone` file) rather than quietly treated as "nothing
+to see here". Deep integrity re-verification (`reconcile`) and any
+destination-touching recovery only happen when the user explicitly asks for
+them via `tiddl recover` — never as a side effect of running an unrelated
+command.
+
+This module has NO dependency on `Downloader`, TIDAL auth, or any network
+code — `tiddl recover` works fully offline.
+
+Crash-durability contract [P1, third audit finding #3]: every write this
+module performs that's meant to survive a restart — the registry file
+itself, its corrupt/unsupported-version backups, and a file's move/copy
+into the quarantine directory — goes through `atomic_write_bytes(...,
+fsync_dir=True)` or an explicit `_fsync_dir()` call after the relevant
+`os.replace()`, not just the atomic-replace-of-content that
+`atomic_write_bytes` already gives for free. Content-level atomicity alone
+(no torn/partial file) is not the same guarantee as directory-entry
+durability: without fsyncing the containing directory on POSIX, a power
+loss immediately after a successful `os.replace()` can still lose or roll
+back the directory entry pointing at the new inode, even though the write
+itself completed. This is best-effort on Windows, where directory fsync
+isn't supported (`fsio._fsync_dir` is a documented no-op there) — the
+content-atomicity guarantee still holds on Windows, just not the
+directory-entry one.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import shutil
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum
+from logging import getLogger
+from pathlib import Path
+from typing import Literal, Optional
+from uuid import uuid4
+
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
+
+from tiddl.cli.const import APP_PATH
+
+from .fsio import _fsync_dir, _fsync_path, _safe_unlink_warn, _same_volume, atomic_write_bytes
+
+log = getLogger(__name__)
+
+REGISTRY_VERSION = 1
+DEFAULT_LOCK_TIMEOUT = 10.0
+HASH_ALGORITHM = "sha256"
+#: [P2, third audit finding #5] Schema validation previously accepted ANY
+#: name in `hashlib.algorithms_available` for `hash_algorithm`, but
+#: `_hash_and_size`/`hexdigest()` are called with no extra arguments —
+#: variable-length algorithms like `shake_128`/`shake_256` require a
+#: `length` argument to `hexdigest()` and raise `TypeError` (not `OSError`,
+#: so it wasn't even caught by the per-entry error isolation elsewhere)
+#: the moment they're actually hashed. Registry version 1 only ever WRITES
+#: `sha256` (see `HASH_ALGORITHM` above) — restricting what it will accept
+#: on READ to the same fixed-length allowlist closes that gap without
+#: weakening anything production actually needs today. Extend this set
+#: (with a corresponding registry version bump if the on-disk format is
+#: meant to change) if algorithm agility is genuinely needed later.
+SUPPORTED_HASH_ALGORITHMS = frozenset({"sha256"})
+
+
+def registry_path() -> Path:
+    return APP_PATH / "retained_staging.json"
+
+
+def _lock_path() -> Path:
+    return APP_PATH / "retained_staging.json.lock"
+
+
+def _recovery_lock_path() -> Path:
+    """A SEPARATE lock file from `_lock_path()`, deliberately. `filelock`
+    locks are not reentrant across distinct `FileLock` instances on the same
+    path within one process (confirmed empirically: a second `FileLock` on
+    an already-held path just times out) — so a single long-held lock
+    guarding a whole recovery sequence cannot share a path with the
+    short-lived lock `_transaction()` takes internally for each registry
+    mutation, or a recovery operation would time out locking itself out.
+    Two independent lock files keep those two locking needs from colliding
+    while still being consistent (both live under the same APP_PATH)."""
+    return APP_PATH / "retained_staging.recovery.lock"
+
+
+def quarantine_dir() -> Path:
+    return APP_PATH / "retained"
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class RetainReason(str, Enum):
+    #: The destination could not be published; `staging_path` is the only
+    #: copy of the verified content. Must be re-published, not deleted.
+    PUBLISH_PENDING = "publish_pending"
+    #: The destination WAS published successfully; `staging_path` is a
+    #: redundant local copy that only needs to be cleaned up once the
+    #: destination is confirmed to still hold the same content.
+    CLEANUP_PENDING = "cleanup_pending"
+
+
+ReconcileStatus = Literal["ok", "gone", "corrupt", "already_published"]
+#: 'corrupt'/'unsupported_version': the file WAS read successfully (raw_bytes
+#: is available) but its content is invalid UTF-8/JSON/schema, or from a
+#: future registry version — a mutation can safely back this up before
+#: overwriting. 'unreadable': the file could NOT be read at all (permission
+#: error, a sharing violation, a transient network-share I/O error) — there
+#: is no `raw_bytes` to back up, and — critically — no way to know whether
+#: the content on disk still matches what was reported as unreadable a
+#: moment ago. [P1, third audit finding #1] This must never be treated the
+#: same as 'corrupt': a mutation must refuse outright rather than silently
+#: replacing a file it was never actually able to read.
+RegistryStatus = Literal["missing", "valid", "corrupt", "unsupported_version", "unreadable"]
+
+
+@dataclass
+class RetainedEntry:
+    id: str
+    reason: RetainReason
+    staging_path: str
+    output_path: str
+    observed_size: int
+    observed_hash: str
+    hash_algorithm: str = HASH_ALGORITHM
+    track_title: Optional[str] = None
+    created_at: str = field(default_factory=_utcnow_iso)
+    #: False if the move into `quarantine_dir()` failed and this entry's
+    #: `staging_path` is still wherever the caller originally staged it (a
+    #: degraded-but-not-lost outcome — see `quarantine_file`).
+    quarantined: bool = True
+
+    def to_json_dict(self) -> dict:
+        d = asdict(self)
+        d["reason"] = self.reason.value
+        return d
+
+    @staticmethod
+    def from_json_dict(d: dict) -> "RetainedEntry":
+        """Raises ValueError/TypeError/KeyError on a schema violation.
+        Callers (`_parse_registry_text`) treat any such failure as making
+        the WHOLE registry corrupt, not just this one entry — a registry
+        that can silently drop individual malformed entries while reporting
+        itself 'valid' can lose track of a retained file without any
+        visible warning, which is worse than refusing to touch it.
+
+        Deliberately NOT strict about `id` being a UUID or `observed_hash`
+        matching the exact digest length for its algorithm: this project's
+        own test suite constructs entries with short human-readable ids and
+        placeholder hashes, and there is no correctness reason a foreign/
+        future registry writer couldn't use a different id scheme. The
+        checks below focus on things that would otherwise crash downstream
+        code (wrong types, negative sizes, unknown hash algorithms, naive
+        timestamps) rather than pinning today's production format as the
+        only valid one.
+        """
+        d = dict(d)
+
+        entry_id = d.get("id")
+        if not isinstance(entry_id, str) or not entry_id:
+            raise ValueError(f"invalid 'id': {entry_id!r}")
+
+        reason = RetainReason(d["reason"])  # raises ValueError on unknown value
+
+        for key in ("staging_path", "output_path"):
+            v = d.get(key)
+            if not isinstance(v, str) or not v:
+                raise ValueError(f"invalid {key!r}: {v!r}")
+
+        size = d.get("observed_size")
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise ValueError(f"invalid 'observed_size': {size!r}")
+
+        algorithm = d.get("hash_algorithm", HASH_ALGORITHM)
+        if not isinstance(algorithm, str) or algorithm not in SUPPORTED_HASH_ALGORITHMS:
+            raise ValueError(f"unsupported 'hash_algorithm': {algorithm!r}")
+
+        # Deliberately only checking the TYPE here, not hex-charset/length:
+        # this project's own test suite uses human-readable placeholder
+        # values (e.g. "doesnotmatch") for `observed_hash` specifically to
+        # simulate a hash MISMATCH that should be caught by re-hashing at
+        # `reconcile()` time — that is a content-integrity check, not a
+        # schema violation, and must not be conflated with one here.
+        digest = d.get("observed_hash")
+        if not isinstance(digest, str) or not digest:
+            raise ValueError(f"invalid 'observed_hash': {digest!r}")
+
+        track_title = d.get("track_title")
+        if track_title is not None and not isinstance(track_title, str):
+            raise ValueError(f"invalid 'track_title': {track_title!r}")
+
+        created_at = d.get("created_at")
+        if not isinstance(created_at, str):
+            raise ValueError(f"invalid 'created_at': {created_at!r}")
+        try:
+            parsed_created_at = datetime.fromisoformat(created_at)
+        except ValueError as e:
+            raise ValueError(f"'created_at' is not a valid ISO timestamp: {created_at!r}") from e
+        if parsed_created_at.tzinfo is None:
+            raise ValueError(f"'created_at' must be timezone-aware: {created_at!r}")
+
+        quarantined = d.get("quarantined", True)
+        if not isinstance(quarantined, bool):
+            raise ValueError(f"invalid 'quarantined': {quarantined!r}")
+
+        d["reason"] = reason
+        d["hash_algorithm"] = algorithm
+        return RetainedEntry(**d)
+
+
+@dataclass
+class ReadResult:
+    status: RegistryStatus
+    entries: list  # list[RetainedEntry]
+    #: [P1, fourth audit finding #1] Bytes, not decoded text — this must
+    #: hold the EXACT original bytes read from disk (whether or not they're
+    #: valid UTF-8) so a corrupt/unsupported-version backup preserves the
+    #: original file byte-for-byte instead of round-tripping it through a
+    #: decode+re-encode that only works when the original happened to be
+    #: valid UTF-8 in the first place.
+    raw_bytes: Optional[bytes] = None
+
+
+@dataclass
+class ReconcileEntry:
+    entry: RetainedEntry
+    status: ReconcileStatus
+    detail: Optional[str] = None
+
+
+@dataclass
+class ReconcileReport:
+    status: RegistryStatus
+    entries: list  # list[ReconcileEntry]
+    orphans: list  # list[Path]
+
+
+@dataclass
+class StartupStatus:
+    status: RegistryStatus
+    count: int
+
+
+# ---------------------------------------------------------------------------
+# Low-level read/write. Reads never need a lock: atomic_write_bytes always
+# publishes a complete file via os.replace, so a concurrent reader sees
+# either the old or the new content, never a torn one.
+# ---------------------------------------------------------------------------
+
+
+def _parse_registry_text(text: str, raw_bytes: bytes) -> ReadResult:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        log.warning(f"Retained-staging registry at {registry_path()} is not valid JSON: {e}")
+        return ReadResult(status="corrupt", entries=[], raw_bytes=raw_bytes)
+
+    try:
+        version = data["version"]
+        raw_entries = data["entries"]
+        if not isinstance(raw_entries, list):
+            raise TypeError("'entries' is not a list")
+    except (KeyError, TypeError) as e:
+        log.warning(f"Retained-staging registry at {registry_path()} has an unexpected shape: {e}")
+        return ReadResult(status="corrupt", entries=[], raw_bytes=raw_bytes)
+
+    if version != REGISTRY_VERSION:
+        log.warning(
+            f"Retained-staging registry at {registry_path()} is version {version!r}, "
+            f"this build understands version {REGISTRY_VERSION}. Leaving it untouched."
+        )
+        return ReadResult(status="unsupported_version", entries=[], raw_bytes=raw_bytes)
+
+    entries = []
+    for raw in raw_entries:
+        try:
+            entries.append(RetainedEntry.from_json_dict(raw))
+        except (KeyError, TypeError, ValueError) as e:
+            # A single malformed entry makes the WHOLE registry 'corrupt' for
+            # this read, rather than being silently skipped while the
+            # registry is reported 'valid' — otherwise a partially-corrupted
+            # file could quietly lose track of a retained file with no
+            # visible warning, and (worse) a mutation could go on to write
+            # back a registry that's missing that entry entirely.
+            log.warning(
+                f"Retained-staging registry at {registry_path()} has an unreadable "
+                f"entry ({e}); treating the whole registry as corrupt so nothing is "
+                "silently dropped."
+            )
+            return ReadResult(status="corrupt", entries=[], raw_bytes=raw_bytes)
+    return ReadResult(status="valid", entries=entries, raw_bytes=raw_bytes)
+
+
+def read_entries() -> ReadResult:
+    """Read-only. Never mutates the registry file, never raises on a
+    missing/corrupt/future-version/unreadable/non-UTF-8 file — always
+    returns a usable result.
+
+    [P1, third audit finding #1] An I/O failure while reading (permissions,
+    a sharing violation, a transient network-share error) is reported as
+    'unreadable', NOT 'corrupt' — 'corrupt' means the content was
+    successfully read and turned out to be invalid, which is safe to back
+    up and replace. 'unreadable' means we never got the content at all, so
+    there is nothing to back up and no way to know it's safe to replace
+    whatever is actually on disk. `_transaction()` refuses to mutate on
+    'unreadable' rather than treating it like 'corrupt'.
+
+    [P1, fourth audit finding #1] Reads raw BYTES first, then decodes as a
+    separate, explicit step. An earlier version called
+    `Path.read_text(encoding="utf-8")` directly, which conflates I/O
+    failure (`OSError`) with decode failure (`UnicodeDecodeError` — NOT an
+    `OSError` subclass) into a single call. A registry containing invalid
+    UTF-8 bytes made `read_text()` raise `UnicodeDecodeError` straight out
+    of this function, uncaught — bypassing the controlled 'unreadable'/
+    'corrupt' handling entirely and crashing `tiddl recover` and every
+    other caller with an unhandled traceback. Splitting the read into
+    read-bytes-then-decode makes invalid UTF-8 an ordinary, controlled
+    'corrupt' result (the bytes WERE read; they just aren't valid text —
+    exactly like invalid JSON is 'corrupt'), with the original bytes
+    preserved byte-for-byte in `raw_bytes` for `_preserve_unreadable` to
+    back up, no round-trip through a decode that would have failed."""
+    path = registry_path()
+    try:
+        raw_bytes = path.read_bytes()
+    except FileNotFoundError:
+        return ReadResult(status="missing", entries=[])
+    except OSError as e:
+        log.warning(f"Could not read the retained-staging registry at {path}: {e}")
+        return ReadResult(status="unreadable", entries=[])
+
+    try:
+        text = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as e:
+        log.warning(f"Retained-staging registry at {path} is not valid UTF-8: {e}")
+        return ReadResult(status="corrupt", entries=[], raw_bytes=raw_bytes)
+
+    return _parse_registry_text(text, raw_bytes)
+
+
+def _write_entries(entries: list) -> None:
+    payload = {
+        "version": REGISTRY_VERSION,
+        "entries": [e.to_json_dict() for e in entries],
+    }
+    data = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    # [P1, third audit finding #3] fsync_dir=True: this file is explicitly
+    # described (see this module's docstring) as surviving app restarts —
+    # atomic_write_bytes's os.replace() alone prevents a TORN write, but
+    # without also fsyncing the containing directory, a power loss right
+    # after a successful replace can still lose or roll back the directory
+    # entry pointing at the new inode on POSIX. Best-effort/no-op on
+    # Windows (see fsio._fsync_dir).
+    atomic_write_bytes(registry_path(), data, fsync_dir=True)
+
+
+class RegistryPreservationError(Exception):
+    """Raised when a corrupt/unsupported-version registry could not be
+    backed up before a mutation would otherwise have overwritten it. The
+    mutation MUST be aborted in this case — proceeding would destroy the
+    only copy of whatever the original file contained, silently. The
+    original registry file itself is untouched by this failure (nothing has
+    been written yet), so the caller can retry later once the underlying
+    problem (e.g. a full disk, permissions) is fixed."""
+
+
+def _preserve_unreadable(read: ReadResult) -> None:
+    """Back up a corrupt/unsupported-version registry under a timestamped
+    name before a mutation would otherwise overwrite it with a fresh one.
+    Quarantined FILES are never touched by this — only the registry JSON.
+
+    Fails CLOSED: if the backup itself cannot be written, this raises
+    `RegistryPreservationError` instead of letting the caller proceed to
+    overwrite the original — silently destroying an unreadable registry is
+    strictly worse than refusing the mutation, since backup failures are
+    usually transient (disk full, permissions) and retryable, while an
+    overwritten original is not recoverable."""
+    if read.raw_bytes is None:
+        return
+    ts = _utcnow_iso().replace(":", "").replace("-", "")
+    backup = registry_path().with_name(f"{registry_path().name}.{read.status}-{ts}.bak")
+    # [P1, fourth audit finding #1] Use the original bytes directly — NOT a
+    # decode-then-re-encode round trip. That round trip only works when the
+    # original bytes happened to be valid UTF-8 in the first place; for a
+    # registry that's corrupt precisely BECAUSE it's not valid UTF-8, a
+    # decode would already have failed before ever reaching here. Preserving
+    # `raw_bytes` verbatim is what makes it possible to back up ANY corrupt
+    # content, not just the subset that also happens to decode.
+    payload = read.raw_bytes
+    try:
+        # [P2, third audit finding #9] Use the same atomic-write primitive
+        # the registry itself uses (temp file -> fsync -> os.replace ->
+        # fsync the directory), not a plain Path.write_text() — a crash or
+        # disk-full event mid-write must not leave a partial/torn backup
+        # standing in for "the original was safely preserved".
+        atomic_write_bytes(backup, payload, fsync_dir=True)
+        # And don't just trust that the write "succeeded" — read it back
+        # and compare byte-for-byte before treating the original as safely
+        # backed up. Belt-and-suspenders: atomic_write_bytes already fsyncs
+        # before replace, but this is the one place in the whole module
+        # where "the backup exists" is treated as a green light to
+        # overwrite the only other copy of this data, so it's worth the
+        # extra read.
+        if backup.read_bytes() != payload:
+            raise OSError(f"backup at {backup} did not read back identical to what was written")
+    except OSError as e:
+        log.error(
+            f"Retained-staging registry was {read.status} AND the backup copy could "
+            f"not be written and verified ({e}); refusing to proceed with this "
+            f"mutation so the original content at {registry_path()} is not lost. "
+            f"Quarantined files under {quarantine_dir()} are untouched. Try again "
+            "once the problem preventing the backup write is resolved."
+        )
+        raise RegistryPreservationError(str(e)) from e
+    log.warning(
+        f"Retained-staging registry was {read.status}; preserved and verified the original at "
+        f"{backup} before writing a fresh one. Any quarantined files under "
+        f"{quarantine_dir()} are untouched and can be recovered manually."
+    )
+
+
+class RegistryLockTimeout(Exception):
+    """Raised when a registry mutation could not acquire the transaction
+    lock in time. The caller's in-memory state (e.g. task.retained_staging
+    for the CURRENT run) is unaffected either way — this only means the
+    NEXT restart won't know about this particular change."""
+
+
+class RegistryReadError(Exception):
+    """[P1, third audit finding #1] Raised when a registry mutation could
+    not even READ the registry file (as opposed to reading it and finding
+    invalid content, which is 'corrupt' and handled by
+    `RegistryPreservationError`/`_preserve_unreadable`). There is no
+    `raw_bytes` to back up in this case, and critically no way to know
+    whether the file that couldn't be read a moment ago still has the same
+    content now — proceeding to write a fresh empty registry here would
+    risk silently discarding whatever is actually on disk. The mutation is
+    aborted outright; nothing is written."""
+
+
+def _transaction(timeout: Optional[float] = None):
+    """Context manager yielding a mutable `{"entries": [...]}` box. On clean
+    exit (no exception), the box's entries are atomically written back under
+    the same lock that guarded the read — the whole read -> mutate -> write
+    sequence is one transaction, not two independently-locked calls.
+
+    `timeout` defaults to the module-level `DEFAULT_LOCK_TIMEOUT`, read
+    dynamically (not baked in as a def-time default) so tests can override it
+    via `monkeypatch.setattr(reg, "DEFAULT_LOCK_TIMEOUT", ...)`."""
+    from contextlib import contextmanager
+
+    if timeout is None:
+        timeout = DEFAULT_LOCK_TIMEOUT
+
+    @contextmanager
+    def _cm():
+        lock = FileLock(str(_lock_path()), timeout=timeout)
+        try:
+            with lock:
+                result = read_entries()
+                if result.status == "unreadable":
+                    log.error(
+                        f"Refusing to mutate the retained-staging registry at "
+                        f"{registry_path()}: it could not be read (see the "
+                        "preceding warning for the underlying I/O error), so there "
+                        "is nothing to safely back up and no way to know this "
+                        "mutation wouldn't silently discard whatever is actually "
+                        "on disk. Nothing was written. Try again once the "
+                        "underlying problem (permissions, a sharing lock, a "
+                        "network-share hiccup) is resolved."
+                    )
+                    raise RegistryReadError(
+                        f"could not read {registry_path()} before mutating it"
+                    )
+                if result.status in ("corrupt", "unsupported_version"):
+                    _preserve_unreadable(result)
+                    entries = []
+                else:
+                    entries = list(result.entries)
+                box = {"entries": entries}
+                yield box
+                _write_entries(box["entries"])
+        except FileLockTimeout as e:
+            log.warning(
+                f"Could not acquire the retained-staging registry lock within "
+                f"{timeout}s ({e}); skipping this registry update (best-effort — "
+                "the file itself, if any, is untouched)."
+            )
+            raise RegistryLockTimeout(str(e)) from e
+
+    return _cm()
+
+
+def recovery_operation_lock(timeout: Optional[float] = None) -> FileLock:
+    """Public: a process-wide lock for callers (namely `tiddl recover`) that
+    need to serialize an entire multi-step recovery sequence — verify a
+    candidate, publish or clean up the file, THEN mutate the registry — not
+    just the registry's own internal read-mutate-write.
+
+    [P2, finding #12] `_transaction()` alone only ever locks the JSON
+    read/write itself. Two concurrent `tiddl recover` processes racing on
+    the same (or even a different) entry could previously each decide,
+    independently, that it was safe to act — real file I/O in between was
+    never covered by any lock, so e.g. two processes could both publish the
+    same source, or one could publish while another purges the same entry
+    out from under it. Holding THIS lock for the full verify -> publish/
+    cleanup -> registry-mutation sequence serializes all recovery activity
+    across processes.
+
+    Deliberately a DIFFERENT lock file from `_lock_path()` (see
+    `_recovery_lock_path`) — nesting a second `FileLock` on the same path
+    while the first is held would just time itself out (`filelock` is not
+    reentrant across separate instances), and this lock is held for the
+    entire recovery sequence specifically so it can safely call
+    `add_entry`/`update_entry`/`remove_entry` (each of which briefly takes
+    the OTHER lock via `_transaction()`) from within its `with` block."""
+    if timeout is None:
+        timeout = DEFAULT_LOCK_TIMEOUT
+    return FileLock(str(_recovery_lock_path()), timeout=timeout)
+
+
+def add_entry(entry: RetainedEntry) -> RetainedEntry:
+    with _transaction() as box:
+        box["entries"].append(entry)
+    return entry
+
+
+def update_entry(entry_id: str, **changes) -> Optional[RetainedEntry]:
+    updated = None
+    with _transaction() as box:
+        for i, e in enumerate(box["entries"]):
+            if e.id == entry_id:
+                updated = replace(e, **changes)
+                box["entries"][i] = updated
+                break
+    return updated
+
+
+def remove_entry(entry_id: str) -> bool:
+    removed = False
+    with _transaction() as box:
+        before = len(box["entries"])
+        box["entries"] = [e for e in box["entries"] if e.id != entry_id]
+        removed = len(box["entries"]) != before
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Quarantine: move a retained file out of the OS temp directory.
+# ---------------------------------------------------------------------------
+
+
+def quarantine_file(staging: Path, *, output_suffix: str, entry_id: str) -> tuple[Path, bool]:
+    """Move `staging` into the quarantine dir under a name derived from
+    `entry_id` (NOT staging's own `.part.<random>` suffix, which has nothing
+    to do with the media type) so the registry entry and the file on disk
+    can always be matched back up — see `find_orphaned_quarantine_files`.
+
+    Returns `(final_path, quarantined)`. On any failure this degrades to
+    `(staging, False)` — the caller still has a usable path, just not one
+    protected from OS temp cleanup.
+
+    Cross-filesystem case: `staging` is the ONLY verified copy of this file
+    at this point, so it is never deleted until the quarantine copy has been
+    independently verified byte-for-byte (exact size + sha256) against it —
+    a copy is not trusted just because `shutil.copy2` didn't raise. This
+    mirrors the same discipline `publish_verified_file` already applies to
+    the destination copy (see PR #12) — an earlier version of this function
+    skipped that step and could silently promote a corrupt copy to
+    "quarantined" while deleting the only good bytes."""
+    qdir = quarantine_dir()
+    try:
+        qdir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        log.warning(
+            f"Could not create the retained-staging quarantine dir at {qdir} ({e}); "
+            f"leaving the retained file at its original location {staging}."
+        )
+        return staging, False
+
+    target = qdir / f"{entry_id}{output_suffix}"
+
+    if _same_volume(staging, qdir):
+        # Atomic rename: no bytes are copied, so there is nothing to verify —
+        # `target` is byte-identical to `staging` by construction.
+        try:
+            os.replace(staging, target)
+            # [P1, third audit finding #3] fsync the quarantine directory
+            # itself so the new directory entry survives a power loss —
+            # os.replace() alone is atomic against torn content but not
+            # against the directory entry itself being lost/rolled back.
+            _fsync_dir(qdir)
+            return target, True
+        except OSError as e:
+            log.warning(
+                f"Could not move the retained file at {staging} into quarantine ({e}); "
+                "leaving it at its original location."
+            )
+            return staging, False
+
+    # Cross filesystem: copy to a quarantine-side temp, verify it against the
+    # SOURCE's own exact size/hash, and only then atomically publish it as
+    # `target` — and only THEN consider deleting the source.
+    dest_tmp = target.with_name(target.name + f".part.{uuid4().hex[:8]}")
+    try:
+        source_size, source_hash = _hash_and_size(staging)
+        shutil.copy2(str(staging), str(dest_tmp))
+        _fsync_path(dest_tmp)
+        dest_size, dest_hash = _hash_and_size(dest_tmp)
+    except OSError as e:
+        log.warning(
+            f"Could not copy the retained file at {staging} into quarantine ({e}); "
+            "leaving it at its original location."
+        )
+        _safe_unlink_warn(dest_tmp, "cleanup after a failed quarantine copy")
+        return staging, False
+
+    if dest_size != source_size or dest_hash != source_hash:
+        log.warning(
+            f"Quarantine copy of {staging} did not verify (expected {source_size}b/"
+            f"{source_hash}, got {dest_size}b/{dest_hash}); leaving the original in "
+            "place — it was NOT deleted."
+        )
+        _safe_unlink_warn(dest_tmp, "cleanup after a failed quarantine copy verification")
+        return staging, False
+
+    try:
+        os.replace(dest_tmp, target)
+        # [P1, third audit finding #3] Same reasoning as the same-volume
+        # branch above: fsync the quarantine directory so this publish's
+        # directory entry survives a power loss, not just the file's bytes.
+        _fsync_dir(qdir)
+    except OSError as e:
+        log.warning(
+            f"Verified quarantine copy of {staging} could not be published to {target} "
+            f"({e}); leaving the original in place — it was NOT deleted."
+        )
+        _safe_unlink_warn(dest_tmp, "cleanup after a failed quarantine publish")
+        return staging, False
+
+    # Only now — `target` is a byte-verified copy of `staging` — is it safe
+    # to consider the source redundant. A failure to delete it is harmless
+    # (the quarantined copy is authoritative) but must not go unreported.
+    cleanup_ctx = "cleanup of original staging after a VERIFIED quarantine copy"
+    if not _safe_unlink_warn(staging, cleanup_ctx):
+        log.warning(
+            f"Quarantined copy of '{staging.name}' is verified and safe to use at "
+            f"{target}, but the original at {staging} could not be deleted; a "
+            "redundant copy remains there (harmless)."
+        )
+    return target, True
+
+
+def find_orphaned_quarantine_files() -> list:
+    """Files physically present in the quarantine dir with no matching
+    registry entry — e.g. a crash between `quarantine_file` and the registry
+    write that was supposed to record it, or between a successful recovery
+    delete and its `remove_entry` call. Never auto-deleted; only surfaced."""
+    qdir = quarantine_dir()
+    if not qdir.is_dir():
+        return []
+    known = {Path(e.staging_path).name for e in read_entries().entries}
+    try:
+        return sorted(
+            p for p in qdir.iterdir()
+            if p.is_file() and p.name not in known and not p.name.endswith(".lock")
+        )
+    except OSError:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Hashing (observed-at-retention-time facts, independent of any upstream
+# `expected_hash`, which may be absent).
+# ---------------------------------------------------------------------------
+
+
+def _hash_and_size(path: Path, algorithm: str = HASH_ALGORITHM) -> tuple[int, str]:
+    h = hashlib.new(algorithm)
+    size = 0
+    with open(path, "rb") as f:
+        while True:
+            chunk = f.read(1024 * 1024)
+            if not chunk:
+                break
+            size += len(chunk)
+            h.update(chunk)
+    return size, h.hexdigest()
+
+
+async def hash_and_size_async(path: Path, algorithm: str = HASH_ALGORITHM) -> tuple[int, str]:
+    """Public: also used by `tiddl recover` (`cli/commands/recover.py`) to
+    re-verify a candidate against an entry's observed size/hash without
+    reaching into this module's private helpers. `algorithm` should be the
+    SPECIFIC entry's own `hash_algorithm` when re-verifying an existing
+    entry — the module default is only correct for brand-new entries being
+    retained for the first time under the current build's algorithm."""
+    return await asyncio.to_thread(_hash_and_size, path, algorithm)
+
+
+def delete_quarantined_file(path: Path, context: str) -> bool:
+    """Public wrapper around the shared best-effort-delete-and-warn helper,
+    so callers outside this module (namely `tiddl recover`) don't need to
+    reach into `tiddl.core.utils.fsio` directly."""
+    return _safe_unlink_warn(path, context)
+
+
+# ---------------------------------------------------------------------------
+# Registering a newly-retained file (called from Downloader._download_with_retry).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RegisterResult:
+    #: Where the file ACTUALLY is right now, regardless of whether registry
+    #: persistence succeeded — the caller (Downloader) must always point
+    #: `task.retained_staging` at this, never at the pre-quarantine path.
+    actual_path: Path
+    #: The persisted registry entry, or None if bookkeeping failed (the file
+    #: itself is still fine at `actual_path` — this only affects whether a
+    #: restart will know about it).
+    entry: Optional[RetainedEntry]
+
+    @property
+    def persisted(self) -> bool:
+        return self.entry is not None
+
+
+async def register_retained_file(
+    retained: Path,
+    output_path: Path,
+    reason: RetainReason,
+    track_title: Optional[str] = None,
+) -> RegisterResult:
+    """Quarantine `retained` and record it in the registry. Best-effort end
+    to end: a registry-persistence failure is logged and leaves `entry=None`
+    rather than raising — persistence is a breadcrumb for the NEXT restart,
+    it must never turn an already-decided publish outcome (success or
+    failure) into an exception for the CURRENT run. `actual_path` on the
+    returned result is ALWAYS the file's real current location — even when
+    persistence fails after the file has already been (possibly)
+    quarantined — so the caller's own in-process pointer never goes stale."""
+    entry_id = uuid4().hex
+    suffix = output_path.suffix or Path(retained).suffix
+    retained = Path(retained)
+
+    try:
+        final_path, quarantined = await asyncio.to_thread(
+            quarantine_file, retained, output_suffix=suffix, entry_id=entry_id
+        )
+    except OSError as e:
+        log.warning(
+            f"Unexpected failure quarantining the retained file for "
+            f"'{track_title}' ({e}); it remains at its original location {retained}."
+        )
+        return RegisterResult(actual_path=retained, entry=None)
+
+    try:
+        size, digest = await hash_and_size_async(final_path)
+        entry = RetainedEntry(
+            id=entry_id,
+            reason=reason,
+            staging_path=str(final_path),
+            output_path=str(output_path),
+            observed_size=size,
+            observed_hash=digest,
+            track_title=track_title,
+            quarantined=quarantined,
+        )
+        persisted_entry = await asyncio.to_thread(add_entry, entry)
+        return RegisterResult(actual_path=final_path, entry=persisted_entry)
+    except (OSError, RegistryLockTimeout, RegistryPreservationError, RegistryReadError) as e:
+        log.warning(
+            f"Could not persist retained-file recovery bookkeeping for "
+            f"'{track_title}' ({e}); the file itself is unaffected and is "
+            f"currently at {final_path} — it will not be listed by `tiddl "
+            "recover` after a restart unless this succeeds on a later attempt."
+        )
+        return RegisterResult(actual_path=final_path, entry=None)
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation.
+# ---------------------------------------------------------------------------
+
+
+async def _verify_observed(path: Path, entry: RetainedEntry) -> tuple[bool, Optional[str]]:
+    if not path.exists():
+        return False, "missing"
+    size, digest = await hash_and_size_async(path, entry.hash_algorithm)
+    if size != entry.observed_size:
+        return False, f"size mismatch: recorded {entry.observed_size}, now {size}"
+    if digest != entry.observed_hash:
+        return False, f"{entry.hash_algorithm} mismatch: content has changed since it was retained"
+    return True, None
+
+
+async def reconcile() -> ReconcileReport:
+    """Deep check: does each entry's file still exist, and does it still
+    match what was observed when it was retained? Involves hashing every
+    retained file — by design this is ONLY called explicitly (`tiddl
+    recover`), never from ordinary application startup.
+
+    A single bad entry (unreadable file, permission error, whatever) must
+    never abort the whole reconciliation — it is reported as `corrupt` and
+    the rest of the entries still get checked.
+    """
+    result = read_entries()
+    out = []
+    for e in result.entries:
+        try:
+            out.append(await _reconcile_one(e))
+        except OSError as exc:
+            log.warning(f"Error reconciling retained entry {e.id}: {exc}")
+            out.append(ReconcileEntry(e, "corrupt", f"error while reconciling: {exc}"))
+    return ReconcileReport(
+        status=result.status, entries=out, orphans=find_orphaned_quarantine_files()
+    )
+
+
+async def _reconcile_one(e: RetainedEntry) -> ReconcileEntry:
+    p = Path(e.staging_path)
+    if p.exists():
+        ok, detail = await _verify_observed(p, e)
+        return ReconcileEntry(e, "ok" if ok else "corrupt", detail)
+
+    # The retained copy is gone. This is normally a real loss — but it is
+    # also exactly what happens when a PRIOR recovery attempt actually
+    # succeeded (published the destination and/or deleted the local copy)
+    # and then crashed or was killed before it could remove the registry
+    # entry. Telling those two situations apart matters: naively reporting
+    # "gone" here would make a fully-recovered file look unrecoverable
+    # forever (there is no source left to re-publish from). So: if the
+    # destination independently matches the size+hash observed at retention
+    # time, this is stale bookkeeping from an already-converged recovery,
+    # not data loss — surface it distinctly so it can be safely dropped
+    # without requiring any (nonexistent) source bytes or further I/O.
+    dest = Path(e.output_path)
+    if dest.exists():
+        try:
+            dsize, ddigest = await hash_and_size_async(dest, e.hash_algorithm)
+        except OSError as exc:
+            log.warning(f"Could not re-verify destination {dest} for entry {e.id}: {exc}")
+            dsize, ddigest = None, None
+        if dsize == e.observed_size and ddigest == e.observed_hash:
+            return ReconcileEntry(
+                e, "already_published",
+                "the retained copy is gone, but the destination independently "
+                "matches the content observed when this entry was retained "
+                "(a prior recovery attempt already succeeded before it could "
+                "update this registry) — safe to drop this stale entry",
+            )
+    return ReconcileEntry(e, "gone", "the retained file no longer exists on disk")
+
+
+def startup_status() -> StartupStatus:
+    """Lightweight: registry status + entry count only. No hashing, no
+    filesystem access beyond reading the registry JSON itself, no
+    destination I/O. Cheap and safe to call from the app's root callback
+    for ordinary subcommand invocations (`auth`, `recover`, non-download
+    commands).
+
+    [P2, third audit finding #8] NOT called for `--help`/`--version` —
+    those are eager Click/Typer options that exit during parameter
+    processing, before the root callback's body (where this is invoked
+    from, in `cli/app.py`) ever runs. Verified via a `CliRunner` check
+    (`tests/test_app_startup_notice.py`), not assumed — an earlier version
+    of this docstring claimed the opposite."""
+    result = read_entries()
+    return StartupStatus(status=result.status, count=len(result.entries))


### PR DESCRIPTION
# Persistent recovery of `retained_staging` across app restarts

## Summary / Resumen

**EN:** Persists verified staging files that could not be published or cleaned up, so they survive application restarts and can be reviewed, republished, or purged offline without re-downloading. Downloads and recovery now share the same atomic filesystem and verified-publish primitives.

**ES:** Conserva los archivos de staging verificados que no pudieron publicarse o limpiarse, para que sobrevivan a reinicios de la aplicación y puedan revisarse, republicarse o purgarse offline sin volver a descargarlos. Las descargas y la recuperación ahora comparten las mismas primitivas atómicas de filesystem y publicación verificada.

## Main changes / Cambios principales

### EN

- Moves retained files from the OS temporary directory into the durable per-user application data directory.
- Stores recovery metadata in a versioned JSON registry protected by `FileLock` and atomic write/replace operations.
- Adds the offline `tiddl recover` workflow:
  - list and reconcile retained entries;
  - `--publish <id>` for one entry;
  - `--all --yes` for batch recovery;
  - `--purge <id>` for acknowledged gone/corrupt entries.
- Adds lightweight startup notices when retained files or registry problems require attention.
- Extracts shared filesystem helpers and `publish_verified_file()`, used by both normal downloads and restart recovery.
- Reuses the shared atomic writer for authentication data while preserving secure POSIX permissions.
- Handles invalid UTF-8, invalid JSON/schema, unsupported registry versions, unreadable registries, concurrent operations, interrupted cleanup, and cross-filesystem quarantine without silently losing the retained file.
- Returns a non-zero CLI status when recovery publishes a destination but still leaves local cleanup pending.

### ES

- Mueve los archivos retenidos fuera del directorio temporal del sistema hacia el directorio de datos durable por usuario.
- Guarda los metadatos de recuperación en un registro JSON versionado, protegido con `FileLock` y escrituras/reemplazos atómicos.
- Añade el flujo offline `tiddl recover`:
  - listar y reconciliar entradas retenidas;
  - `--publish <id>` para una entrada;
  - `--all --yes` para recuperación por lote;
  - `--purge <id>` para entradas desaparecidas/corruptas reconocidas.
- Añade avisos ligeros al iniciar cuando existen archivos retenidos o problemas con el registro.
- Extrae helpers compartidos de filesystem y `publish_verified_file()`, usados tanto por descargas normales como por recuperación tras reinicio.
- Reutiliza la escritura atómica compartida para los datos de autenticación, conservando permisos POSIX seguros.
- Controla UTF-8 inválido, JSON/esquema inválido, versiones desconocidas, registros ilegibles, concurrencia, limpieza interrumpida y cuarentena cross-filesystem sin perder silenciosamente el archivo retenido.
- Devuelve un estado CLI distinto de cero cuando el destino fue publicado pero todavía queda limpieza local pendiente.

## Safety contract / Contrato de seguridad

1. Retained content is hashed and recorded before persistence.
2. Registry mutations run under a lock and publish complete files through atomic replacement.
3. Corrupt or unsupported registries are preserved byte-for-byte before replacement; unreadable registries fail closed and are not overwritten.
4. Cross-filesystem quarantine and publication use copy → verify → atomic replace → delete source.
5. A valid existing destination is not overwritten by a failed recovery attempt.
6. Recovery refuses to create a missing destination parent automatically.
7. Cleanup failures remain registered as `cleanup_pending` and produce a non-zero command result.

## Scope / Alcance

- Commit: `767584b`
- Files changed: **15**
- Diff: **+3832 / −213**
- Runtime dependencies: unchanged
- `requirements.lock`: unchanged

## Verification / Verificación

### Independent local verification

- Windows full suite: **169 passed, 2 skipped**
- Linux full suite: **171 passed**
- Focused Windows recovery/publish/startup suite: **77 passed**
- Scoped Ruff checks: clean
- Python 3.10 and 3.13 compilation: clean

### GitHub Actions

CI run: https://github.com/np3ir/tiddl-elvigilante/actions/runs/32068296162

**13/13 jobs passed:**

- Tests on Ubuntu and Windows × Python 3.10, 3.11, 3.12, and 3.13
- Locked installation and outside-checkout smoke test on Ubuntu and Windows × Python 3.10 and 3.13
- Lockfile drift check

## Declared limitations / Limitaciones declaradas

### EN

- An existing destination directory does not prove that the intended NAS/removable volume is mounted. A future destination-root/volume-identity policy should cover both live downloads and offline recovery.
- Directory-entry `fsync` is best-effort and is a documented no-op on Windows; content-level atomic replacement still applies.
- A crash during a destination-side copy may leave an orphan `.part` file; an age-based sweeper remains follow-up work.
- Eager `--help`/`--version` processing may exit before the root startup notice runs.

### ES

- Que exista el directorio de destino no demuestra que el NAS/volumen removible esperado esté montado. Una política futura de identidad del root/volumen deberá cubrir descargas normales y recuperación offline.
- El `fsync` de la entrada de directorio es best-effort y no opera en Windows; el reemplazo atómico del contenido sí se mantiene.
- Un cierre durante la copia al destino puede dejar un temporal `.part` huérfano; el sweeper por antigüedad queda como trabajo posterior.
- El procesamiento anticipado de `--help`/`--version` puede terminar antes de ejecutar el aviso de inicio.

## Review notes / Notas de revisión

- The implementation completed four audit rounds, including independent Windows verification.
- No unresolved inline review threads remain.
- Sourcery did not perform a semantic review because the diff exceeded its 150,000-character review limit; this is a tooling limit, not a passing semantic review.

## Merge status / Estado de merge

The branch is mergeable and the full CI matrix is green. No merge is performed by this description update.

La rama es mergeable y toda la matriz de CI está verde. Esta actualización de descripción no realiza el merge.
