### PR TITLE
feat: protect destination writes with volume identity / proteger el destino

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ### ✨ Added
 
+- **Destination-volume identity** (`tiddl/core/utils/destination_anchor.py`, `tiddl destination trust/status/forget`, `tiddl recover --bind-root`)
+  — Opt-in guard (`[download] destination_identity = "strict"`, default `"off"`) against
+  writing to the wrong place when a NAS/USB/network destination is unmounted and the
+  path silently falls back to a local folder that happens to share the same name.
+  `tiddl destination trust <path>` writes a small marker file at the real destination
+  root plus a per-machine local record; every one of the nine places a download or
+  recovery writes to disk (track/video directory creation, media publication, `.lrc`,
+  track/video metadata, M3U, cover, mtime update) refuses in `strict` mode unless the
+  configured root's marker and local record still agree. A refusal never loses data —
+  the verified local copy is retained (`tiddl recover` picks it up once the real
+  destination is trusted again) and the command exits non-zero. `"off"` performs zero
+  extra filesystem reads; existing installs are unaffected until this is turned on.
+
 - **`--embed-lyrics` / `--save-lyrics` per-run overrides** (`tiddl/cli/commands/download/__init__.py`)
   — Lyrics options lived only in `[metadata]` config. The new paired flags
   (`--save-lyrics/--no-save-lyrics`, `--embed-lyrics/--no-embed-lyrics`) override the

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ At scale — tens of thousands of albums — this means your library reflects th
 - 📝 **Complete Metadata** - Artist, album, cover, lyrics, credits
 - 🌍 **Unicode Support** - CJK, Arabic, Vietnamese, Devanagari
 - 💾 **File Integrity** - Hash verification & corruption detection
+- 🔒 **Destination-Volume Identity** (opt-in) - Refuse to write if a configured NAS/USB destination is unmounted and silently falls back to a same-named local folder — `tiddl destination trust <path>`, then `[download] destination_identity = "strict"`
 - ⚡ **Async Downloads** - Concurrent multi-threaded downloads
 - 🔍 **Smart Quality** - Automatic fallback for unavailable qualities
 - 📦 **M3U8 Export** - Create playlists for media players

--- a/config.example.toml
+++ b/config.example.toml
@@ -136,6 +136,16 @@ track_delay = 3.0              # default: 3.0
 # Max tracks per run. 0 = unlimited.
 max_tracks_per_session = 0     # default: 0
 
+# Destination-volume identity: refuse to write if download_path/
+# video_download_path doesn't resolve to the destination you actually meant
+# (e.g. an unmounted NAS/USB drive silently falling back to a local folder
+# with the same path). "off" writes exactly as before, no extra checks.
+# "strict" requires the root to have been explicitly trusted first — see
+# `tiddl destination trust/status/forget --help`. A refusal never loses
+# data: the verified local copy is retained (`tiddl recover` picks it up
+# once the real destination is trusted) and the command exits non-zero.
+destination_identity = "off"   # default: "off"  — options: "off", "strict"
+
 
 # =============================================================================
 # [m3u] — generate .m3u playlists

--- a/tests/test_destination_anchor.py
+++ b/tests/test_destination_anchor.py
@@ -1,0 +1,429 @@
+"""Coverage for `tiddl.core.utils.destination_anchor` — see
+PROPOSAL_destination_volume_identity_v2_1.md through v2_4.md (kept
+local/untracked) for the design each test pins. This module has no
+dependency on Downloader/TIDAL, matching `retained_registry.py`'s own
+"works fully offline" goal."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import pytest
+
+import tiddl.core.utils.destination_anchor as da
+from tiddl.core.utils.destination_anchor import (
+    AnchorAlreadyExists,
+    DestinationNotTrusted,
+    IdentityFailureTracker,
+    LocalStateLockTimeout,
+    LocalStatePreservationError,
+    LocalStateReadError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_app_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(da, "APP_PATH", tmp_path / "_app")
+    (tmp_path / "_app").mkdir(parents=True, exist_ok=True)
+    return tmp_path / "_app"
+
+
+@pytest.fixture
+def root(tmp_path):
+    r = tmp_path / "dest_root"
+    r.mkdir()
+    return r
+
+
+# ---------------------------------------------------------------------------
+# off mode — disabled reason, zero anchor I/O (v2.4 §1)
+# ---------------------------------------------------------------------------
+
+
+def test_off_mode_returns_disabled_without_any_anchor_io(root, monkeypatch, tmp_path):
+    def _boom(*a, **k):
+        raise AssertionError("off mode must not read local state or the marker")
+
+    monkeypatch.setattr(da, "read_state", _boom)
+    monkeypatch.setattr(da, "read_marker", _boom)
+
+    check = da.check_write_allowed(root, root / "x.flac", mode="off")
+    assert check.allowed is True
+    assert check.reason == "disabled"
+
+
+def test_off_mode_never_reported_as_trusted():
+    # Regression for the v2.3 audit's finding: off-mode must never be
+    # described with the same reason as an actually-verified trust.
+    assert "disabled" in da.AnchorCheckReason.__args__
+    assert "trusted" in da.AnchorCheckReason.__args__
+    assert "disabled" != "trusted"
+
+
+# ---------------------------------------------------------------------------
+# Containment (v2.1 §8)
+# ---------------------------------------------------------------------------
+
+
+def test_output_outside_root_is_not_contained(root, tmp_path):
+    outside = tmp_path / "elsewhere" / "x.flac"
+    check = da.check_write_allowed(root, outside, mode="strict")
+    assert check.allowed is False
+    assert check.reason == "not_contained"
+
+
+def test_str_startswith_would_wrongly_allow_a_sibling_with_shared_prefix(tmp_path):
+    # root "music" vs a sibling "music-backup" — str.startswith would treat
+    # the sibling as contained; commonpath must not.
+    music = tmp_path / "music"
+    music.mkdir()
+    sibling = tmp_path / "music-backup" / "x.flac"
+    assert da.is_contained(music, sibling) is False
+
+
+# ---------------------------------------------------------------------------
+# Marker file (v2.1 §3, v2.2 §6)
+# ---------------------------------------------------------------------------
+
+
+def test_marker_absent_is_reported_distinctly(root):
+    status, anchor_id, detail = da.read_marker(root)
+    assert status == "absent"
+    assert anchor_id is None
+
+
+def test_marker_oversized_is_invalid_not_truncated_and_parsed(root):
+    (root / da.MARKER_FILENAME).write_bytes(b"x" * (da.MARKER_MAX_BYTES + 1))
+    status, anchor_id, detail = da.read_marker(root)
+    assert status == "invalid"
+    assert anchor_id is None
+
+
+def test_marker_wrong_format_is_invalid(root):
+    payload = {"format": "nope", "version": 1, "anchor_id": "x"}
+    (root / da.MARKER_FILENAME).write_text(json.dumps(payload))
+    status, _, _ = da.read_marker(root)
+    assert status == "invalid"
+
+
+def test_marker_missing_anchor_id_is_invalid(root):
+    (root / da.MARKER_FILENAME).write_text(json.dumps({"format": da.MARKER_FORMAT, "version": 1}))
+    status, _, _ = da.read_marker(root)
+    assert status == "invalid"
+
+
+def test_marker_invalid_utf8_is_invalid_not_unreadable(root):
+    (root / da.MARKER_FILENAME).write_bytes(b"\xff\xfe\x00\x01")
+    status, _, _ = da.read_marker(root)
+    assert status == "invalid"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_marker_symlink_is_unreadable_never_followed(root, tmp_path):
+    real_target = tmp_path / "real_marker.json"
+    payload = {"format": da.MARKER_FORMAT, "version": 1, "anchor_id": "deadbeef"}
+    real_target.write_text(json.dumps(payload))
+    (root / da.MARKER_FILENAME).symlink_to(real_target)
+    status, anchor_id, _ = da.read_marker(root)
+    assert status == "unreadable"
+    assert anchor_id is None
+
+
+def test_marker_unreadable_due_to_permission_error_is_structured_not_raised(root, monkeypatch):
+    from pathlib import Path
+
+    def _boom(self):
+        raise PermissionError("simulated permission error")
+
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+    status, anchor_id, detail = da.read_marker(root)
+    assert status == "unreadable"
+    assert anchor_id is None
+    assert detail is not None
+
+
+# ---------------------------------------------------------------------------
+# Trust lifecycle (v2.1 §2)
+# ---------------------------------------------------------------------------
+
+
+def test_establish_anchor_creates_marker_and_local_record(root):
+    anchor_id = da.establish_anchor(root)
+    status, marker_id, _ = da.read_marker(root)
+    assert status == "trusted"
+    assert marker_id == anchor_id
+
+    state = da.read_state()
+    assert state.status == "valid"
+    record = da.find_record(state.records, da.root_key(root))
+    assert record is not None
+    assert record.anchor_id == anchor_id
+
+
+def test_establish_anchor_refuses_to_overwrite_existing_marker(root):
+    da.establish_anchor(root)
+    with pytest.raises(AnchorAlreadyExists):
+        da.establish_anchor(root)
+
+
+def test_establish_anchor_leaves_marker_intact_if_local_state_write_fails(root, monkeypatch):
+    # PROPOSAL v2.1 §13's partial-failure rule: the marker is the
+    # authoritative artifact and must never be deleted to "undo" a failed
+    # local-state write.
+    def _boom(*a, **k):
+        raise LocalStateLockTimeout("simulated lock timeout")
+
+    monkeypatch.setattr(da, "_record_root_locally", _boom)
+    with pytest.raises(LocalStateLockTimeout):
+        da.establish_anchor(root)
+    status, anchor_id, _ = da.read_marker(root)
+    assert status == "trusted"
+    assert anchor_id is not None
+
+
+def test_adopt_existing_records_locally_without_touching_marker(root):
+    anchor_id = da.establish_anchor(root)
+    marker_bytes_before = (root / da.MARKER_FILENAME).read_bytes()
+
+    # Simulate a second machine: clear local state, then adopt.
+    da.forget_anchor(root)
+    adopted_id = da.adopt_anchor(root)
+    assert adopted_id == anchor_id
+    assert (root / da.MARKER_FILENAME).read_bytes() == marker_bytes_before
+
+
+def test_adopt_existing_refuses_when_no_marker_present(root):
+    with pytest.raises(ValueError):
+        da.adopt_anchor(root)
+
+
+def test_forget_clears_local_state_only(root):
+    da.establish_anchor(root)
+    assert da.forget_anchor(root) is True
+    state = da.read_state()
+    assert da.find_record(state.records, da.root_key(root)) is None
+    # Marker itself is untouched.
+    status, _, _ = da.read_marker(root)
+    assert status == "trusted"
+
+
+def test_forget_unknown_root_is_a_no_op(root):
+    assert da.forget_anchor(root) is False
+
+
+# ---------------------------------------------------------------------------
+# check_write_allowed — the guard (v2.1 §7, v2.2 §2, v2.4 §1/§5)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_root_refuses(root):
+    check = da.check_write_allowed(root, root / "x.flac", mode="strict")
+    assert check.allowed is False
+    assert check.reason == "unknown_root"
+
+
+def test_trusted_root_allows(root):
+    da.establish_anchor(root)
+    check = da.check_write_allowed(root, root / "sub" / "x.flac", mode="strict")
+    assert check.allowed is True
+    assert check.reason == "trusted"
+
+
+def test_missing_marker_after_trust_refuses(root):
+    da.establish_anchor(root)
+    (root / da.MARKER_FILENAME).unlink()
+    check = da.check_write_allowed(root, root / "x.flac", mode="strict")
+    assert check.allowed is False
+    assert check.reason == "marker_absent"
+
+
+def test_forget_and_re_trust_with_new_anchor_makes_old_expected_id_refuse(root):
+    # The triple-identity regression test PROPOSAL v2.1 §7 (originally the
+    # v2 audit) specifically asked for: an entry staged against an OLD
+    # anchor must not silently pass against a NEWLY re-trusted one.
+    old_id = da.establish_anchor(root)
+    da.forget_anchor(root)
+    (root / da.MARKER_FILENAME).unlink()
+    new_id = da.establish_anchor(root)
+    assert old_id != new_id
+
+    check = da.check_write_allowed(root, root / "x.flac", mode="strict", expected_anchor_id=old_id)
+    assert check.allowed is False
+    assert check.reason == "id_mismatch"
+
+    check2 = da.check_write_allowed(root, root / "x.flac", mode="strict", expected_anchor_id=new_id)
+    assert check2.allowed is True
+
+
+def test_local_state_unreadable_refuses_structured(root, monkeypatch):
+    da.establish_anchor(root)
+    result = da.LocalStateReadResult(status="unreadable", records=[])
+    monkeypatch.setattr(da, "read_state", lambda: result)
+    check = da.check_write_allowed(root, root / "x.flac", mode="strict")
+    assert check.allowed is False
+    assert check.reason == "local_state_unreadable"
+
+
+def test_local_state_corrupt_refuses_structured(root, monkeypatch):
+    da.establish_anchor(root)
+    result = da.LocalStateReadResult(status="corrupt", records=[])
+    monkeypatch.setattr(da, "read_state", lambda: result)
+    check = da.check_write_allowed(root, root / "x.flac", mode="strict")
+    assert check.allowed is False
+    assert check.reason == "local_state_invalid"
+
+
+def test_local_state_and_marker_read_failures_never_raise_from_check_write_allowed(
+    root, monkeypatch
+):
+    # v2.4 audit mandatory safeguard #1: expected filesystem failures during
+    # the check itself must become structured outcomes, never an escaping
+    # OSError a caller's own except Exception could swallow.
+    from pathlib import Path
+
+    def _boom(self):
+        raise PermissionError("simulated")
+
+    da.establish_anchor(root)
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+    check = da.check_write_allowed(root, root / "x.flac", mode="strict")
+    assert check.allowed is False
+    assert check.reason in ("local_state_unreadable", "marker_unreadable")
+
+
+def test_assert_write_allowed_raises_destination_not_trusted_with_structured_check(root):
+    with pytest.raises(DestinationNotTrusted) as exc_info:
+        da.assert_write_allowed(root, root / "x.flac", mode="strict")
+    assert exc_info.value.check.reason == "unknown_root"
+    assert exc_info.value.check.allowed is False
+
+
+def test_assert_write_allowed_returns_check_on_success(root):
+    da.establish_anchor(root)
+    check = da.assert_write_allowed(root, root / "x.flac", mode="strict")
+    assert check.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Local-state schema/fail-closed contract (v2.1 §4)
+# ---------------------------------------------------------------------------
+
+
+def test_state_missing_reads_as_missing_with_no_records():
+    result = da.read_state()
+    assert result.status == "missing"
+    assert result.records == []
+
+
+def test_state_invalid_utf8_is_corrupt_not_crashed():
+    da.anchor_state_path().parent.mkdir(parents=True, exist_ok=True)
+    da.anchor_state_path().write_bytes(b"\xff\xfe\x00\x01")
+    result = da.read_state()
+    assert result.status == "corrupt"
+    assert result.raw_bytes == b"\xff\xfe\x00\x01"
+
+
+def test_state_duplicate_root_key_is_corrupt(root):
+    da.establish_anchor(root)
+    raw = json.loads(da.anchor_state_path().read_bytes())
+    raw["roots"].append(dict(raw["roots"][0]))  # exact duplicate root_key
+    da.anchor_state_path().write_bytes(json.dumps(raw).encode("utf-8"))
+    result = da.read_state()
+    assert result.status == "corrupt"
+
+
+def test_state_unsupported_version_is_preserved_before_reset(root):
+    da.establish_anchor(root)
+    raw = json.loads(da.anchor_state_path().read_bytes())
+    raw["version"] = 99
+    da.anchor_state_path().write_bytes(json.dumps(raw).encode("utf-8"))
+
+    assert da.read_state().status == "unsupported_version"
+
+    other_root = root.parent / "other_root"
+    other_root.mkdir()
+    # A mutation on a different root — must preserve, not lose, the future-version content.
+    da.establish_anchor(other_root)
+
+    backups = list(da.anchor_state_path().parent.glob("*.unsupported_version-*.bak"))
+    assert len(backups) == 1
+    assert json.loads(backups[0].read_bytes())["version"] == 99
+
+
+def test_state_unreadable_refuses_mutation_outright(root, monkeypatch):
+    from pathlib import Path
+
+    def _boom(self):
+        raise PermissionError("simulated")
+
+    monkeypatch.setattr(Path, "read_bytes", _boom)
+    with pytest.raises(LocalStateReadError):
+        da.establish_anchor(root)
+
+
+def test_state_preservation_failure_raises_and_blocks_mutation(root, monkeypatch):
+    da.establish_anchor(root)
+    raw = json.loads(da.anchor_state_path().read_bytes())
+    raw["version"] = 99
+    da.anchor_state_path().write_bytes(json.dumps(raw).encode("utf-8"))
+
+    def _boom(path, data, **kwargs):
+        if "bak" in str(path):
+            raise OSError("simulated disk-full during backup")
+        from tiddl.core.utils.fsio import atomic_write_bytes as real
+        real(path, data, **kwargs)
+
+    monkeypatch.setattr(da, "atomic_write_bytes", _boom)
+    other_root = root.parent / "other_root2"
+    other_root.mkdir()
+    with pytest.raises(LocalStatePreservationError):
+        da.establish_anchor(other_root)
+    # Original (future-version) content must be untouched.
+    assert json.loads(da.anchor_state_path().read_bytes())["version"] == 99
+
+
+def test_two_concurrent_mutations_both_survive(root, tmp_path):
+    r2 = tmp_path / "root2"
+    r2.mkdir()
+    da.establish_anchor(root)
+    da.establish_anchor(r2)
+    state = da.read_state()
+    assert len(state.records) == 2
+
+
+# ---------------------------------------------------------------------------
+# IdentityFailureTracker (v2.4 §2)
+# ---------------------------------------------------------------------------
+
+
+def test_tracker_starts_unrefused():
+    t = IdentityFailureTracker()
+    assert t.any_refused is False
+    assert t.first_refusal is None
+
+
+def test_tracker_marks_and_stays_monotonic():
+    t = IdentityFailureTracker()
+    c1 = da.AnchorCheck(False, "unknown_root", __import__("pathlib").Path("/a"))
+    c2 = da.AnchorCheck(False, "not_contained", __import__("pathlib").Path("/b"))
+    t.mark_refused(c1)
+    assert t.any_refused is True
+    assert t.first_refusal is c1
+    t.mark_refused(c2)
+    # First refusal is preserved even after a second one.
+    assert t.first_refusal is c1
+    assert t.any_refused is True
+
+
+async def test_tracker_event_is_awaitable_and_asyncio_native():
+    t = IdentityFailureTracker()
+
+    async def _mark_later():
+        await asyncio.sleep(0)
+        t.mark_refused(da.AnchorCheck(False, "unknown_root", __import__("pathlib").Path("/a")))
+
+    task = asyncio.create_task(_mark_later())
+    await t._event.wait()
+    await task
+    assert t.any_refused is True

--- a/tests/test_destination_cli.py
+++ b/tests/test_destination_cli.py
@@ -166,7 +166,7 @@ def test_forget_clears_only_local_state(root):
 def test_forget_unknown_root_is_informational_not_an_error(root):
     result = runner.invoke(app, ["destination", "forget", str(root)])
     assert result.exit_code == 0
-    assert "nothing to do" in result.output.lower()
+    assert "nothing to do" in _flat(result.output).lower()
 
 
 def test_status_single_path_trusted(root):

--- a/tests/test_destination_cli.py
+++ b/tests/test_destination_cli.py
@@ -9,6 +9,7 @@ APP_PATH, matching tests/test_recover_cli.py's own convention.
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 from typer.testing import CliRunner
@@ -19,6 +20,24 @@ from tiddl.cli.app import app
 
 runner = CliRunner()
 
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Rich renders styled spans as separate ANSI-wrapped runs, so a run's
+    tail and the next run's head can be split across a word-wrapped line
+    with no literal space between them once escape codes are left in —
+    `_flat()`'s whitespace-flattening alone doesn't fix that. Strip codes
+    FIRST, then flatten whitespace. Same helper as
+    tests/test_recover_cli.py's, added there after an implementation-audit
+    finding (2026-08-18) reproduced two flaky failures here
+    (`test_trust_already_trusted_is_a_no_op_success` and
+    `test_trust_never_touches_registry_or_download_paths`) on a Windows
+    worktree, where the longer `C:\\Users\\...\\AppData\\Local\\Temp\\...`
+    tmp_path embedded in these messages shifts the wrap point versus this
+    sandbox's shorter `/tmp/...` paths."""
+    return _ANSI_RE.sub("", text)
+
 
 def _flat(text: str) -> str:
     """Rich's Console word-wraps long lines at terminal width, which can
@@ -26,7 +45,7 @@ def _flat(text: str) -> str:
     before substring-checking CLI output, same idea as
     tests/test_recover_cli.py's own output assertions avoid by checking
     short fragments — these messages are long enough to need it."""
-    return " ".join(text.split())
+    return " ".join(_strip_ansi(text).split())
 
 
 @pytest.fixture(autouse=True)
@@ -91,7 +110,11 @@ def test_trust_already_trusted_is_a_no_op_success(root):
     before = (root / da.MARKER_FILENAME).read_bytes()
     result = runner.invoke(app, ["destination", "trust", str(root), "--confirm-mounted"])
     assert result.exit_code == 0
-    assert "already trusted" in result.output
+    # Implementation-audit finding (2026-08-18): a longer tmp_path (e.g.
+    # Windows' `C:\Users\...\AppData\Local\Temp\...`) shifts Rich's word-wrap
+    # point and can split "already trusted" across a styled-span boundary —
+    # see _flat()'s docstring. Never substring-check raw result.output here.
+    assert "already trusted" in _flat(result.output)
     assert (root / da.MARKER_FILENAME).read_bytes() == before
 
 
@@ -195,11 +218,19 @@ def test_status_warns_on_corrupt_local_state(root):
 def test_trust_never_touches_registry_or_download_paths(root):
     # Sanity: `tiddl destination trust` only writes the marker + local
     # state, nothing else under APP_PATH.
+    #
+    # Implementation-audit finding (2026-08-18): whether FileLock leaves the
+    # `.lock` file behind afterwards is backend/version-dependent — not part
+    # of this feature's contract, just an implementation detail of whichever
+    # lock the `filelock` package picks on a given platform. Require the
+    # state file and allow the lock file as optional, instead of asserting
+    # the exact two-file set.
     before = set((da.APP_PATH).glob("**/*")) if da.APP_PATH.exists() else set()
     runner.invoke(app, ["destination", "trust", str(root), "--confirm-mounted"])
     after = set((da.APP_PATH).glob("**/*"))
     new_files = {p.name for p in (after - before) if p.is_file()}
-    assert new_files == {"destination_anchors.json", "destination_anchors.json.lock"}
+    assert "destination_anchors.json" in new_files
+    assert new_files <= {"destination_anchors.json", "destination_anchors.json.lock"}
 
 
 def test_marker_json_matches_documented_schema(root):

--- a/tests/test_destination_cli.py
+++ b/tests/test_destination_cli.py
@@ -1,0 +1,210 @@
+"""End-to-end coverage for `tiddl destination trust/status/forget` — the
+only commands allowed to mutate destination-anchor trust state (see
+`tiddl.core.utils.destination_anchor` and
+PROPOSAL_destination_volume_identity_v2_1.md §2, kept local/untracked).
+
+Uses Typer's CliRunner against the real `app`, isolated to a tmp_path-backed
+APP_PATH, matching tests/test_recover_cli.py's own convention.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+import tiddl.core.utils.destination_anchor as da
+import tiddl.core.utils.retained_registry as reg
+from tiddl.cli.app import app
+
+runner = CliRunner()
+
+
+def _flat(text: str) -> str:
+    """Rich's Console word-wraps long lines at terminal width, which can
+    split an assertion's substring across a newline. Normalize whitespace
+    before substring-checking CLI output, same idea as
+    tests/test_recover_cli.py's own output assertions avoid by checking
+    short fragments — these messages are long enough to need it."""
+    return " ".join(text.split())
+
+
+@pytest.fixture(autouse=True)
+def _isolated_app_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(da, "APP_PATH", tmp_path / "_app")
+    # cli/app.py's root callback prints a retained-staging startup notice
+    # using the registry module's own (real, unpatched) APP_PATH — isolate
+    # it too so a stray real ~/.tiddl/retained_staging.json can't leak
+    # unrelated warning text into this file's output assertions.
+    monkeypatch.setattr(reg, "APP_PATH", tmp_path / "_app")
+    return tmp_path / "_app"
+
+
+@pytest.fixture
+def root(tmp_path):
+    r = tmp_path / "dest_root"
+    r.mkdir()
+    return r
+
+
+def test_trust_refuses_nonexistent_path(tmp_path):
+    result = runner.invoke(app, ["destination", "trust", str(tmp_path / "nope")])
+    assert result.exit_code == 1
+    assert "does not exist" in _flat(result.output)
+    assert da.read_state().records == []
+
+
+def test_trust_refuses_non_directory(tmp_path):
+    f = tmp_path / "afile"
+    f.write_text("x")
+    result = runner.invoke(app, ["destination", "trust", str(f)])
+    assert result.exit_code == 1
+    assert "not a directory" in _flat(result.output)
+
+
+def test_trust_confirm_mounted_establishes_anchor(root):
+    result = runner.invoke(app, ["destination", "trust", str(root), "--confirm-mounted"])
+    assert result.exit_code == 0
+    assert "Trusted" in result.output
+    status, anchor_id, _ = da.read_marker(root)
+    assert status == "trusted"
+    assert anchor_id is not None
+
+
+def test_trust_declined_confirmation_writes_nothing(root):
+    result = runner.invoke(app, ["destination", "trust", str(root)], input="n\n")
+    assert result.exit_code == 1
+    status, _, _ = da.read_marker(root)
+    assert status == "absent"
+    assert da.read_state().records == []
+
+
+def test_trust_confirmed_via_prompt_establishes_anchor(root):
+    result = runner.invoke(app, ["destination", "trust", str(root)], input="y\n")
+    assert result.exit_code == 0
+    status, _, _ = da.read_marker(root)
+    assert status == "trusted"
+
+
+def test_trust_already_trusted_is_a_no_op_success(root):
+    runner.invoke(app, ["destination", "trust", str(root), "--confirm-mounted"])
+    before = (root / da.MARKER_FILENAME).read_bytes()
+    result = runner.invoke(app, ["destination", "trust", str(root), "--confirm-mounted"])
+    assert result.exit_code == 0
+    assert "already trusted" in result.output
+    assert (root / da.MARKER_FILENAME).read_bytes() == before
+
+
+def test_trust_existing_marker_without_local_state_refuses_without_adopt_existing(root):
+    da.establish_anchor(root)
+    da.forget_anchor(root)  # simulate a second, fresh machine's local state
+    result = runner.invoke(app, ["destination", "trust", str(root), "--confirm-mounted"])
+    assert result.exit_code == 1
+    assert "--adopt-existing" in result.output
+
+
+def test_trust_adopt_existing_records_without_touching_destination(root):
+    anchor_id = da.establish_anchor(root)
+    da.forget_anchor(root)
+    marker_before = (root / da.MARKER_FILENAME).read_bytes()
+
+    result = runner.invoke(
+        app, ["destination", "trust", str(root), "--adopt-existing", "--confirm-mounted"]
+    )
+    assert result.exit_code == 0
+    assert "Adopted" in result.output
+    assert (root / da.MARKER_FILENAME).read_bytes() == marker_before
+    state = da.read_state()
+    record = da.find_record(state.records, da.root_key(root))
+    assert record is not None
+    assert record.anchor_id == anchor_id
+
+
+def test_trust_refuses_unreadable_marker_never_silently_adopted(root):
+    (root / da.MARKER_FILENAME).write_bytes(b"\xff\xfe not json")
+    result = runner.invoke(
+        app, ["destination", "trust", str(root), "--adopt-existing", "--confirm-mounted"]
+    )
+    assert result.exit_code == 1
+    assert da.read_state().records == []
+
+
+def test_forget_clears_only_local_state(root):
+    da.establish_anchor(root)
+    result = runner.invoke(app, ["destination", "forget", str(root)])
+    assert result.exit_code == 0
+    assert "Forgot" in result.output
+    assert da.find_record(da.read_state().records, da.root_key(root)) is None
+    # Marker still exists on the "destination".
+    status, _, _ = da.read_marker(root)
+    assert status == "trusted"
+
+
+def test_forget_unknown_root_is_informational_not_an_error(root):
+    result = runner.invoke(app, ["destination", "forget", str(root)])
+    assert result.exit_code == 0
+    assert "nothing to do" in result.output.lower()
+
+
+def test_status_single_path_trusted(root):
+    da.establish_anchor(root)
+    result = runner.invoke(app, ["destination", "status", str(root)])
+    assert result.exit_code == 0
+    assert "trusted" in result.output
+
+
+def test_status_single_path_unknown(root):
+    result = runner.invoke(app, ["destination", "status", str(root)])
+    assert result.exit_code == 0
+    assert "unknown_root" in result.output
+
+
+def test_status_no_path_lists_all_known_roots(root, tmp_path):
+    r2 = tmp_path / "root2"
+    r2.mkdir()
+    da.establish_anchor(root)
+    da.establish_anchor(r2)
+    result = runner.invoke(app, ["destination", "status"])
+    assert result.exit_code == 0
+    # The table column truncates long paths, so check structurally instead
+    # of for the full path string: two roots listed, both currently trusted.
+    state = da.read_state()
+    assert {r.root_key for r in state.records} == {da.root_key(root), da.root_key(r2)}
+    # Title ("Trusted destination roots") + two per-row "trusted" reasons.
+    # \b excludes the "trusted_at" column header ("d"/"_" is not a word
+    # boundary), so this counts only whole-word "trusted" occurrences.
+    import re
+
+    assert len(re.findall(r"\btrusted\b", result.output, re.IGNORECASE)) == 3
+
+
+def test_status_no_roots_yet(tmp_path):
+    result = runner.invoke(app, ["destination", "status"])
+    assert result.exit_code == 0
+    assert "No roots trusted yet" in result.output
+
+
+def test_status_warns_on_corrupt_local_state(root):
+    da.establish_anchor(root)
+    da.anchor_state_path().write_bytes(b"not json at all")
+    result = runner.invoke(app, ["destination", "status"])
+    assert result.exit_code == 0
+    assert "could not be parsed" in result.output
+
+
+def test_trust_never_touches_registry_or_download_paths(root):
+    # Sanity: `tiddl destination trust` only writes the marker + local
+    # state, nothing else under APP_PATH.
+    before = set((da.APP_PATH).glob("**/*")) if da.APP_PATH.exists() else set()
+    runner.invoke(app, ["destination", "trust", str(root), "--confirm-mounted"])
+    after = set((da.APP_PATH).glob("**/*"))
+    new_files = {p.name for p in (after - before) if p.is_file()}
+    assert new_files == {"destination_anchors.json", "destination_anchors.json.lock"}
+
+
+def test_marker_json_matches_documented_schema(root):
+    da.establish_anchor(root)
+    data = json.loads((root / da.MARKER_FILENAME).read_bytes())
+    assert data["format"] == "tiddl-destination-anchor"
+    assert data["version"] == 1
+    assert isinstance(data["anchor_id"], str) and data["anchor_id"]

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -770,19 +770,56 @@ async def test_publish_off_mode_ignores_an_untrusted_root(tmp_path, fast_sleep, 
     assert dl.identity_tracker.any_refused is False
 
 
-async def test_publish_task_without_root_skips_the_guard_entirely(
+async def test_publish_task_without_root_is_refused_in_strict_mode(
     tmp_path, fast_sleep, stage_dir
 ):
-    # A DownloadTask built without `root` (e.g. every other test in this
-    # file, predating this feature) must behave exactly as before: strict
-    # mode configured on the Downloader is irrelevant if this task never
-    # got a root, per DownloadTask.root's own docstring.
+    # Implementation-audit finding, P1 #2: a DownloadTask built without
+    # `root` used to skip the guard entirely and publish unchecked, even in
+    # strict mode — a fail-OPEN bypass. A future constructor, refactor, or
+    # plugin that forgets to set `root` must fail CLOSED instead: strict
+    # mode's whole promise is that an unverified destination never gets
+    # written to. This replaces the old
+    # test_publish_task_without_root_skips_the_guard_entirely, which
+    # codified the bypass as the intended behavior.
+    dest = tmp_path / "out.bin"
+    tracker = da.IdentityFailureTracker()
+
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, dl = await _download(
+            server, task, destination_identity="strict", identity_tracker=tracker,
+        )
+    finally:
+        await server.close()
+
+    assert ok is False
+    assert not dest.exists()  # never published
+    assert task.error_message and "no_root_configured" in task.error_message
+    assert tracker.any_refused is True
+    assert tracker.first_refusal.reason == "no_root_configured"
+    # Treated exactly like any other identity refusal: staging retained,
+    # registered PUBLISH_PENDING for later recovery.
+    assert task.retained_staging is not None
+    assert Path(task.retained_staging).exists()
+    entries = registrymod.read_entries().entries
+    assert len(entries) == 1
+    assert entries[0].reason == registrymod.RetainReason.PUBLISH_PENDING
+
+
+async def test_publish_task_without_root_still_works_in_off_mode(
+    tmp_path, fast_sleep, stage_dir
+):
+    # Root-less tasks may continue ONLY under mode="off" (v2.4 §1: off
+    # performs zero identity reads regardless of what root information is
+    # or isn't available) — this is the one case the audit explicitly
+    # allows a root-less task to keep publishing.
     dest = tmp_path / "out.bin"
 
     server = await _start([("ok", 5000)])
     try:
         task = DownloadTask(url="x", output_path=dest, expected_size=5000)
-        ok, dl = await _download(server, task, destination_identity="strict")
+        ok, dl = await _download(server, task, destination_identity="off")
     finally:
         await server.close()
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -12,12 +12,14 @@ import hashlib
 import os
 import shutil
 import types
+from pathlib import Path
 
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestServer
 
 import tiddl.cli.commands.download.downloader as dlmod
+import tiddl.core.utils.destination_anchor as da
 import tiddl.core.utils.fsio as fsiomod
 import tiddl.core.utils.publish as publishmod
 import tiddl.core.utils.retained_registry as registrymod
@@ -52,9 +54,11 @@ class _StubDownloader:
     _publish_staged = Downloader._publish_staged
     _verify_or_repair = Downloader._verify_or_repair
 
-    def __init__(self):
+    def __init__(self, destination_identity="off", identity_tracker=None):
         self._http_session = None
         self.rich_output = _StubOutput()
+        self.destination_identity = destination_identity
+        self.identity_tracker = identity_tracker or da.IdentityFailureTracker()
 
 
 def _scripted_app(script: list) -> web.Application:
@@ -141,10 +145,10 @@ def _no_staging_leftovers(stage_dir) -> bool:
     return not list(stage_dir.glob("tiddl-*.part.*"))
 
 
-async def _download(server: TestServer, task: DownloadTask):
+async def _download(server: TestServer, task: DownloadTask, **stub_kwargs):
     """Returns (ok, stub) so a test can inspect the stub (e.g. visual resets)."""
     url = str(server.make_url("/track"))
-    dl = _StubDownloader()
+    dl = _StubDownloader(**stub_kwargs)
     try:
         ok = await dl._download_with_retry(task, [url], task_id=0)
     finally:
@@ -681,3 +685,102 @@ async def test_same_volume_uses_atomic_rename_not_copy(
 
     assert ok is True                # published via atomic os.replace, no copy
     assert dest.stat().st_size == 5000
+
+
+# ------------------------------------------------------------------
+# Destination-volume identity — operation 3 (media publication), the
+# tightest of the nine guarded writes (see tiddl.core.utils.destination_
+# anchor and PROPOSAL_destination_volume_identity_v2_1..v2_4.md, kept
+# local/untracked). Exercised end to end via _download_with_retry so the
+# real staging -> verify -> guard -> publish chain runs, not a mock of it.
+# ------------------------------------------------------------------
+
+async def test_publish_refused_by_untrusted_root_retains_staging_as_publish_pending(
+    tmp_path, fast_sleep, stage_dir
+):
+    root = tmp_path / "dest_root"
+    root.mkdir()
+    dest = root / "out.bin"
+    tracker = da.IdentityFailureTracker()
+
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=dest, root=root, expected_size=5000)
+        ok, dl = await _download(
+            server, task, destination_identity="strict", identity_tracker=tracker,
+        )
+    finally:
+        await server.close()
+
+    assert ok is False
+    assert not dest.exists()  # never published
+    assert task.error_message and "destination not trusted" in task.error_message
+    assert tracker.any_refused is True
+    # Class A (v2.3 §3): treated exactly like any other publish failure —
+    # the verified local copy is retained, not deleted, and registered for
+    # `tiddl recover` to pick up later once the root is actually trusted.
+    assert task.retained_staging is not None
+    assert Path(task.retained_staging).exists()
+    entries = registrymod.read_entries().entries
+    assert len(entries) == 1
+    assert entries[0].reason == registrymod.RetainReason.PUBLISH_PENDING
+    assert entries[0].output_path == str(dest)
+
+
+async def test_publish_succeeds_when_root_is_trusted(tmp_path, fast_sleep, stage_dir):
+    root = tmp_path / "dest_root"
+    root.mkdir()
+    da.establish_anchor(root)
+    dest = root / "out.bin"
+
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=dest, root=root, expected_size=5000)
+        ok, dl = await _download(server, task, destination_identity="strict")
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert dest.stat().st_size == 5000
+    assert dl.identity_tracker.any_refused is False
+    assert registrymod.read_entries().entries == []
+
+
+async def test_publish_off_mode_ignores_an_untrusted_root(tmp_path, fast_sleep, stage_dir):
+    # "off" performs zero identity reads (v2.4 §1) — root has no anchor and
+    # no local trust record at all, yet the publish proceeds unaffected.
+    root = tmp_path / "dest_root"
+    root.mkdir()
+    dest = root / "out.bin"
+
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=dest, root=root, expected_size=5000)
+        ok, dl = await _download(server, task, destination_identity="off")
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert dest.stat().st_size == 5000
+    assert dl.identity_tracker.any_refused is False
+
+
+async def test_publish_task_without_root_skips_the_guard_entirely(
+    tmp_path, fast_sleep, stage_dir
+):
+    # A DownloadTask built without `root` (e.g. every other test in this
+    # file, predating this feature) must behave exactly as before: strict
+    # mode configured on the Downloader is irrelevant if this task never
+    # got a root, per DownloadTask.root's own docstring.
+    dest = tmp_path / "out.bin"
+
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=dest, expected_size=5000)
+        ok, dl = await _download(server, task, destination_identity="strict")
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert dest.stat().st_size == 5000
+    assert dl.identity_tracker.any_refused is False

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -9,6 +9,7 @@ end to end. Staging is redirected into the test's tmp dir so we can assert no
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
 import types
@@ -896,3 +897,89 @@ async def test_off_mode_retained_entry_never_carries_identity(
     entries = registrymod.read_entries().entries
     assert entries[0].destination_root is None
     assert entries[0].destination_anchor_id is None
+
+
+def _write_marker(root: Path, anchor_id: str) -> None:
+    """Writes a marker with a SPECIFIC anchor id, bypassing
+    establish_anchor() (which always mints a fresh random one) — used to
+    simulate a destination reappearing intact with its original marker,
+    as opposed to a fresh trust/re-trust."""
+    payload = json.dumps(
+        {"format": da.MARKER_FORMAT, "version": da.MARKER_VERSION, "anchor_id": anchor_id}
+    ).encode("utf-8")
+    da.marker_path(root).write_bytes(payload)
+
+
+async def test_pre_staging_identity_survives_a_publish_time_refusal(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    # Second implementation-audit finding (2026-08-18), P1 #1: identity must
+    # be captured at operations 1/2 (pre-staging), not only at operation 3
+    # (post-staging) — otherwise a root trusted before staging that
+    # disappears mid-download loses its identity entirely, and the
+    # resulting PUBLISH_PENDING entry falls back to legacy under strict
+    # recovery even though it really WAS verified before the download
+    # started.
+    #
+    # Mirrors the real wiring in Downloader.download(): call the real
+    # _guarded_mkdir (operations 1/2's guard) BEFORE staging and capture
+    # its result onto the task, exactly as downloader.py's two call sites
+    # do, then let the download/publish pipeline run with the marker
+    # removed mid-flight — simulating the destination disappearing during
+    # the download.
+    monkeypatch.setattr(publishmod, "_safe_unlink", lambda p: False)
+    root = tmp_path / "dest_root"
+    root.mkdir()
+    anchor_id = da.establish_anchor(root)
+    dest = root / "out.bin"
+
+    mkdir_check = dlmod._guarded_mkdir(root, dest, "strict")
+    assert mkdir_check.reason == "trusted"
+
+    task = DownloadTask(url="x", output_path=dest, root=root, expected_size=5000)
+    task.verified_root_key = da.root_key(root)
+    task.verified_anchor_id = mkdir_check.anchor_id
+
+    # Destination disappears mid-download, before operation 3's publish-
+    # time recheck runs.
+    da.marker_path(root).unlink()
+
+    server = await _start([("ok", 5000)])
+    try:
+        ok, dl = await _download(server, task, destination_identity="strict")
+    finally:
+        await server.close()
+
+    assert ok is False
+    assert not dest.exists()  # never published
+
+    # THE fix: the pre-staging identity is NOT erased by the publish-time
+    # refusal.
+    assert task.verified_root_key == da.root_key(root)
+    assert task.verified_anchor_id == anchor_id
+
+    entries = registrymod.read_entries().entries
+    assert len(entries) == 1
+    assert entries[0].reason == registrymod.RetainReason.PUBLISH_PENDING
+    assert entries[0].destination_root == da.root_key(root)
+    assert entries[0].destination_anchor_id == anchor_id
+
+    # Restore the SAME marker (the destination reappears intact) -> strict
+    # recovery succeeds WITHOUT --bind-root.
+    _write_marker(root, anchor_id)
+    check = da.check_write_allowed(
+        Path(entries[0].destination_root), dest, mode="strict",
+        expected_anchor_id=entries[0].destination_anchor_id,
+    )
+    assert check.allowed is True
+
+    # Forget + re-trust with a DIFFERENT anchor -> refuses.
+    da.forget_anchor(root)
+    da.marker_path(root).unlink()
+    different_anchor_id = da.establish_anchor(root)
+    assert different_anchor_id != anchor_id
+    check2 = da.check_write_allowed(
+        Path(entries[0].destination_root), dest, mode="strict",
+        expected_anchor_id=entries[0].destination_anchor_id,
+    )
+    assert check2.allowed is False

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -109,6 +109,11 @@ def _isolate_retained_registry(tmp_path, monkeypatch):
     """Every test in this module gets its own retained-staging registry +
     quarantine dir under pytest's tmp_path, never the real ~/.tiddl."""
     monkeypatch.setattr(registrymod, "APP_PATH", tmp_path / "_app")
+    # Same isolation for destination_anchor's local state — the identity
+    # tests below call da.establish_anchor()/check_write_allowed() directly,
+    # matching the convention every other test file in this suite already
+    # follows (test_destination_cli.py, test_recover_cli.py, test_m3u.py).
+    monkeypatch.setattr(da, "APP_PATH", tmp_path / "_app")
 
 
 @pytest.fixture
@@ -784,3 +789,73 @@ async def test_publish_task_without_root_skips_the_guard_entirely(
     assert ok is True
     assert dest.stat().st_size == 5000
     assert dl.identity_tracker.any_refused is False
+
+
+async def test_retained_entry_from_a_trusted_publish_carries_the_verified_identity(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    # Implementation-audit finding (2026-08-18): a retained entry from a real
+    # strict-mode download never carried destination_root/destination_anchor_id,
+    # so `tiddl recover` always classified it as legacy and refused until a
+    # manual --bind-root — defeating the point of capturing identity at all.
+    # Reproduced here via the CLEANUP_PENDING path (publish succeeds, the
+    # best-effort staging unlink fails) since it's the simplest way to force
+    # a retained_registry entry while keeping the root genuinely trusted.
+    monkeypatch.setattr(publishmod, "_safe_unlink", lambda p: False)
+
+    root = tmp_path / "dest_root"
+    root.mkdir()
+    anchor_id = da.establish_anchor(root)
+    dest = root / "out.bin"
+
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=dest, root=root, expected_size=5000)
+        ok, dl = await _download(server, task, destination_identity="strict")
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.verified_root_key == da.root_key(root)
+    assert task.verified_anchor_id == anchor_id
+
+    entries = registrymod.read_entries().entries
+    assert len(entries) == 1
+    assert entries[0].reason == registrymod.RetainReason.CLEANUP_PENDING
+    assert entries[0].destination_root == da.root_key(root)
+    assert entries[0].destination_anchor_id == anchor_id
+
+    # And recovery picks it up WITHOUT --bind-root, because the identity was
+    # already captured at staging time — this is the actual point of §5.
+    check = da.check_write_allowed(
+        Path(entries[0].destination_root), dest, mode="strict",
+        expected_anchor_id=entries[0].destination_anchor_id,
+    )
+    assert check.allowed is True
+
+
+async def test_off_mode_retained_entry_never_carries_identity(
+    tmp_path, fast_sleep, stage_dir, cross_volume, monkeypatch
+):
+    # Requirement #4 (audit correction): off mode must never persist
+    # destination_root/destination_anchor_id, even when task.root is set.
+    monkeypatch.setattr(publishmod, "_safe_unlink", lambda p: False)
+
+    root = tmp_path / "dest_root"
+    root.mkdir()
+    da.establish_anchor(root)
+    dest = root / "out.bin"
+
+    server = await _start([("ok", 5000)])
+    try:
+        task = DownloadTask(url="x", output_path=dest, root=root, expected_size=5000)
+        ok, dl = await _download(server, task, destination_identity="off")
+    finally:
+        await server.close()
+
+    assert ok is True
+    assert task.verified_root_key is None
+    assert task.verified_anchor_id is None
+    entries = registrymod.read_entries().entries
+    assert entries[0].destination_root is None
+    assert entries[0].destination_anchor_id is None

--- a/tests/test_guarded_writes.py
+++ b/tests/test_guarded_writes.py
@@ -38,7 +38,7 @@ from tiddl.cli.commands.download import (
     _write_video_metadata_guarded,
 )
 from tiddl.cli.commands.download.downloader import _guarded_mkdir
-from tiddl.core.metadata import Cover
+from tiddl.core.metadata import Cover, CoverDataNotPrefetched
 
 
 @pytest.fixture(autouse=True)
@@ -316,6 +316,102 @@ def test_touch_guard_refuses_and_never_touches_when_untrusted(untrusted_root):
 
     assert excinfo.value.check.reason == "unknown_root"
     assert target.stat().st_mtime == 0  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Second implementation-audit finding (2026-08-18), P1 #2: write_prefetched()
+# was not actually network-free — a failed first fetch left cover.data
+# falsy, and its own fallback silently fetched AGAIN, after the identity
+# check had already run once (for _guarded_save_cover's guarded write).
+# These tests pin the fixed contract: _get_data() is called AT MOST ONCE by
+# _guarded_save_cover, and write_prefetched() never calls it at all.
+# ---------------------------------------------------------------------------
+
+def test_write_prefetched_never_fetches_and_raises_without_data(tmp_path):
+    cover = Cover("uid-1")
+
+    def _must_not_be_called():
+        pytest.fail("write_prefetched() must never call _get_data()")
+
+    cover._get_data = _must_not_be_called  # type: ignore[method-assign]
+    assert cover.data is None
+
+    with pytest.raises(CoverDataNotPrefetched):
+        cover.write_prefetched(tmp_path / "cover")
+
+    assert not (tmp_path / "cover.jpg").exists()
+
+
+def test_write_prefetched_writes_when_data_already_present(tmp_path):
+    cover = Cover("uid-1")
+    cover.data = b"jpegbytes"
+
+    cover.write_prefetched(tmp_path / "cover")
+
+    assert (tmp_path / "cover.jpg").read_bytes() == b"jpegbytes"
+
+
+async def test_cover_guard_fetches_exactly_once_when_trusted(trusted_root, monkeypatch):
+    cover = Cover("uid-1")
+    calls = []
+
+    def _get_data():
+        calls.append(1)
+        return b"jpegbytes"
+
+    monkeypatch.setattr(cover, "_get_data", _get_data)
+    tracker = da.IdentityFailureTracker()
+    cover_path = trusted_root / "cover"
+
+    await _guarded_save_cover(cover, trusted_root, cover_path, "strict", tracker, "album")
+
+    assert len(calls) == 1  # never fetched twice
+    assert cover_path.with_suffix(".jpg").read_bytes() == b"jpegbytes"
+
+
+async def test_cover_guard_writes_nothing_on_empty_fetch_data(trusted_root, monkeypatch):
+    # A legitimately empty fetch result (network/HTTP failure inside
+    # _get_data, which returns b"" without raising) must skip the write
+    # entirely — no file, no identity check, no second fetch attempt, and
+    # NOT reported as a destination-identity refusal (it's a fetch
+    # failure, unrelated to trust).
+    cover = Cover("uid-1")
+    calls = []
+
+    def _get_data():
+        calls.append(1)
+        return b""
+
+    monkeypatch.setattr(cover, "_get_data", _get_data)
+    tracker = da.IdentityFailureTracker()
+    cover_path = trusted_root / "cover"
+
+    await _guarded_save_cover(cover, trusted_root, cover_path, "strict", tracker, "album")
+
+    assert len(calls) == 1  # exactly one fetch attempt, never a silent retry
+    assert not cover_path.with_suffix(".jpg").exists()
+    assert tracker.any_refused is False
+
+
+async def test_cover_guard_never_fetches_twice_even_when_untrusted(
+    untrusted_root, monkeypatch
+):
+    cover = Cover("uid-1")
+    calls = []
+
+    def _get_data():
+        calls.append(1)
+        return b"jpegbytes"
+
+    monkeypatch.setattr(cover, "_get_data", _get_data)
+    tracker = da.IdentityFailureTracker()
+    cover_path = untrusted_root / "cover"
+
+    await _guarded_save_cover(cover, untrusted_root, cover_path, "strict", tracker, "album")
+
+    assert len(calls) == 1
+    assert not cover_path.with_suffix(".jpg").exists()
+    assert tracker.any_refused is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_guarded_writes.py
+++ b/tests/test_guarded_writes.py
@@ -316,3 +316,25 @@ def test_touch_guard_refuses_and_never_touches_when_untrusted(untrusted_root):
 
     assert excinfo.value.check.reason == "unknown_root"
     assert target.stat().st_mtime == 0  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Second implementation-audit finding (2026-08-18), P1 #1: identity must be
+# captured at operations 1/2 (pre-staging), not only at operation 3
+# (post-staging) — a refusal at operation 3 must never erase what 1/2
+# already captured.
+# ---------------------------------------------------------------------------
+
+def test_mkdir_guard_returns_the_trusted_check_for_capture(trusted_root):
+    target = trusted_root / "track.flac"
+    check = _guarded_mkdir(trusted_root, target, "strict")
+    assert check.reason == "trusted"
+    assert check.anchor_id is not None
+    assert check.anchor_id == da.read_marker(trusted_root)[1]
+
+
+def test_mkdir_guard_off_mode_returns_disabled_not_trusted(untrusted_root):
+    target = untrusted_root / "track.flac"
+    check = _guarded_mkdir(untrusted_root, target, "off")
+    assert check.reason == "disabled"
+    assert check.anchor_id is None

--- a/tests/test_guarded_writes.py
+++ b/tests/test_guarded_writes.py
@@ -1,23 +1,30 @@
-"""Coverage for the operation 5/6/8 guarded-write helpers in
-`tiddl.cli.commands.download` — `_write_track_metadata_guarded`,
-`_write_video_metadata_guarded`, `_guarded_save_cover`.
+"""Coverage for the operation 1/2/4/5/6/8/9 guarded-write helpers in
+`tiddl.cli.commands.download` (`__init__.py`) and `.downloader` —
+`_guarded_mkdir`, `_write_lrc_guarded`, `_write_track_metadata_guarded`,
+`_write_video_metadata_guarded`, `_guarded_save_cover`, `_touch_guarded`.
 
-These were extracted from inline closures inside the (untestable-in-
-isolation) `handle_item`/`download_callback` call graph specifically so the
-implementation-audit finding (2026-08-18, P1 #3 — "guards placed before
-asyncio.to_thread are not at the final mutation boundary") has direct,
-targeted regression coverage: the identity check must run INSIDE the same
-unit of work as the mutation, with no await point, sleep, or network I/O
-between "checked" and "written."
+Operations 5/6/8 were extracted from inline closures inside the
+(untestable-in-isolation) `handle_item`/`download_callback` call graph
+specifically so the implementation-audit finding (2026-08-18, P1 #3 —
+"guards placed before asyncio.to_thread are not at the final mutation
+boundary") has direct, targeted regression coverage: the identity check
+must run INSIDE the same unit of work as the mutation, with no await
+point, sleep, or network I/O between "checked" and "written."
 
-Also covers a slice of the P2 finding ("seven guarded operation classes
-lack direct integration evidence") for operations 5, 6 and 8 specifically —
-the other five (1, 2, 4, 7, 9) remain covered only indirectly via
-test_downloader.py/test_destination_anchor.py, which is a real, disclosed
-gap (see the audit response)."""
+Operations 1, 2, 4 and 9 have no such gap (their check and mutation were
+already adjacent statements, never separated by a to_thread dispatch) but
+were extracted the same way purely so each guarded operation class has its
+own direct unit test — implementation-audit P2 finding ("seven guarded
+operation classes lack direct integration evidence"). That leaves only
+operation 3 (media publication — covered end-to-end in
+test_downloader.py) and operation 7 (M3U — covered in test_m3u.py) without
+a dedicated test in *this* file; both already have direct coverage
+elsewhere, matching the audit's own note that those two were the ones NOT
+missing evidence."""
 from __future__ import annotations
 
 import asyncio
+import os
 
 import pytest
 
@@ -25,9 +32,12 @@ import tiddl.cli.commands.download as dlinit
 import tiddl.core.utils.destination_anchor as da
 from tiddl.cli.commands.download import (
     _guarded_save_cover,
+    _touch_guarded,
+    _write_lrc_guarded,
     _write_track_metadata_guarded,
     _write_video_metadata_guarded,
 )
+from tiddl.cli.commands.download.downloader import _guarded_mkdir
 from tiddl.core.metadata import Cover
 
 
@@ -233,3 +243,76 @@ async def test_cover_guard_off_mode_never_checks(untrusted_root, monkeypatch):
 
     assert cover_path.with_suffix(".jpg").read_bytes() == b"jpegbytes"
     assert tracker.any_refused is False
+
+
+# ---------------------------------------------------------------------------
+# Operations 1/2: audio/video directory creation
+# ---------------------------------------------------------------------------
+
+def test_mkdir_guard_creates_the_directory_when_trusted(trusted_root):
+    target = trusted_root / "sub" / "dir" / "track.flac"
+    _guarded_mkdir(trusted_root, target, "strict")
+    assert target.parent.is_dir()
+
+
+def test_mkdir_guard_refuses_and_never_creates_when_untrusted(untrusted_root):
+    target = untrusted_root / "sub" / "dir" / "track.flac"
+    with pytest.raises(da.DestinationNotTrusted) as excinfo:
+        _guarded_mkdir(untrusted_root, target, "strict")
+
+    assert excinfo.value.check.reason == "unknown_root"
+    assert not target.parent.exists()  # the mutation never ran
+
+
+def test_mkdir_guard_off_mode_never_checks(untrusted_root):
+    target = untrusted_root / "sub" / "dir" / "video.ts"
+    _guarded_mkdir(untrusted_root, target, "off")
+    assert target.parent.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Operation 4: .lrc write
+# ---------------------------------------------------------------------------
+
+def test_lrc_guard_writes_when_trusted(trusted_root):
+    lrc_path = trusted_root / "track.lrc"
+    _write_lrc_guarded(trusted_root, lrc_path, "strict", "[00:01.00]la la la")
+    assert lrc_path.read_text(encoding="utf-8") == "[00:01.00]la la la"
+
+
+def test_lrc_guard_refuses_and_never_writes_when_untrusted(untrusted_root):
+    lrc_path = untrusted_root / "track.lrc"
+    with pytest.raises(da.DestinationNotTrusted) as excinfo:
+        _write_lrc_guarded(untrusted_root, lrc_path, "strict", "[00:01.00]la la la")
+
+    assert excinfo.value.check.reason == "unknown_root"
+    assert not lrc_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Operation 9: utime
+# ---------------------------------------------------------------------------
+
+def test_touch_guard_updates_mtime_when_trusted(trusted_root):
+    target = trusted_root / "track.flac"
+    target.write_bytes(b"x")
+    old_mtime = target.stat().st_mtime
+    # Force a detectable mtime change regardless of filesystem timestamp
+    # resolution by setting it in the past first.
+    os.utime(target, (old_mtime - 1000, old_mtime - 1000))
+
+    _touch_guarded(trusted_root, target, "strict")
+
+    assert target.stat().st_mtime > old_mtime - 1000
+
+
+def test_touch_guard_refuses_and_never_touches_when_untrusted(untrusted_root):
+    target = untrusted_root / "track.flac"
+    target.write_bytes(b"x")
+    os.utime(target, (0, 0))  # a known, ancient mtime
+
+    with pytest.raises(da.DestinationNotTrusted) as excinfo:
+        _touch_guarded(untrusted_root, target, "strict")
+
+    assert excinfo.value.check.reason == "unknown_root"
+    assert target.stat().st_mtime == 0  # untouched

--- a/tests/test_guarded_writes.py
+++ b/tests/test_guarded_writes.py
@@ -31,7 +31,9 @@ import pytest
 import tiddl.cli.commands.download as dlinit
 import tiddl.core.utils.destination_anchor as da
 from tiddl.cli.commands.download import (
+    _download_exit_code,
     _guarded_save_cover,
+    _should_insert_db_record,
     _touch_guarded,
     _write_lrc_guarded,
     _write_track_metadata_guarded,
@@ -434,3 +436,100 @@ def test_mkdir_guard_off_mode_returns_disabled_not_trusted(untrusted_root):
     check = _guarded_mkdir(untrusted_root, target, "off")
     assert check.reason == "disabled"
     assert check.anchor_id is None
+
+
+# ---------------------------------------------------------------------------
+# Second implementation-audit finding (2026-08-18), P2: helper-level tests
+# prove individual operations allow/refuse their own mutation, but not that
+# the surrounding call sites preserve the accepted Class B/Class C DB
+# semantics or the final command-level outcome. These pin the three
+# specific outcome behaviors the audit asked for: one Class B path, one
+# Class C path (below, in the cover section, plus test_m3u.py's own
+# addition), and the mixed-refusal exit code.
+# ---------------------------------------------------------------------------
+
+def test_class_b_withholds_db_insert_when_this_items_identity_refused():
+    # Operations 4/5/6 (.lrc, track/video metadata): a refusal sets
+    # identity_refused=True, which must withhold THIS item's _db_insert.
+    assert _should_insert_db_record(was_downloaded=True, identity_refused=True) is False
+
+
+def test_class_b_inserts_normally_when_not_refused():
+    assert _should_insert_db_record(was_downloaded=True, identity_refused=False) is True
+
+
+def test_class_b_never_inserts_for_a_skipped_item_regardless_of_refusal():
+    # was_downloaded=False (skip-existing path) never inserts, identity
+    # refusal or not — this decision doesn't invent a reason to insert.
+    assert _should_insert_db_record(was_downloaded=False, identity_refused=False) is False
+    assert _should_insert_db_record(was_downloaded=False, identity_refused=True) is False
+
+
+async def test_class_c_cover_refusal_never_touches_db_or_registry(untrusted_root, monkeypatch):
+    # Class C (v2.3 §3): operations 7/8 (M3U/cover) run AFTER every
+    # per-track DB insert has already happened, and a refusal there must
+    # never touch an already-truthful record. Spies on retained_registry to
+    # prove a cover refusal calls none of its mutating functions — it only
+    # logs and marks the tracker.
+    import tiddl.core.utils.retained_registry as registrymod
+
+    def _must_not_be_called(*a, **k):
+        pytest.fail("a cover refusal must never touch the retained registry")
+
+    monkeypatch.setattr(registrymod, "register_retained_file", _must_not_be_called)
+    monkeypatch.setattr(registrymod, "update_entry", _must_not_be_called)
+    monkeypatch.setattr(registrymod, "remove_entry", _must_not_be_called)
+
+    cover = Cover("uid-1")
+    monkeypatch.setattr(cover, "_get_data", lambda: b"jpegbytes")
+    tracker = da.IdentityFailureTracker()
+    cover_path = untrusted_root / "cover"
+
+    await _guarded_save_cover(cover, untrusted_root, cover_path, "strict", tracker, "album")
+
+    assert tracker.any_refused is True
+    assert not cover_path.with_suffix(".jpg").exists()
+
+
+def test_exit_code_is_nonzero_when_any_identity_check_refused():
+    assert _download_exit_code(True) == 1
+
+
+def test_exit_code_is_none_when_nothing_refused():
+    # None -> falls through to Typer's normal 0, not an explicit sys.exit(0)
+    # (which would bypass Typer's own post-command handling).
+    assert _download_exit_code(False) is None
+
+
+async def test_mixed_concurrent_success_and_refusal_trips_the_shared_tracker(tmp_path):
+    # "Mixed concurrent success/refusal" end to end: several guarded writes
+    # run concurrently against the SAME IdentityFailureTracker — some
+    # trusted (succeed), one untrusted (refuses) — and the tracker's
+    # monotonic any_refused correctly reflects "at least one refused",
+    # which _download_exit_code above turns into a non-zero exit. Uses the
+    # real _guarded_mkdir helper, not a mock of the tracker itself.
+    tracker = da.IdentityFailureTracker()
+    results = []
+
+    async def _item(root_name, establish):
+        root = tmp_path / root_name
+        root.mkdir()
+        if establish:
+            da.establish_anchor(root)
+        target = root / "track.flac"
+        try:
+            _guarded_mkdir(root, target, "strict")
+            results.append("ok")
+        except da.DestinationNotTrusted as e:
+            tracker.mark_refused(e.check)
+            results.append("refused")
+
+    await asyncio.gather(
+        _item("trusted_a", True),
+        _item("trusted_b", True),
+        _item("untrusted", False),
+    )
+
+    assert sorted(results) == ["ok", "ok", "refused"]
+    assert tracker.any_refused is True
+    assert _download_exit_code(tracker.any_refused) == 1

--- a/tests/test_guarded_writes.py
+++ b/tests/test_guarded_writes.py
@@ -25,13 +25,17 @@ from __future__ import annotations
 
 import asyncio
 import os
+import types
 
 import pytest
 
 import tiddl.cli.commands.download as dlinit
+import tiddl.cli.const as const_mod
 import tiddl.core.utils.destination_anchor as da
 from tiddl.cli.commands.download import (
     _download_exit_code,
+    _finalize_db_record,
+    _finish_download_run,
     _guarded_save_cover,
     _should_insert_db_record,
     _touch_guarded,
@@ -39,7 +43,8 @@ from tiddl.cli.commands.download import (
     _write_track_metadata_guarded,
     _write_video_metadata_guarded,
 )
-from tiddl.cli.commands.download.downloader import _guarded_mkdir
+from tiddl.cli.commands.download.downloader import Downloader, _guarded_mkdir
+from tiddl.core.api.models import Track, Video
 from tiddl.core.metadata import Cover, CoverDataNotPrefetched
 
 
@@ -61,6 +66,34 @@ def untrusted_root(tmp_path):
     root = tmp_path / "dest_root"
     root.mkdir()
     return root  # never establish_anchor()'d — no trust record, no marker
+
+
+class _DbOnlyDownloader:
+    """Minimal host exposing only the real Downloader._init_db/_db_insert/
+    _db_lookup — the REAL SQLite-backed DB layer `_finalize_db_record`
+    actually calls — without constructing a full `Downloader` (which needs
+    a TidalAPI, RichOutput, thread pool, etc. that have nothing to do with
+    what the Class B/C outcome tests below verify). Same pattern as
+    test_downloader.py's `_StubDownloader`: bind real methods onto a
+    lightweight host rather than mocking them."""
+
+    _init_db = Downloader._init_db
+    _db_insert = Downloader._db_insert
+    _db_lookup = Downloader._db_lookup
+
+    def __init__(self):
+        self._db = self._init_db()
+
+
+@pytest.fixture
+def db_downloader(tmp_path, monkeypatch):
+    app_dir = tmp_path / "_app"
+    app_dir.mkdir(parents=True, exist_ok=True)
+    # _init_db() does `from tiddl.cli.const import APP_PATH` locally, so the
+    # module-level attribute is what must be patched — not downloader.py's
+    # namespace (it never imports APP_PATH at module scope).
+    monkeypatch.setattr(const_mod, "APP_PATH", app_dir)
+    return _DbOnlyDownloader()
 
 
 # ---------------------------------------------------------------------------
@@ -533,3 +566,166 @@ async def test_mixed_concurrent_success_and_refusal_trips_the_shared_tracker(tmp
     assert sorted(results) == ["ok", "ok", "refused"]
     assert tracker.any_refused is True
     assert _download_exit_code(tracker.any_refused) == 1
+
+
+# ---------------------------------------------------------------------------
+# Third implementation-audit finding (2026-08-18), P2: integration coverage
+# that reaches the REAL call sites (`_finalize_db_record`, wired into
+# `handle_item`; `_finish_download_run`, wired into `run()`) instead of only
+# the pure decision helpers (`_should_insert_db_record`, `_download_exit_code`)
+# in isolation. A test of a decision helper alone keeps passing even if the
+# real call site stopped calling it, inverted its result, or wired in a
+# different function entirely — these tests exercise the actual production
+# code path: a real `_write_lrc_guarded`/`_write_video_metadata_guarded`/
+# `_guarded_save_cover` refusal, a real SQLite-backed
+# `Downloader._db_insert`/`_db_lookup` via `_finalize_db_record` (queried
+# directly, not spied on), and a real `SystemExit` via `_finish_download_run`.
+# ---------------------------------------------------------------------------
+
+def test_class_b_real_lrc_refusal_withholds_the_real_db_insert(untrusted_root, db_downloader):
+    # Class B (v2.3 §3), via the REAL call site: drive a genuine operation-4
+    # (.lrc) refusal through `_write_lrc_guarded` against an untrusted root,
+    # then call `_finalize_db_record` — the exact function `handle_item`
+    # calls — the same way `handle_item` would (identity_refused=True
+    # because THIS item's own guarded write refused). Query the real
+    # SQLite-backed `_db_lookup` (not a spy) to prove no record exists.
+    track = Track.construct(id=101, audioQuality="LOSSLESS")
+    download_path = untrusted_root / "track.flac"
+    lrc_path = untrusted_root / "track.lrc"
+
+    identity_refused = False
+    try:
+        _write_lrc_guarded(untrusted_root, lrc_path, "strict", "[00:00.00]la la la")
+    except da.DestinationNotTrusted:
+        identity_refused = True
+
+    assert identity_refused is True
+    assert not lrc_path.exists()
+
+    _finalize_db_record(
+        db_downloader, track, download_path, was_downloaded=True,
+        identity_refused=identity_refused,
+    )
+
+    assert db_downloader._db_lookup(track.id) is None
+
+
+def test_class_b_real_lrc_success_performs_the_real_db_insert(trusted_root, db_downloader):
+    # Positive control for the test above: same real call sites, but against
+    # a trusted root — the .lrc write succeeds, identity_refused stays
+    # False, and `_finalize_db_record` performs the real insert.
+    track = Track.construct(id=102, audioQuality="LOSSLESS")
+    download_path = trusted_root / "track.flac"
+    lrc_path = trusted_root / "track.lrc"
+
+    identity_refused = False
+    try:
+        _write_lrc_guarded(trusted_root, lrc_path, "strict", "[00:00.00]la la la")
+    except da.DestinationNotTrusted:
+        identity_refused = True
+
+    assert identity_refused is False
+    assert lrc_path.exists()
+
+    _finalize_db_record(
+        db_downloader, track, download_path, was_downloaded=True,
+        identity_refused=identity_refused,
+    )
+
+    assert db_downloader._db_lookup(track.id) == download_path
+
+
+def test_class_b_real_video_metadata_refusal_withholds_the_real_db_insert(
+    untrusted_root, db_downloader, monkeypatch
+):
+    # Same Class B real-call-site proof, but for operation 6 (video
+    # metadata) — the other operation class that can set
+    # identity_refused=True, this time for a Video item.
+    monkeypatch.setattr(
+        dlinit,
+        "add_video_metadata",
+        lambda **kw: pytest.fail("must not write video metadata when the identity check refuses"),
+    )
+    video = Video.construct(id=201)
+    download_path = untrusted_root / "video.mp4"
+
+    identity_refused = False
+    try:
+        _write_video_metadata_guarded(
+            untrusted_root, download_path, "strict",
+            video=video, artist_separator=" / ",
+        )
+    except da.DestinationNotTrusted:
+        identity_refused = True
+
+    assert identity_refused is True
+
+    _finalize_db_record(
+        db_downloader, video, download_path, was_downloaded=True,
+        identity_refused=identity_refused,
+    )
+
+    assert db_downloader._db_lookup(video.id) is None
+
+
+async def test_class_c_real_cover_refusal_leaves_an_already_inserted_record_untouched(
+    untrusted_root, db_downloader, monkeypatch
+):
+    # Class C (v2.3 §3), via the REAL call site: seed a REAL record in the
+    # temp DB via `_finalize_db_record` (as `handle_item` would after a
+    # successful download with no refusal), then force a REAL operation-8
+    # (cover) refusal via `_guarded_save_cover` against the same untrusted
+    # root, and prove — by querying the real SQLite DB, not a spy — that the
+    # seeded record is still present and unchanged.
+    track = Track.construct(id=301, audioQuality="LOSSLESS")
+    download_path = untrusted_root / "track.flac"
+
+    # Seed: this item's OWN writes succeeded (identity_refused=False) before
+    # the cover step runs, matching handle_item's real ordering (ops 4/5/6
+    # happen, then _finalize_db_record, then ops 7/8).
+    _finalize_db_record(
+        db_downloader, track, download_path, was_downloaded=True,
+        identity_refused=False,
+    )
+    assert db_downloader._db_lookup(track.id) == download_path
+
+    cover = Cover("uid-c")
+    monkeypatch.setattr(cover, "_get_data", lambda: b"jpegbytes")
+    tracker = da.IdentityFailureTracker()
+    cover_path = untrusted_root / "cover"
+
+    await _guarded_save_cover(cover, untrusted_root, cover_path, "strict", tracker, "album")
+
+    assert tracker.any_refused is True
+    assert not cover_path.with_suffix(".jpg").exists()
+    # The record seeded above must be exactly as it was — a cover refusal
+    # (Class C) must never touch an already-truthful per-track record.
+    assert db_downloader._db_lookup(track.id) == download_path
+
+
+def test_finish_download_run_exits_nonzero_on_a_refused_run():
+    # Mixed CLI outcome, via the REAL call site: `_finish_download_run` is
+    # what `run()` actually calls (not `_download_exit_code()` + `sys.exit()`
+    # inline) — a test of `_download_exit_code()` alone wouldn't prove
+    # `run()`'s closure still calls it, still uses its return value, or
+    # still actually exits the process.
+    printed = []
+    console = types.SimpleNamespace(print=lambda *a, **k: printed.append((a, k)))
+
+    with pytest.raises(SystemExit) as excinfo:
+        _finish_download_run(console, True)
+
+    assert excinfo.value.code == 1
+    assert len(printed) == 1
+
+
+def test_finish_download_run_exits_normally_when_nothing_refused():
+    # Positive control: no identity refusal during the run -> no SystemExit
+    # raised at all (falls through to Typer's own normal exit-0 handling)
+    # and nothing printed.
+    printed = []
+    console = types.SimpleNamespace(print=lambda *a, **k: printed.append((a, k)))
+
+    _finish_download_run(console, False)
+
+    assert printed == []

--- a/tests/test_guarded_writes.py
+++ b/tests/test_guarded_writes.py
@@ -1,0 +1,235 @@
+"""Coverage for the operation 5/6/8 guarded-write helpers in
+`tiddl.cli.commands.download` — `_write_track_metadata_guarded`,
+`_write_video_metadata_guarded`, `_guarded_save_cover`.
+
+These were extracted from inline closures inside the (untestable-in-
+isolation) `handle_item`/`download_callback` call graph specifically so the
+implementation-audit finding (2026-08-18, P1 #3 — "guards placed before
+asyncio.to_thread are not at the final mutation boundary") has direct,
+targeted regression coverage: the identity check must run INSIDE the same
+unit of work as the mutation, with no await point, sleep, or network I/O
+between "checked" and "written."
+
+Also covers a slice of the P2 finding ("seven guarded operation classes
+lack direct integration evidence") for operations 5, 6 and 8 specifically —
+the other five (1, 2, 4, 7, 9) remain covered only indirectly via
+test_downloader.py/test_destination_anchor.py, which is a real, disclosed
+gap (see the audit response)."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import tiddl.cli.commands.download as dlinit
+import tiddl.core.utils.destination_anchor as da
+from tiddl.cli.commands.download import (
+    _guarded_save_cover,
+    _write_track_metadata_guarded,
+    _write_video_metadata_guarded,
+)
+from tiddl.core.metadata import Cover
+
+
+@pytest.fixture(autouse=True)
+def _isolated_app_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(da, "APP_PATH", tmp_path / "_app")
+
+
+@pytest.fixture
+def trusted_root(tmp_path):
+    root = tmp_path / "dest_root"
+    root.mkdir()
+    da.establish_anchor(root)
+    return root
+
+
+@pytest.fixture
+def untrusted_root(tmp_path):
+    root = tmp_path / "dest_root"
+    root.mkdir()
+    return root  # never establish_anchor()'d — no trust record, no marker
+
+
+# ---------------------------------------------------------------------------
+# Operation 5: track metadata
+# ---------------------------------------------------------------------------
+
+def test_track_metadata_guard_writes_when_trusted(trusted_root, monkeypatch):
+    calls = []
+    monkeypatch.setattr(dlinit, "add_track_metadata", lambda **kw: calls.append(kw))
+
+    download_path = trusted_root / "track.flac"
+    _write_track_metadata_guarded(
+        trusted_root, download_path, "strict",
+        track="TRACK", lyrics="", album_artist="A", cover_data=None,
+        date="", credits=None, comment="", genre=None, artist_separator="; ",
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["path"] == download_path
+    assert calls[0]["track"] == "TRACK"
+
+
+def test_track_metadata_guard_refuses_and_never_writes_when_untrusted(
+    untrusted_root, monkeypatch
+):
+    calls = []
+    monkeypatch.setattr(dlinit, "add_track_metadata", lambda **kw: calls.append(kw))
+
+    download_path = untrusted_root / "track.flac"
+    with pytest.raises(da.DestinationNotTrusted) as excinfo:
+        _write_track_metadata_guarded(
+            untrusted_root, download_path, "strict",
+            track="TRACK", lyrics="", album_artist="A", cover_data=None,
+            date="", credits=None, comment="", genre=None, artist_separator="; ",
+        )
+
+    assert excinfo.value.check.reason == "unknown_root"
+    assert calls == []  # the mutation never ran
+
+
+async def test_track_metadata_guard_propagates_through_to_thread(
+    untrusted_root, monkeypatch
+):
+    # Mirrors the real call site: `await asyncio.to_thread(_write_track_
+    # metadata_guarded, ...)`. Proves DestinationNotTrusted survives the
+    # thread hop intact so the event-loop caller can catch it and mark the
+    # tracker there (v2.4 mandatory safeguard #2) — never inside the worker.
+    monkeypatch.setattr(dlinit, "add_track_metadata", lambda **kw: pytest.fail("must not write"))
+
+    download_path = untrusted_root / "track.flac"
+    with pytest.raises(da.DestinationNotTrusted):
+        await asyncio.to_thread(
+            _write_track_metadata_guarded,
+            untrusted_root, download_path, "strict",
+            track="TRACK", lyrics="", album_artist="A", cover_data=None,
+            date="", credits=None, comment="", genre=None, artist_separator="; ",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Operation 6: video metadata
+# ---------------------------------------------------------------------------
+
+def test_video_metadata_guard_writes_when_trusted(trusted_root, monkeypatch):
+    calls = []
+    monkeypatch.setattr(dlinit, "add_video_metadata", lambda **kw: calls.append(kw))
+
+    download_path = trusted_root / "video.mp4"
+    _write_video_metadata_guarded(
+        trusted_root, download_path, "strict",
+        video="VIDEO", artist_separator="; ",
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["path"] == download_path
+
+
+def test_video_metadata_guard_refuses_and_never_writes_when_untrusted(
+    untrusted_root, monkeypatch
+):
+    calls = []
+    monkeypatch.setattr(dlinit, "add_video_metadata", lambda **kw: calls.append(kw))
+
+    download_path = untrusted_root / "video.mp4"
+    with pytest.raises(da.DestinationNotTrusted) as excinfo:
+        _write_video_metadata_guarded(
+            untrusted_root, download_path, "strict",
+            video="VIDEO", artist_separator="; ",
+        )
+
+    assert excinfo.value.check.reason == "unknown_root"
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Operation 8: cover write
+# ---------------------------------------------------------------------------
+
+async def test_cover_guard_writes_when_trusted(trusted_root, monkeypatch):
+    cover = Cover("uid-1")
+    monkeypatch.setattr(cover, "_get_data", lambda: b"jpegbytes")
+    tracker = da.IdentityFailureTracker()
+    cover_path = trusted_root / "cover"
+
+    await _guarded_save_cover(cover, trusted_root, cover_path, "strict", tracker, "album")
+
+    assert cover_path.with_suffix(".jpg").read_bytes() == b"jpegbytes"
+    assert tracker.any_refused is False
+
+
+async def test_cover_guard_refuses_and_never_writes_when_untrusted(
+    untrusted_root, monkeypatch
+):
+    cover = Cover("uid-1")
+    monkeypatch.setattr(cover, "_get_data", lambda: b"jpegbytes")
+    tracker = da.IdentityFailureTracker()
+    cover_path = untrusted_root / "cover"
+
+    await _guarded_save_cover(cover, untrusted_root, cover_path, "strict", tracker, "album")
+
+    assert not cover_path.with_suffix(".jpg").exists()
+    assert tracker.any_refused is True
+    assert tracker.first_refusal.reason == "unknown_root"
+
+
+async def test_cover_guard_skips_fetch_and_check_when_file_already_exists(
+    untrusted_root, monkeypatch
+):
+    # Matches the pre-existing Cover.save_to_directory contract: an
+    # existing file short-circuits before any network I/O or identity
+    # check — including on an untrusted root, since nothing is being
+    # written. Proves _get_data() is never called (would raise if it were).
+    cover_path = untrusted_root / "cover"
+    cover_path.with_suffix(".jpg").write_bytes(b"already-here")
+
+    cover = Cover("uid-1")
+    monkeypatch.setattr(cover, "_get_data", lambda: pytest.fail("must not fetch"))
+    tracker = da.IdentityFailureTracker()
+
+    await _guarded_save_cover(cover, untrusted_root, cover_path, "strict", tracker, "album")
+
+    assert cover_path.with_suffix(".jpg").read_bytes() == b"already-here"
+    assert tracker.any_refused is False
+
+
+async def test_cover_guard_closes_the_fetch_to_write_toctou_gap(trusted_root, monkeypatch):
+    # THE regression test for the audit's P1 #3 finding: the destination
+    # becomes untrusted DURING the (network) fetch — after the old
+    # pre-dispatch check would already have passed, but before the actual
+    # write. The old code (check on the event loop, then
+    # `to_thread(cover.save_to_directory, ...)` which fetches-then-writes
+    # inside the worker) would have published the cover anyway, because its
+    # only check happened before the fetch ran. The new code fetches first,
+    # then checks immediately before writing — so this must refuse.
+    cover = Cover("uid-1")
+
+    def _fetch_then_destination_disappears():
+        # Simulates the mount vanishing mid-network-fetch (a slow cover
+        # download over several retries is exactly the kind of gap the
+        # audit flagged).
+        da.marker_path(trusted_root).unlink()
+        return b"jpegbytes"
+
+    monkeypatch.setattr(cover, "_get_data", _fetch_then_destination_disappears)
+    tracker = da.IdentityFailureTracker()
+    cover_path = trusted_root / "cover"
+
+    await _guarded_save_cover(cover, trusted_root, cover_path, "strict", tracker, "album")
+
+    assert not cover_path.with_suffix(".jpg").exists()  # never published
+    assert tracker.any_refused is True
+    assert tracker.first_refusal.reason == "marker_absent"
+
+
+async def test_cover_guard_off_mode_never_checks(untrusted_root, monkeypatch):
+    cover = Cover("uid-1")
+    monkeypatch.setattr(cover, "_get_data", lambda: b"jpegbytes")
+    tracker = da.IdentityFailureTracker()
+    cover_path = untrusted_root / "cover"
+
+    await _guarded_save_cover(cover, untrusted_root, cover_path, "off", tracker, "album")
+
+    assert cover_path.with_suffix(".jpg").read_bytes() == b"jpegbytes"
+    assert tracker.any_refused is False

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -74,6 +74,34 @@ def test_strict_mode_untrusted_root_refuses_and_trips_the_tracker(tmp_path):
     assert tracker.any_refused is True
 
 
+def test_class_c_refusal_never_touches_db_or_registry(tmp_path, monkeypatch):
+    # Second implementation-audit finding (2026-08-18), P2: Class C (v2.3
+    # §3) — every track in this M3U already has its own truthful
+    # `_db_insert` record by the time this runs, and a refusal here must
+    # never touch it. Spies on retained_registry to prove no registry
+    # function is called during an M3U refusal — matches
+    # test_guarded_writes.py's analogous cover test.
+    import tiddl.core.utils.retained_registry as registrymod
+
+    def _must_not_be_called(*a, **k):
+        pytest.fail("an m3u refusal must never touch the retained registry")
+
+    monkeypatch.setattr(registrymod, "register_retained_file", _must_not_be_called)
+    monkeypatch.setattr(registrymod, "update_entry", _must_not_be_called)
+    monkeypatch.setattr(registrymod, "remove_entry", _must_not_be_called)
+
+    root = tmp_path / "dest"
+    root.mkdir()
+    path = root / "playlist"
+    tracker = da.IdentityFailureTracker()
+    save_tracks_to_m3u(
+        [(root / "t.flac", _fake_track())], path,
+        root=root, mode="strict", tracker=tracker,
+    )
+    assert not (root / "playlist.m3u").exists()
+    assert tracker.any_refused is True
+
+
 def test_strict_mode_refusal_without_a_tracker_does_not_raise(tmp_path):
     # tracker is optional too — a caller not threading one through still
     # gets a safe refusal, not an AttributeError on None.

--- a/tests/test_m3u.py
+++ b/tests/test_m3u.py
@@ -1,0 +1,101 @@
+"""Coverage for tiddl.core.utils.m3u.save_tracks_to_m3u's destination-volume
+identity guard (operation 7, see tiddl.core.utils.destination_anchor and
+PROPOSAL_destination_volume_identity_v2_1..v2_4.md, kept local/untracked).
+
+Pre-existing behavior (no root/mode/tracker passed) is exercised too, since
+those parameters are optional precisely so callers that predate this feature
+(direct unit tests of this function, before this PR) keep working unchanged.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import tiddl.core.utils.destination_anchor as da
+from tiddl.core.utils.m3u import save_tracks_to_m3u
+
+
+@pytest.fixture(autouse=True)
+def _isolated_anchor_app_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(da, "APP_PATH", tmp_path / "_app")
+
+
+def _fake_track(title="T", duration=180, artist_name="A"):
+    artist = types.SimpleNamespace(name=artist_name) if artist_name else None
+    return types.SimpleNamespace(title=title, duration=duration, artist=artist)
+
+
+def test_no_root_given_skips_the_guard_entirely(tmp_path):
+    # Backward compatible: a caller that doesn't pass root/mode (mode stays
+    # the "off" default) never touches destination_anchor's I/O at all.
+    path = tmp_path / "playlist"
+    save_tracks_to_m3u([(tmp_path / "t.flac", _fake_track())], path)
+    assert (tmp_path / "playlist.m3u").exists()
+
+
+def test_off_mode_writes_even_with_no_trust_record(tmp_path):
+    root = tmp_path / "dest"
+    root.mkdir()
+    path = root / "playlist"
+    save_tracks_to_m3u(
+        [(root / "t.flac", _fake_track())], path, root=root, mode="off",
+    )
+    assert (root / "playlist.m3u").exists()
+
+
+def test_strict_mode_trusted_root_writes_normally(tmp_path):
+    root = tmp_path / "dest"
+    root.mkdir()
+    da.establish_anchor(root)
+    path = root / "playlist"
+    tracker = da.IdentityFailureTracker()
+    save_tracks_to_m3u(
+        [(root / "t.flac", _fake_track())], path,
+        root=root, mode="strict", tracker=tracker,
+    )
+    assert (root / "playlist.m3u").exists()
+    assert tracker.any_refused is False
+
+
+def test_strict_mode_untrusted_root_refuses_and_trips_the_tracker(tmp_path):
+    root = tmp_path / "dest"
+    root.mkdir()
+    path = root / "playlist"
+    tracker = da.IdentityFailureTracker()
+    save_tracks_to_m3u(
+        [(root / "t.flac", _fake_track())], path,
+        root=root, mode="strict", tracker=tracker,
+    )
+    # Class C (v2.3 §3): no exception escapes this function — matches its
+    # existing "log and return" contract for every other failure mode here
+    # (see the except Exception clause below the guard).
+    assert not (root / "playlist.m3u").exists()
+    assert tracker.any_refused is True
+
+
+def test_strict_mode_refusal_without_a_tracker_does_not_raise(tmp_path):
+    # tracker is optional too — a caller not threading one through still
+    # gets a safe refusal, not an AttributeError on None.
+    root = tmp_path / "dest"
+    root.mkdir()
+    path = root / "playlist"
+    save_tracks_to_m3u(
+        [(root / "t.flac", _fake_track())], path, root=root, mode="strict",
+    )
+    assert not (root / "playlist.m3u").exists()
+
+
+def test_empty_tracklist_still_short_circuits_before_the_guard(tmp_path, monkeypatch):
+    # Pre-existing behavior: no tracks -> warn and return, never even reaching
+    # the identity guard (asserted by making the guard explode if reached).
+    root = tmp_path / "dest"
+    root.mkdir()
+    path = root / "playlist"
+
+    def _boom(*a, **k):
+        raise AssertionError("guard must not run when there are no tracks")
+
+    monkeypatch.setattr(da, "assert_write_allowed", _boom)
+    save_tracks_to_m3u([], path, root=root, mode="strict")
+    assert not (root / "playlist.m3u").exists()

--- a/tests/test_recover_cli.py
+++ b/tests/test_recover_cli.py
@@ -539,6 +539,68 @@ def test_bind_root_refuses_an_already_identified_entry(tmp_path):
     assert "already has a destination identity" in result.output
 
 
+def test_bind_root_refuses_if_marker_disappears_during_confirmation(tmp_path, monkeypatch):
+    # Implementation-audit finding (2026-08-18), P1 #4: the original code
+    # re-read the marker independently (`anchor.read_marker(root)`),
+    # uncoordinated with the earlier `check_write_allowed` call, and never
+    # accounted for the confirmation prompt itself taking arbitrary real
+    # time. Simulates the destination disappearing WHILE the user is still
+    # looking at the "Proceed?" prompt — the persisted pair must come from
+    # a check re-run AFTER confirmation, not the stale pre-prompt one.
+    import tiddl.cli.commands.recover as recovermod
+    import tiddl.core.utils.destination_anchor as da
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="B7")
+    root = dest.parent
+    da.establish_anchor(root)
+
+    def _confirm_then_vanish(*args, **kwargs):
+        da.marker_path(root).unlink()
+        return True
+
+    monkeypatch.setattr(recovermod.typer, "confirm", _confirm_then_vanish)
+
+    result = runner.invoke(app, ["recover", "--bind-root", entry.id[:8], "--root", str(root)])
+    assert result.exit_code == 1
+    normalized = " ".join(_strip_ansi(result.output).split())
+    assert "no longer trusted" in normalized
+    # Byte-for-byte unchanged — never a half-written destination_root/
+    # destination_anchor_id pair (the both-or-neither invariant).
+    unchanged = reg.read_entries().entries[0]
+    assert unchanged.destination_root is None
+    assert unchanged.destination_anchor_id is None
+
+
+def test_bind_root_persists_the_post_confirmation_anchor_when_it_changed(tmp_path, monkeypatch):
+    # The marker can also CHANGE (not just vanish) during confirmation —
+    # e.g. a concurrent forget + re-trust with a new anchor id. The
+    # persisted id must be the fresh, post-confirmation one, never the
+    # stale pre-prompt id that the first check happened to see.
+    import tiddl.cli.commands.recover as recovermod
+    import tiddl.core.utils.destination_anchor as da
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="B8")
+    root = dest.parent
+    old_anchor_id = da.establish_anchor(root)
+
+    new_anchor_id = None
+
+    def _confirm_then_retrust(*args, **kwargs):
+        nonlocal new_anchor_id
+        da.forget_anchor(root)
+        da.marker_path(root).unlink()
+        new_anchor_id = da.establish_anchor(root)
+        return True
+
+    monkeypatch.setattr(recovermod.typer, "confirm", _confirm_then_retrust)
+
+    result = runner.invoke(app, ["recover", "--bind-root", entry.id[:8], "--root", str(root)])
+    assert result.exit_code == 0
+    assert new_anchor_id is not None and new_anchor_id != old_anchor_id
+    bound = reg.read_entries().entries[0]
+    assert bound.destination_anchor_id == new_anchor_id
+
+
 def test_strict_mode_legacy_entry_refuses_and_names_bind_root(tmp_path, _strict_mode):
     entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="S1")
     result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])

--- a/tests/test_recover_cli.py
+++ b/tests/test_recover_cli.py
@@ -9,6 +9,7 @@ command (see cli/commands/recover.py's module docstring).
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,21 @@ import tiddl.core.utils.retained_registry as reg
 from tiddl.cli.app import app
 
 runner = CliRunner()
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Rich renders styled spans as separate ANSI-wrapped runs (e.g. the
+    tail of one colored phrase and the head of the next can be split across
+    a word-wrapped line with no literal space between them once codes are
+    left in) — a plain `" ".join(text.split())` flattens *whitespace* but
+    can still leave escape codes sitting inside what should be one
+    contiguous phrase. Strip the codes first, then flatten whitespace, so
+    substring assertions are robust to wherever Rich happens to wrap a
+    given run (which varies with the length of the tmp_path-derived text
+    embedded in these messages, not just the terminal width)."""
+    return _ANSI_RE.sub("", text)
 
 
 @pytest.fixture(autouse=True)
@@ -411,3 +427,196 @@ def test_recover_purge_refuses_on_unreadable_registry_without_crashing(tmp_path,
     # APP_PATH-isolation patch (same fixture instance).
     with open(reg.registry_path(), "rb") as f:
         assert f.read() == original  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Destination-volume identity: --bind-root + the strict-mode triple-identity
+# check (PROPOSAL_destination_volume_identity_v2_1.md sections 6-7, kept
+# local/untracked — not part of this diff).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_anchor_app_path(tmp_path, monkeypatch):
+    import tiddl.core.utils.destination_anchor as da
+
+    monkeypatch.setattr(da, "APP_PATH", tmp_path / "_app")
+    return da
+
+
+@pytest.fixture
+def _strict_mode(monkeypatch):
+    from tiddl.cli.config import CONFIG
+
+    monkeypatch.setattr(CONFIG.download, "destination_identity", "strict")
+
+
+def test_bind_root_requires_root_option(tmp_path):
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="B1")
+    result = runner.invoke(app, ["recover", "--bind-root", entry.id[:8]])
+    assert result.exit_code == 1
+    assert "--root" in result.output
+
+
+def test_bind_root_refuses_untrusted_root(tmp_path):
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="B2")
+    untrusted_root = dest.parent
+    result = runner.invoke(
+        app, ["recover", "--bind-root", entry.id[:8], "--root", str(untrusted_root)]
+    )
+    assert result.exit_code == 1
+    # Rich word-wraps at the detected console width, which can split a
+    # literal phrase across a line break depending on how long the
+    # tmp_path-derived string embedded in the message is (see the
+    # analogous comment above on test_recover_publish_one_missing_dest) —
+    # strip ANSI styling and normalize whitespace before substring-checking.
+    normalized = " ".join(_strip_ansi(result.output).split())
+    assert "not currently trusted" in normalized
+    assert reg.read_entries().entries[0].destination_root is None
+
+
+def test_bind_root_refuses_output_outside_root(tmp_path):
+    import tiddl.core.utils.destination_anchor as da
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="B3")
+    other_root = tmp_path / "unrelated_root"
+    other_root.mkdir()
+    da.establish_anchor(other_root)
+
+    result = runner.invoke(
+        app, ["recover", "--bind-root", entry.id[:8], "--root", str(other_root), "--confirm"]
+    )
+    assert result.exit_code == 1
+    normalized = " ".join(_strip_ansi(result.output).split())
+    assert "not contained" in normalized
+    assert reg.read_entries().entries[0].destination_root is None
+
+
+def test_bind_root_confirmed_binds_the_entry(tmp_path):
+    import tiddl.core.utils.destination_anchor as da
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="B4")
+    root = dest.parent
+    anchor_id = da.establish_anchor(root)
+
+    result = runner.invoke(
+        app, ["recover", "--bind-root", entry.id[:8], "--root", str(root), "--confirm"]
+    )
+    assert result.exit_code == 0
+    assert "Bound" in result.output
+
+    bound = reg.read_entries().entries[0]
+    assert bound.destination_root == da.root_key(root)
+    assert bound.destination_anchor_id == anchor_id
+
+
+def test_bind_root_declined_confirmation_changes_nothing(tmp_path):
+    import tiddl.core.utils.destination_anchor as da
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="B5")
+    root = dest.parent
+    da.establish_anchor(root)
+
+    result = runner.invoke(
+        app, ["recover", "--bind-root", entry.id[:8], "--root", str(root)], input="n\n"
+    )
+    assert result.exit_code == 1
+    assert reg.read_entries().entries[0].destination_root is None
+
+
+def test_bind_root_refuses_an_already_identified_entry(tmp_path):
+    import tiddl.core.utils.destination_anchor as da
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="B6")
+    root = dest.parent
+    da.establish_anchor(root)
+    reg.update_entry(entry.id, destination_root="/already/set", destination_anchor_id="x" * 32)
+
+    result = runner.invoke(
+        app, ["recover", "--bind-root", entry.id[:8], "--root", str(root), "--confirm"]
+    )
+    assert result.exit_code == 1
+    assert "already has a destination identity" in result.output
+
+
+def test_strict_mode_legacy_entry_refuses_and_names_bind_root(tmp_path, _strict_mode):
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="S1")
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    assert result.exit_code != 0
+    assert "--bind-root" in result.output
+    assert dest.exists() is False  # nothing was published
+    assert reg.read_entries().entries[0].id == entry.id  # entry untouched
+
+
+def test_strict_mode_bound_entry_with_matching_anchor_recovers(tmp_path, _strict_mode):
+    import tiddl.core.utils.destination_anchor as da
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="S2")
+    root = dest.parent
+    anchor_id = da.establish_anchor(root)
+    reg.update_entry(
+        entry.id, destination_root=da.root_key(root), destination_anchor_id=anchor_id
+    )
+
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    assert result.exit_code == 0
+    assert dest.exists()
+    assert reg.read_entries().entries == []
+
+
+def test_strict_mode_forget_and_re_trust_makes_a_previously_valid_entry_refuse(
+    tmp_path, _strict_mode
+):
+    # The v2 audit's triple-identity regression case, exercised end-to-end
+    # through the CLI: an entry bound against an OLD anchor must not
+    # silently pass once the root is re-trusted with a NEW one.
+    import tiddl.core.utils.destination_anchor as da
+
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="S3")
+    root = dest.parent
+    old_anchor_id = da.establish_anchor(root)
+    reg.update_entry(
+        entry.id, destination_root=da.root_key(root), destination_anchor_id=old_anchor_id
+    )
+
+    da.forget_anchor(root)
+    (root / da.MARKER_FILENAME).unlink()
+    da.establish_anchor(root)  # new anchor id
+
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    assert result.exit_code != 0
+    assert "id_mismatch" in result.output
+    assert dest.exists() is False
+    assert reg.read_entries().entries[0].id == entry.id  # nothing destroyed on refusal
+
+
+def test_off_mode_legacy_entry_recovers_unchanged(tmp_path):
+    # destination_identity defaults to "off" — existing (pre-feature)
+    # behavior for a legacy entry must be completely unaffected.
+    entry, dest = _make_retained(tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="S4")
+    result = runner.invoke(app, ["recover", "--publish", entry.id[:8]])
+    assert result.exit_code == 0
+    assert dest.exists()
+
+
+def test_batch_all_returns_nonzero_if_any_targets_identity_check_fails(tmp_path, _strict_mode):
+    import tiddl.core.utils.destination_anchor as da
+
+    ok_entry, ok_dest = _make_retained(
+        tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="S5a"
+    )
+    root = ok_dest.parent
+    anchor_id = da.establish_anchor(root)
+    reg.update_entry(
+        ok_entry.id, destination_root=da.root_key(root), destination_anchor_id=anchor_id
+    )
+
+    legacy_entry, legacy_dest = _make_retained(
+        tmp_path, reg.RetainReason.PUBLISH_PENDING, track_title="S5b"
+    )
+
+    result = runner.invoke(app, ["recover", "--all", "--yes"])
+    assert result.exit_code != 0  # legacy entry's refusal makes the batch non-zero
+    assert ok_dest.exists()  # but the trusted one still succeeded
+    remaining_ids = {e.id for e in reg.read_entries().entries}
+    assert remaining_ids == {legacy_entry.id}  # only the refused one is left

--- a/tests/test_retained_registry.py
+++ b/tests/test_retained_registry.py
@@ -975,3 +975,145 @@ def test_recovery_converges_via_reconcile_and_cli_if_interrupted_after_publish(
     assert "already converged" in cli_result.output
     assert dest.read_bytes() == content  # untouched by the convergence
     assert reg.read_entries().entries == []
+
+
+# ---------------------------------------------------------------------------
+# Destination-volume identity: REGISTRY_VERSION 1 -> 2, destination_root/
+# destination_anchor_id (PROPOSAL_destination_volume_identity_v2_2.md/
+# v2_3.md §4, kept local/untracked — not part of this diff).
+# ---------------------------------------------------------------------------
+
+
+def test_registry_version_1_parses_cleanly_as_all_legacy_entries():
+    payload = {
+        "version": 1,
+        "entries": [
+            {
+                "id": "abc123",
+                "reason": "publish_pending",
+                "staging_path": "/tmp/x.bin",
+                "output_path": "/mnt/nas/x.bin",
+                "observed_size": 100,
+                "observed_hash": "deadbeef",
+                "created_at": "2026-01-01T00:00:00+00:00",
+            }
+        ],
+    }
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_bytes(json.dumps(payload).encode("utf-8"))
+
+    result = reg.read_entries()
+    assert result.status == "valid"
+    assert len(result.entries) == 1
+    assert result.entries[0].destination_root is None
+    assert result.entries[0].destination_anchor_id is None
+
+
+def test_first_mutation_upgrades_a_v1_registry_to_v2_in_place():
+    payload = {
+        "version": 1,
+        "entries": [
+            {
+                "id": "abc123",
+                "reason": "publish_pending",
+                "staging_path": "/tmp/x.bin",
+                "output_path": "/mnt/nas/x.bin",
+                "observed_size": 100,
+                "observed_hash": "deadbeef",
+                "created_at": "2026-01-01T00:00:00+00:00",
+            }
+        ],
+    }
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_bytes(json.dumps(payload).encode("utf-8"))
+
+    reg.update_entry("abc123", observed_size=200)
+
+    on_disk = json.loads(reg.registry_path().read_bytes())
+    assert on_disk["version"] == 2
+    assert on_disk["entries"][0]["observed_size"] == 200
+
+
+def test_v2_entry_with_only_one_destination_field_set_is_corrupt():
+    entry = _entry(destination_root="/mnt/nas/music")  # anchor id left unset -> None
+    payload = {"version": 2, "entries": [entry.to_json_dict()]}
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_bytes(json.dumps(payload).encode("utf-8"))
+
+    result = reg.read_entries()
+    assert result.status == "corrupt"
+
+
+def test_v2_entry_with_both_destination_fields_set_parses_cleanly():
+    entry = _entry(destination_root="/mnt/nas/music", destination_anchor_id="deadbeef" * 4)
+    reg.add_entry(entry)
+
+    result = reg.read_entries()
+    assert result.status == "valid"
+    assert result.entries[0].destination_root == "/mnt/nas/music"
+    assert result.entries[0].destination_anchor_id == "deadbeef" * 4
+
+
+def test_an_artificially_future_registry_version_is_unsupported_not_guessed_at():
+    payload = {"version": 3, "entries": []}
+    reg.registry_path().parent.mkdir(parents=True, exist_ok=True)
+    reg.registry_path().write_bytes(json.dumps(payload).encode("utf-8"))
+
+    result = reg.read_entries()
+    assert result.status == "unsupported_version"
+
+    # A read-only listing must not have touched the file.
+    assert json.loads(reg.registry_path().read_bytes())["version"] == 3
+
+
+def test_older_build_mutation_against_a_v2_registry_backs_up_then_resets_active_state():
+    # Simulates an "older build" (REGISTRY_VERSION == 1) encountering a
+    # version-2 registry during a MUTATION — not just a read-only listing.
+    # Confirms the corrected downgrade claim in
+    # PROPOSAL_destination_volume_identity_v2_3.md §4: the older build's own
+    # mutation backs up the v2 content (preserved, not lost outright) but
+    # then writes back a registry containing only ITS OWN change — the
+    # pre-existing v2 entries drop out of the ACTIVE file.
+    v2_entry = _entry(id="v2-entry", destination_root="/r", destination_anchor_id="a" * 32)
+    reg.add_entry(v2_entry)
+    assert json.loads(reg.registry_path().read_bytes())["version"] == 2
+
+    with monkeypatch_module_attr(reg, "REGISTRY_VERSION", 1), monkeypatch_module_attr(
+        reg, "_LEGACY_READABLE_VERSIONS", frozenset()
+    ):
+        new_entry = _entry(id="old-build-entry")
+        reg.add_entry(new_entry)
+
+    on_disk = json.loads(reg.registry_path().read_bytes())
+    assert on_disk["version"] == 1
+    assert [e["id"] for e in on_disk["entries"]] == ["old-build-entry"]
+
+    backups = list(reg.registry_path().parent.glob("*.unsupported_version-*.bak"))
+    assert len(backups) == 1
+    backed_up = json.loads(backups[0].read_bytes())
+    assert backed_up["version"] == 2
+    assert [e["id"] for e in backed_up["entries"]] == ["v2-entry"]
+
+
+class monkeypatch_module_attr:
+    """Tiny context-manager wrapper around setattr/delattr so two module
+    attributes can be patched together in a single `with`, restored on
+    exit regardless of the block's outcome. pytest's `monkeypatch` fixture
+    isn't available inside a plain `with` block outside a test function
+    signature, and this test needs the patch scoped tightly around a single
+    mutation rather than the whole test."""
+
+    _MISSING = object()
+
+    def __init__(self, obj, name, value):
+        self.obj, self.name, self.value = obj, name, value
+        self._original = self._MISSING
+
+    def __enter__(self):
+        self._original = getattr(self.obj, self.name)
+        setattr(self.obj, self.name, self.value)
+        return self
+
+    def __exit__(self, *exc):
+        setattr(self.obj, self.name, self._original)
+        return False

--- a/tiddl/cli/commands/__init__.py
+++ b/tiddl/cli/commands/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typer import Typer
 
 from .auth import auth_command
+from .destination import destination_command
 from .download import download_command
 from .info import info_command
 from .recover import recover_command
@@ -11,6 +12,7 @@ from .recover import recover_command
 
 COMMANDS = [
     auth_command,
+    destination_command,
     download_command,
     info_command,
     recover_command,

--- a/tiddl/cli/commands/destination.py
+++ b/tiddl/cli/commands/destination.py
@@ -1,0 +1,238 @@
+"""`tiddl destination trust/status/forget` — administer destination-volume
+identity trust records (see `tiddl.core.utils.destination_anchor`).
+
+Deliberately the ONLY place that mutates anchor state. A download or
+`tiddl recover` never creates, replaces, adopts, or rotates an anchor,
+under any flag, in any mode (PROPOSAL_destination_volume_identity_v2_1.md
+§2, kept local/untracked) — enforced by construction: no code path outside
+this module calls `establish_anchor`/`adopt_anchor`/`forget_anchor`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from typing_extensions import Annotated
+
+from tiddl.core.utils import destination_anchor as da
+
+console = Console()
+
+destination_command = typer.Typer(
+    name="destination",
+    help="Manage destination-volume identity trust records.",
+    no_args_is_help=True,
+)
+
+
+def _print_state_status_warning(status: str) -> None:
+    # Mirrors cli/commands/recover.py's _print_registry_status_warning: this
+    # describes only what has verifiably happened (a read-only listing never
+    # mutates the file), matching retained_registry's own precedent.
+    if status == "corrupt":
+        console.print(
+            f"[yellow]⚠️  The destination-anchor local state at {da.anchor_state_path()} "
+            "could not be parsed. It has NOT been modified by this listing; a future "
+            "trust/forget will back it up before writing a fresh one.[/]"
+        )
+    elif status == "unsupported_version":
+        console.print(
+            "[yellow]⚠️  The destination-anchor local state is from a newer/unknown "
+            "version of tiddl. It has NOT been modified by this listing.[/]"
+        )
+    elif status == "unreadable":
+        console.print(
+            f"[red]⚠️  The destination-anchor local state at {da.anchor_state_path()} "
+            "could not be read (see the logs for the exact I/O error). It has NOT been "
+            "modified. Any trust/forget will refuse until this is resolved.[/]"
+        )
+
+
+_CONFIRM_PROMPT = (
+    "Only continue if you've confirmed this is the real, currently-mounted "
+    "destination — not a fallback local directory. Proceed?"
+)
+
+
+@destination_command.command()
+def trust(
+    path: Annotated[Path, typer.Argument(help="The destination root to trust.")],
+    confirm_mounted: Annotated[
+        bool,
+        typer.Option(
+            "--confirm-mounted",
+            help="Skip the confirmation prompt (scripted/unattended use).",
+        ),
+    ] = False,
+    adopt_existing: Annotated[
+        bool,
+        typer.Option(
+            "--adopt-existing",
+            help=(
+                "Adopt an anchor another installation already created at this root, "
+                "instead of creating a new one. Never modifies the destination."
+            ),
+        ),
+    ] = False,
+):
+    """Explicitly trust PATH as a real destination root.
+
+    Never run automatically by a download or by `tiddl recover` — this is a
+    deliberate administrative act, exactly like `tiddl auth import-orpheus
+    --trust-pickle` is for a different kind of trust decision in this project.
+    """
+    root = Path(path)
+
+    if not root.exists():
+        console.print(
+            f"[red]'{root}' does not exist. 'trust' never creates the destination — "
+            "create/mount it yourself first, then re-run this command.[/]"
+        )
+        raise typer.Exit(1)
+    if not root.is_dir():
+        console.print(f"[red]'{root}' is not a directory.[/]")
+        raise typer.Exit(1)
+
+    marker_status, marker_anchor_id, marker_detail = da.read_marker(root)
+
+    if marker_status in ("unreadable", "invalid"):
+        console.print(
+            f"[red]The existing marker at {da.marker_path(root)} is {marker_status} "
+            f"({marker_detail}). Never silently adopted or overwritten — resolve this "
+            "manually (e.g. delete a corrupted marker) before trusting this root.[/]"
+        )
+        raise typer.Exit(1)
+
+    if marker_status == "trusted":
+        state = da.read_state()
+        if state.status == "unreadable":
+            console.print(
+                f"[red]Local anchor state at {da.anchor_state_path()} could not be "
+                "read — refusing to proceed until this is resolved.[/]"
+            )
+            raise typer.Exit(1)
+
+        record = None
+        if state.status == "valid":
+            record = da.find_record(state.records, da.root_key(root))
+        if record is not None and record.anchor_id == marker_anchor_id:
+            console.print(
+                f"[green]'{root}' is already trusted (anchor {marker_anchor_id[:8]}...). "
+                "Nothing to do.[/]"
+            )
+            return
+
+        if not adopt_existing:
+            console.print(
+                f"[yellow]A marker already exists at {da.marker_path(root)}, but it "
+                "doesn't match what this machine has recorded (or nothing is recorded "
+                "here yet). If this is genuinely a shared root another installation "
+                "already trusts, re-run with [bold]--adopt-existing[/].[/]"
+            )
+            raise typer.Exit(1)
+
+        console.print(f"About to adopt the existing anchor at {da.marker_path(root)} for '{root}'.")
+        if not confirm_mounted and not typer.confirm(_CONFIRM_PROMPT):
+            console.print("[yellow]Aborted — nothing changed.[/]")
+            raise typer.Exit(1)
+        try:
+            anchor_id = da.adopt_anchor(root)
+        except (
+            da.LocalStateReadError,
+            da.LocalStateLockTimeout,
+            da.LocalStatePreservationError,
+            ValueError,
+        ) as e:
+            console.print(f"[red]Could not adopt the existing anchor: {e}[/]")
+            raise typer.Exit(1)
+        console.print(f"[green]Adopted anchor {anchor_id[:8]}... for '{root}'.[/]")
+        return
+
+    # marker_status == "absent": genuinely establishing a new anchor.
+    console.print(f"About to trust '{root}' as a real destination root.")
+    if not confirm_mounted and not typer.confirm(_CONFIRM_PROMPT):
+        console.print("[yellow]Aborted — nothing changed.[/]")
+        raise typer.Exit(1)
+    try:
+        anchor_id = da.establish_anchor(root)
+    except da.AnchorAlreadyExists:
+        console.print(
+            f"[red]A marker appeared at {da.marker_path(root)} while confirming (a race "
+            f"with another process) — re-run 'tiddl destination trust {root}' to pick it up.[/]"
+        )
+        raise typer.Exit(1)
+    except (da.LocalStateReadError, da.LocalStateLockTimeout, da.LocalStatePreservationError) as e:
+        # Partial-failure rule (PROPOSAL v2.1 §13): the marker is the
+        # authoritative artifact and is left in place even though recording
+        # it locally failed — never deleted to "undo" this.
+        console.print(
+            f"[yellow]The destination marker was created, but recording it locally "
+            f"failed ({e}). The marker is intact — re-run "
+            f"'tiddl destination trust {root} --adopt-existing' to pick it up.[/]"
+        )
+        raise typer.Exit(1)
+    console.print(f"[green]Trusted '{root}' (anchor {anchor_id[:8]}...).[/]")
+
+
+@destination_command.command()
+def status(
+    path: Annotated[
+        Optional[Path],
+        typer.Argument(help="A specific root to check. Omit to list every known root."),
+    ] = None,
+):
+    """Read-only. Reports the live anchor-check reason for one root, or
+    every root this machine currently has local trust state for. No writes,
+    no locks held beyond the read."""
+    state = da.read_state()
+    _print_state_status_warning(state.status)
+
+    if path is not None:
+        check = da.anchor_status(Path(path))
+        detail = f" ({check.detail})" if check.detail else ""
+        color = "green" if check.reason == "trusted" else "red"
+        console.print(f"{path}: [{color}]{check.reason}[/]{detail}")
+        return
+
+    if state.status == "missing" or (state.status == "valid" and not state.records):
+        console.print("[green]No roots trusted yet.[/]")
+        return
+    if state.status != "valid":
+        return
+
+    table = Table(title="Trusted destination roots")
+    table.add_column("root")
+    table.add_column("live status")
+    table.add_column("trusted_at")
+    for record in state.records:
+        check = da.anchor_status(Path(record.root_display))
+        color = "green" if check.reason == "trusted" else "red"
+        table.add_row(record.root_display, f"[{color}]{check.reason}[/]", record.trusted_at)
+    console.print(table)
+
+
+@destination_command.command()
+def forget(
+    path: Annotated[
+        Path,
+        typer.Argument(help="The root to remove from THIS machine's local trust state."),
+    ],
+):
+    """Removes PATH from local trust state only. Never touches the shared
+    `.tiddl-anchor` marker on the destination — another installation, or
+    this same machine later, may still depend on it existing."""
+    try:
+        removed = da.forget_anchor(Path(path))
+    except (da.LocalStateReadError, da.LocalStateLockTimeout, da.LocalStatePreservationError) as e:
+        console.print(f"[red]Could not forget '{path}': {e}[/]")
+        raise typer.Exit(1)
+    if removed:
+        console.print(
+            f"[green]Forgot '{path}' (local state only — the marker on the destination "
+            "is untouched).[/]"
+        )
+    else:
+        console.print(f"[yellow]'{path}' was not in local trust state — nothing to do.[/]")

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -105,6 +105,114 @@ register_subcommands(download_command)
 log = getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Guarded write helpers for operations 5/6/8 (destination-volume identity,
+# v2.2 §1). Implementation-audit finding, 2026-08-18, P1 #3: these three
+# writes used to check `assert_write_allowed` once on the event loop and
+# THEN dispatch the actual mutation to `asyncio.to_thread`, possibly after a
+# retry sleep (track metadata) or a multi-second network fetch with backoff
+# (covers) — the protected mount could disappear in that gap between "we
+# checked" and "we wrote," exactly the wrong-volume fallback this feature
+# exists to prevent.
+#
+# Each helper below moves `assert_write_allowed` to run INSIDE the same
+# synchronous unit of work as the mutation itself — the whole helper (check
+# + write) is what gets handed to `asyncio.to_thread`, not just the write —
+# so there is no await point, no sleep, and no network I/O between the
+# check and the write it guards. `DestinationNotTrusted` propagates back
+# through `await asyncio.to_thread(...)` and is caught by the caller on the
+# event loop; none of these helpers touch `identity_tracker` themselves
+# (v2.4 mandatory safeguard #2: no `asyncio.Event` mutation from a
+# `to_thread` worker). Standalone module-level functions (not closures) so
+# they're directly unit-testable without going through the full
+# `handle_item` call graph — see tests/test_guarded_writes.py.
+# ---------------------------------------------------------------------------
+
+def _write_track_metadata_guarded(
+    item_root: Path,
+    download_path: Path,
+    mode: str,
+    *,
+    track,
+    lyrics,
+    album_artist,
+    cover_data,
+    date,
+    credits,
+    comment,
+    genre,
+    artist_separator,
+) -> None:
+    """Operation 5. Callers dispatch this whole function via
+    `asyncio.to_thread`, once per retry attempt, so a destination that
+    disappeared between attempts (e.g. while waiting out a locked-file
+    retry sleep) is caught on the very next attempt instead of writing
+    metadata to a mount that is no longer verified."""
+    anchor.assert_write_allowed(item_root, download_path, mode)
+    add_track_metadata(
+        path=download_path,
+        track=track,
+        lyrics=lyrics,
+        album_artist=album_artist,
+        cover_data=cover_data,
+        date=date,
+        credits=credits,
+        comment=comment,
+        genre=genre,
+        artist_separator=artist_separator,
+    )
+
+
+def _write_video_metadata_guarded(
+    item_root: Path,
+    download_path: Path,
+    mode: str,
+    *,
+    video,
+    artist_separator,
+) -> None:
+    """Operation 6 — see `_write_track_metadata_guarded`'s docstring."""
+    anchor.assert_write_allowed(item_root, download_path, mode)
+    add_video_metadata(path=download_path, video=video, artist_separator=artist_separator)
+
+
+async def _guarded_save_cover(
+    cover: Cover,
+    root: Path,
+    path: Path,
+    mode: str,
+    tracker: "anchor.IdentityFailureTracker",
+    label: str,
+) -> None:
+    """Operation 8. Fetches cover bytes (network I/O, its own retry backoff
+    inside `Cover._get_data`) BEFORE the identity check runs — closing the
+    gap `Cover.save_to_directory()` used to leave open by fetching AFTER a
+    passing pre-dispatch check. The check and the actual file write then run
+    together, synchronously, inside one `asyncio.to_thread` dispatch, via
+    `Cover.write_prefetched` (no network I/O in that call). Catches
+    `DestinationNotTrusted` here, on the event loop, and marks `tracker` —
+    the same safeguard-#2 discipline as the metadata helpers above."""
+    file = path.with_suffix(".jpg")
+    if file.exists():
+        log.debug(f"cover exists ({file})")
+        return
+
+    await asyncio.to_thread(cover._get_data)
+
+    def _guarded_write() -> None:
+        anchor.assert_write_allowed(root, path, mode)
+        cover.write_prefetched(path)
+
+    try:
+        await asyncio.to_thread(_guarded_write)
+    except anchor.DestinationNotTrusted as e:
+        tracker.mark_refused(e.check)
+        log.warning(
+            f"[destination-identity] refused {label} cover write "
+            f"for {path}: {e.check.reason}"
+        )
+
+
 @download_command.callback(no_args_is_help=True)
 def download_callback(
     ctx: Context,
@@ -741,57 +849,64 @@ def download_callback(
                                 track_metadata.cover_data = b""
 
                         if REWRITE_METADATA or was_downloaded:
-                            try:
-                                anchor.assert_write_allowed(
-                                    item_root, download_path,
-                                    CONFIG.download.destination_identity,
-                                )
-                            except anchor.DestinationNotTrusted as e:
-                                identity_tracker.mark_refused(e.check)
-                                identity_refused = True
-                                log.warning(
-                                    f"[destination-identity] refused track metadata "
-                                    f"write for {download_path}: {e.check.reason}"
-                                )
-                            else:
-                                for _attempt in range(3):
-                                    try:
-                                        await asyncio.to_thread(
-                                            add_track_metadata,
-                                            path=download_path,
-                                            track=item,
-                                            lyrics=lyrics_subtitles,
-                                            album_artist=track_metadata.artist,
-                                            cover_data=track_metadata.cover_data,
-                                            date=track_metadata.date,
-                                            credits=track_metadata.credits,
-                                            comment=track_metadata.album_review,
-                                            genre=track_metadata.genre,
-                                            artist_separator=CONFIG.templates.artist_separator,
-                                        )
+                            # Operation 5, moved into a guarded worker helper
+                            # (P1 #3 audit fix) — see _write_track_metadata_
+                            # guarded's docstring. The identity check now runs
+                            # fresh on EVERY attempt, inside the same
+                            # to_thread dispatch as the write itself, instead
+                            # of once before the retry loop even starts.
+                            for _attempt in range(3):
+                                try:
+                                    await asyncio.to_thread(
+                                        _write_track_metadata_guarded,
+                                        item_root, download_path,
+                                        CONFIG.download.destination_identity,
+                                        track=item,
+                                        lyrics=lyrics_subtitles,
+                                        album_artist=track_metadata.artist,
+                                        cover_data=track_metadata.cover_data,
+                                        date=track_metadata.date,
+                                        credits=track_metadata.credits,
+                                        comment=track_metadata.album_review,
+                                        genre=track_metadata.genre,
+                                        artist_separator=CONFIG.templates.artist_separator,
+                                    )
+                                    break
+                                except anchor.DestinationNotTrusted as e:
+                                    identity_tracker.mark_refused(e.check)
+                                    identity_refused = True
+                                    log.warning(
+                                        f"[destination-identity] refused track metadata "
+                                        f"write for {download_path}: {e.check.reason}"
+                                    )
+                                    break  # not a lock — retrying won't change a refusal
+                                except Exception as e:
+                                    # mutagen envuelve el PermissionError del SO (lock de slskd/AV en NAS/SMB)
+                                    # en su propia excepcion, asi que detectamos el lock por tipo O por mensaje.
+                                    _locked = isinstance(e, (PermissionError, OSError)) or "Permission denied" in str(e) or "Errno 13" in str(e) or "WinError 5" in str(e)
+                                    if _locked and _attempt < 2:
+                                        log.warning(f"Metadata write blocked (attempt {_attempt + 1}/3), retrying in 2s: {download_path}")
+                                        await asyncio.sleep(2)
+                                    elif _locked:
+                                        log.warning(f"Could not write metadata after 3 attempts (file locked by another process), skipping: {download_path} — {e}")
                                         break
-                                    except Exception as e:
-                                        # mutagen envuelve el PermissionError del SO (lock de slskd/AV en NAS/SMB)
-                                        # en su propia excepcion, asi que detectamos el lock por tipo O por mensaje.
-                                        _locked = isinstance(e, (PermissionError, OSError)) or "Permission denied" in str(e) or "Errno 13" in str(e) or "WinError 5" in str(e)
-                                        if _locked and _attempt < 2:
-                                            log.warning(f"Metadata write blocked (attempt {_attempt + 1}/3), retrying in 2s: {download_path}")
-                                            await asyncio.sleep(2)
-                                        elif _locked:
-                                            log.warning(f"Could not write metadata after 3 attempts (file locked by another process), skipping: {download_path} — {e}")
-                                            break
-                                        else:
-                                            log.warning(f"Metadata write failed for {download_path}, skipping: {e}")
-                                            break
+                                    else:
+                                        log.warning(f"Metadata write failed for {download_path}, skipping: {e}")
+                                        break
 
                     elif isinstance(item, Video):
                         if REWRITE_METADATA or was_downloaded:
+                            # Operation 6, moved into a guarded worker helper
+                            # (P1 #3 audit fix) — see _write_video_metadata_
+                            # guarded's docstring.
                             try:
-                                anchor.assert_write_allowed(
+                                await asyncio.to_thread(
+                                    _write_video_metadata_guarded,
                                     item_root, download_path,
                                     CONFIG.download.destination_identity,
+                                    video=item,
+                                    artist_separator=CONFIG.templates.artist_separator,
                                 )
-                                await asyncio.to_thread(add_video_metadata, path=download_path, video=item, artist_separator=CONFIG.templates.artist_separator)
                             except anchor.DestinationNotTrusted as e:
                                 identity_tracker.mark_refused(e.check)
                                 identity_refused = True
@@ -1128,28 +1243,13 @@ def download_callback(
                         template=CONFIG.cover.templates.album, album=album,
                         artist_separator=CONFIG.templates.artist_separator,
                     )
-                    # Operation 8 (v2.2 §1): checked synchronously here, BEFORE
-                    # the asyncio.to_thread dispatch below — never inside
-                    # Cover.save_to_directory itself, which runs in a worker
-                    # thread. This is what keeps identity_tracker.mark_refused()
-                    # off any to_thread worker (v2.4 mandatory safeguard #2),
-                    # by construction rather than a catch-after-to_thread
-                    # pattern: if this raises, the thread is never dispatched.
-                    try:
-                        anchor.assert_write_allowed(
-                            DOWNLOAD_PATH, _album_cover_path,
-                            CONFIG.download.destination_identity,
-                        )
-                    except anchor.DestinationNotTrusted as e:
-                        identity_tracker.mark_refused(e.check)
-                        log.warning(
-                            f"[destination-identity] refused album cover write "
-                            f"for {_album_cover_path}: {e.check.reason}"
-                        )
-                    else:
-                        await asyncio.to_thread(
-                            cover.save_to_directory, _album_cover_path,
-                        )
+                    # Operation 8 — via the guarded helper (P1 #3 audit fix);
+                    # see _guarded_save_cover's docstring.
+                    await _guarded_save_cover(
+                        cover, DOWNLOAD_PATH, _album_cover_path,
+                        CONFIG.download.destination_identity,
+                        identity_tracker, "album",
+                    )
 
             # resources should be collected from a distinct function
             # that would yield the resources.
@@ -1193,23 +1293,13 @@ def download_callback(
                         CONFIG.cover.templates.track, item=track, album=album,
                         artist_separator=CONFIG.templates.artist_separator,
                     )
-                    # Operation 8 (v2.2 §1) — see the album cover site above
-                    # for why this check runs before, not inside, to_thread.
-                    try:
-                        anchor.assert_write_allowed(
-                            DOWNLOAD_PATH, _track_cover_path,
-                            CONFIG.download.destination_identity,
-                        )
-                    except anchor.DestinationNotTrusted as e:
-                        identity_tracker.mark_refused(e.check)
-                        log.warning(
-                            f"[destination-identity] refused track cover write "
-                            f"for {_track_cover_path}: {e.check.reason}"
-                        )
-                    else:
-                        await asyncio.to_thread(
-                            _track_cover.save_to_directory, _track_cover_path,
-                        )
+                    # Operation 8 — via the guarded helper (P1 #3 audit fix);
+                    # see _guarded_save_cover's docstring.
+                    await _guarded_save_cover(
+                        _track_cover, DOWNLOAD_PATH, _track_cover_path,
+                        CONFIG.download.destination_identity,
+                        identity_tracker, "track",
+                    )
 
             elif resource_type == "video":
                 video = await asyncio.to_thread(ctx.obj.api.get_video, resource.id)
@@ -1753,23 +1843,13 @@ def download_callback(
                         playlist=playlist,
                         artist_separator=CONFIG.templates.artist_separator,
                     )
-                    # Operation 8 (v2.2 §1) — see the album cover site above
-                    # for why this check runs before, not inside, to_thread.
-                    try:
-                        anchor.assert_write_allowed(
-                            DOWNLOAD_PATH, _pl_cover_path,
-                            CONFIG.download.destination_identity,
-                        )
-                    except anchor.DestinationNotTrusted as e:
-                        identity_tracker.mark_refused(e.check)
-                        log.warning(
-                            f"[destination-identity] refused playlist cover write "
-                            f"for {_pl_cover_path}: {e.check.reason}"
-                        )
-                    else:
-                        await asyncio.to_thread(
-                            _pl_cover.save_to_directory, _pl_cover_path,
-                        )
+                    # Operation 8 — via the guarded helper (P1 #3 audit fix);
+                    # see _guarded_save_cover's docstring.
+                    await _guarded_save_cover(
+                        _pl_cover, DOWNLOAD_PATH, _pl_cover_path,
+                        CONFIG.download.destination_identity,
+                        identity_tracker, "playlist",
+                    )
 
                 ctx.obj.console.print(f"\n[bold green]✅ Playlist download completed:[/] {playlist.title}")
                 ctx.obj.console.print(f"   • Downloaded: {len(tracks_with_path)} items")

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -213,6 +213,28 @@ async def _guarded_save_cover(
         )
 
 
+def _write_lrc_guarded(item_root: Path, lrc_path: Path, mode: str, text: str) -> None:
+    """Operation 4. Runs on the event loop, not a worker thread (the write
+    itself is a small synchronous text write, never dispatched to
+    asyncio.to_thread) — check and write are already adjacent statements
+    with no gap to close, unlike operations 5/6/8. Standalone module-level
+    function purely for direct unit-test coverage (implementation-audit P2
+    finding — this operation class had no dedicated test)."""
+    anchor.assert_write_allowed(item_root, lrc_path, mode)
+    lrc_path.write_text(text, encoding="utf-8")
+
+
+def _touch_guarded(item_root: Path, download_path: Path, mode: str) -> None:
+    """Operation 9 (v2.3 §1). Same non-threaded reasoning as
+    `_write_lrc_guarded` above — extracted only for direct unit-test
+    coverage. Unlike operations 4/5/6, a refusal here is COSMETIC: the
+    caller must never treat this as withholding the already-completed
+    `_db_insert` (Class B's documented exception, v2.3 §3) — that
+    distinction is the caller's responsibility, not this function's."""
+    anchor.assert_write_allowed(item_root, download_path, mode)
+    os.utime(download_path, None)
+
+
 @download_command.callback(no_args_is_help=True)
 def download_callback(
     ctx: Context,
@@ -816,11 +838,11 @@ def download_callback(
                                 if fetched_lyrics:
                                     if CONFIG.metadata.save_lyrics and (not lrc_exists or REWRITE_METADATA):
                                         try:
-                                            anchor.assert_write_allowed(
+                                            _write_lrc_guarded(
                                                 item_root, lrc_path,
                                                 CONFIG.download.destination_identity,
+                                                fetched_lyrics,
                                             )
-                                            lrc_path.write_text(fetched_lyrics, encoding="utf-8")
                                         except anchor.DestinationNotTrusted as e:
                                             identity_tracker.mark_refused(e.check)
                                             identity_refused = True
@@ -933,11 +955,10 @@ def download_callback(
 
                 if download_path and CONFIG.download.update_mtime:
                     try:
-                        anchor.assert_write_allowed(
+                        _touch_guarded(
                             item_root, download_path,
                             CONFIG.download.destination_identity,
                         )
-                        os.utime(download_path, None)
                     except anchor.DestinationNotTrusted as e:
                         # Operation 9 (v2.3 §1): unlike 4/5/6 above, this never
                         # sets identity_refused — a stale mtime is cosmetic,

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -252,6 +252,38 @@ def _touch_guarded(item_root: Path, download_path: Path, mode: str) -> None:
     os.utime(download_path, None)
 
 
+def _should_insert_db_record(was_downloaded: bool, identity_refused: bool) -> bool:
+    """Class B (v2.3 §3): a per-item `_db_insert` is withheld exactly when
+    THIS item's own destination-identity refusal happened — operations 4
+    (.lrc), 5 (track metadata) or 6 (video metadata), the only three that
+    set `identity_refused = True`. Operation 9 (utime) deliberately never
+    sets it (a stale mtime is cosmetic, never suppresses an insert that
+    already ran — see `_touch_guarded`'s docstring), and operations 7/8
+    (M3U/cover, Class C) run AFTER this decision and can never un-insert an
+    already-truthful record.
+
+    Standalone pure function so this exact decision has direct unit
+    coverage (implementation-audit P2 finding, second round: outcome-level
+    Class B/C DB semantics lacked a direct test) without needing to invoke
+    the surrounding `handle_item` call graph."""
+    return bool(was_downloaded and not identity_refused)
+
+
+def _download_exit_code(any_identity_refused: bool) -> Optional[int]:
+    """v2.4 §2: the final `tiddl download` exit-code decision, evaluated
+    once after every per-item and per-resource task in the run has
+    completed (`identity_tracker.any_refused`, which is monotonic across
+    however many concurrent tasks refused — see
+    `IdentityFailureTracker.mark_refused`). Returns 1 (non-zero) if any
+    destination-identity check refused a write during the run — a mixed
+    run where some items succeeded and others refused still counts as
+    "one or more refused," per the tracker's own monotonic semantics — or
+    `None` to fall through to Typer's normal 0. Standalone pure function
+    for direct unit coverage of this decision, same audit finding as
+    `_should_insert_db_record` above."""
+    return 1 if any_identity_refused else None
+
+
 @download_command.callback(no_args_is_help=True)
 def download_callback(
     ctx: Context,
@@ -964,7 +996,7 @@ def download_callback(
                 # — identity_refused stays False (a no-op) whenever
                 # CONFIG.download.destination_identity == "off", so this adds
                 # no behavior change for anyone not using the feature.
-                if download_path and was_downloaded and not identity_refused:
+                if download_path and _should_insert_db_record(was_downloaded, identity_refused):
                     if isinstance(item, Track):
                         downloader._db_insert(item.id, download_path, str(item.audioQuality))
                     elif isinstance(item, Video):
@@ -2061,12 +2093,13 @@ def download_callback(
             import traceback
             log.error(traceback.format_exc())
         else:
-            if any_identity_refused:
+            exit_code = _download_exit_code(any_identity_refused)
+            if exit_code is not None:
                 ctx.obj.console.print(
                     "[red]One or more destination-identity checks refused a write "
                     "this run — see the warnings above. Nothing was lost (retryable "
                     "copies were retained where applicable); exiting non-zero.[/]"
                 )
-                sys.exit(1)
+                sys.exit(exit_code)
 
     ctx.call_on_close(run)

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import os
 import re
+import sys
 import random
 import typer
 import asyncio
@@ -269,6 +270,26 @@ def _should_insert_db_record(was_downloaded: bool, identity_refused: bool) -> bo
     return bool(was_downloaded and not identity_refused)
 
 
+def _finalize_db_record(downloader, item, download_path, was_downloaded, identity_refused) -> None:
+    """Class B (v2.3 §3): the COMPLETE per-item DB-insert effect —
+    `handle_item` calls this, not `_should_insert_db_record` +
+    `downloader._db_insert` inline. Implementation-audit finding, third
+    round: a test that only exercises `_should_insert_db_record()` in
+    isolation would keep passing even if `handle_item` stopped calling it,
+    inverted its result, or inserted via a different path — because the
+    helper and the call site were two different pieces of code. Making
+    THIS function the single call site means a test that calls it
+    directly, against a real `Downloader`'s real SQLite-backed
+    `_db_insert`/`_db_lookup`, is exercising the exact same code
+    `handle_item` runs — not a parallel copy of it."""
+    if not download_path or not _should_insert_db_record(was_downloaded, identity_refused):
+        return
+    if isinstance(item, Track):
+        downloader._db_insert(item.id, download_path, str(item.audioQuality))
+    elif isinstance(item, Video):
+        downloader._db_insert(item.id, download_path, "VIDEO")
+
+
 def _download_exit_code(any_identity_refused: bool) -> Optional[int]:
     """v2.4 §2: the final `tiddl download` exit-code decision, evaluated
     once after every per-item and per-resource task in the run has
@@ -282,6 +303,27 @@ def _download_exit_code(any_identity_refused: bool) -> Optional[int]:
     for direct unit coverage of this decision, same audit finding as
     `_should_insert_db_record` above."""
     return 1 if any_identity_refused else None
+
+
+def _finish_download_run(console, any_identity_refused: bool) -> None:
+    """v2.4 §2: the COMPLETE final-outcome effect for `tiddl download` —
+    the warning message AND the actual `sys.exit()` — not just the
+    decision. `run()` calls this, not `_download_exit_code()` +
+    `sys.exit()` inline. Implementation-audit finding, third round: a test
+    of `_download_exit_code()` alone doesn't prove `run()`'s closure still
+    calls it, still uses its return value correctly, or still actually
+    exits the process. This function IS what `run()` calls (see
+    `download_callback` below), so a test calling it directly (asserting
+    `SystemExit` via `pytest.raises`) exercises the real call site, not a
+    parallel copy of its logic."""
+    exit_code = _download_exit_code(any_identity_refused)
+    if exit_code is not None:
+        console.print(
+            "[red]One or more destination-identity checks refused a write "
+            "this run — see the warnings above. Nothing was lost (retryable "
+            "copies were retained where applicable); exiting non-zero.[/]"
+        )
+        sys.exit(exit_code)
 
 
 @download_command.callback(no_args_is_help=True)
@@ -996,11 +1038,9 @@ def download_callback(
                 # — identity_refused stays False (a no-op) whenever
                 # CONFIG.download.destination_identity == "off", so this adds
                 # no behavior change for anyone not using the feature.
-                if download_path and _should_insert_db_record(was_downloaded, identity_refused):
-                    if isinstance(item, Track):
-                        downloader._db_insert(item.id, download_path, str(item.audioQuality))
-                    elif isinstance(item, Video):
-                        downloader._db_insert(item.id, download_path, "VIDEO")
+                _finalize_db_record(
+                    downloader, item, download_path, was_downloaded, identity_refused
+                )
 
                 if download_path and CONFIG.download.update_mtime:
                     try:
@@ -2080,7 +2120,7 @@ def download_callback(
         # cuando el subcomando falló al parsear sus argumentos).
         if not ctx.obj.resources:
             return
-        import warnings, sys
+        import warnings
         # Suppress ResourceWarning noise from asyncio pipe cleanup on Windows Ctrl+C
         if sys.platform == "win32":
             warnings.filterwarnings("ignore", category=ResourceWarning)
@@ -2093,13 +2133,6 @@ def download_callback(
             import traceback
             log.error(traceback.format_exc())
         else:
-            exit_code = _download_exit_code(any_identity_refused)
-            if exit_code is not None:
-                ctx.obj.console.print(
-                    "[red]One or more destination-identity checks refused a write "
-                    "this run — see the warnings above. Nothing was lost (retryable "
-                    "copies were retained where applicable); exiting non-zero.[/]"
-                )
-                sys.exit(exit_code)
+            _finish_download_run(ctx.obj.console, any_identity_refused)
 
     ctx.call_on_close(run)

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -189,15 +189,32 @@ async def _guarded_save_cover(
     gap `Cover.save_to_directory()` used to leave open by fetching AFTER a
     passing pre-dispatch check. The check and the actual file write then run
     together, synchronously, inside one `asyncio.to_thread` dispatch, via
-    `Cover.write_prefetched` (no network I/O in that call). Catches
-    `DestinationNotTrusted` here, on the event loop, and marks `tracker` —
-    the same safeguard-#2 discipline as the metadata helpers above."""
+    `Cover.write_prefetched` (no network I/O in that call — it raises
+    `CoverDataNotPrefetched` rather than fetching if `data` weren't already
+    prefetched, so a second network fetch can never happen from inside the
+    guarded worker). Catches `DestinationNotTrusted` here, on the event
+    loop, and marks `tracker` — the same safeguard-#2 discipline as the
+    metadata helpers above.
+
+    Second implementation-audit finding (2026-08-18), P1 #2: the fetch
+    result is assigned to a local explicitly and checked BEFORE dispatching
+    the guarded write — `cover.data` alone is not trustworthy here (a
+    failed fetch leaves it `None`/falsy, and the old code's implicit
+    reliance on `write_prefetched`'s own now-removed fallback silently
+    re-fetched over the network on every such failure, after the identity
+    check had already run once)."""
     file = path.with_suffix(".jpg")
     if file.exists():
         log.debug(f"cover exists ({file})")
         return
 
-    await asyncio.to_thread(cover._get_data)
+    data = await asyncio.to_thread(cover._get_data)
+    if not data:
+        log.warning(
+            f"[destination-identity] no {label} cover data fetched, skipping write for {path}"
+        )
+        return
+    cover.data = data
 
     def _guarded_write() -> None:
         anchor.assert_write_allowed(root, path, mode)

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -20,6 +20,7 @@ from tiddl.core.api import ApiError
 from tiddl.core.api.models import Album, Track, Video, AlbumItemsCredits
 from tiddl.core.utils.format import format_template
 from tiddl.core.utils.m3u import save_tracks_to_m3u
+from tiddl.core.utils import destination_anchor as anchor
 from tiddl.cli.config import (
     CONFIG,
     TRACK_QUALITY_LITERAL,
@@ -461,6 +462,14 @@ def download_callback(
 
     log.debug(f"{ctx.params=}")
 
+    # One IdentityFailureTracker per `tiddl download` invocation (v2.4
+    # mandatory safeguard #2) — download_callback() runs once per command
+    # invocation, so this is the natural home for it: created here, closed
+    # over by every guarded call site below (save_m3u, the cover.save_to_
+    # directory sites, and — via download_resources()/handle_item — the
+    # Downloader itself), never a module global.
+    identity_tracker = anchor.IdentityFailureTracker()
+
     def resolve_template(specific_cli: str, config_template: str) -> str:
         return specific_cli or TEMPLATE or config_template
 
@@ -483,8 +492,15 @@ def download_callback(
 
         log.debug(f"{resource_type=}, {filename=}, {len(tracks_with_existing_paths)=}")
 
+        # Operation 7 (destination-volume identity, v2.2 §1): save_m3u() runs
+        # synchronously on the event loop (never inside asyncio.to_thread), so
+        # it's safe for save_tracks_to_m3u() to touch identity_tracker
+        # directly — no thread-boundary concern here (contrast with the cover
+        # sites below, which dispatch to a thread).
         save_tracks_to_m3u(
-            tracks_with_path=tracks_with_existing_paths, path=DOWNLOAD_PATH / filename
+            tracks_with_path=tracks_with_existing_paths, path=DOWNLOAD_PATH / filename,
+            root=DOWNLOAD_PATH, mode=CONFIG.download.destination_identity,
+            tracker=identity_tracker,
         )
 
     def get_item_quality(item: Union[Track, Video]):
@@ -520,6 +536,10 @@ def download_callback(
         _session_track_count = [0]
         _session_limit = CONFIG.download.max_tracks_per_session
 
+        # identity_tracker: created once in download_callback() above (not
+        # here) — this closure just reuses it, same object save_m3u() and
+        # the cover call sites below already close over.
+
         downloader = Downloader(
             tidal_api=ctx.obj.api,
             threads_count=THREADS_COUNT,
@@ -532,6 +552,8 @@ def download_callback(
             scan_path=SCAN_PATH,
             video_download_path=VIDEO_DOWNLOAD_PATH,
             fallback_api=ctx.obj.fallback_api,
+            destination_identity=CONFIG.download.destination_identity,
+            identity_tracker=identity_tracker,
         )
 
         # Fast-skip shortcuts (whole-album fast exit, up-front present detection,
@@ -620,6 +642,22 @@ def download_callback(
 
                 log.debug(f"{download_path=}, {was_downloaded=}")
 
+                # Destination-volume identity (operations 4/5/6/9, v2.2 §1 /
+                # v2.3 §1): the same root operations 1/2/3 already checked for
+                # this item, in downloader.py. Tracks and videos can have
+                # different configured roots (--video-path overrides --path),
+                # so this is item-type-dependent, computed once and reused.
+                item_root = (
+                    DOWNLOAD_PATH if isinstance(item, Track)
+                    else (VIDEO_DOWNLOAD_PATH or DOWNLOAD_PATH)
+                )
+                # Class B (v2.3 §3): a refusal at the .lrc/metadata level skips
+                # this item's _db_insert below, so a later run's directory-scan
+                # fallback retries it. utime (operation 9) is exempted per its
+                # own outcome rule — never suppresses an insert that already
+                # happened.
+                identity_refused = False
+
                 if (
                     CONFIG.metadata.enable
                     and download_path
@@ -670,7 +708,18 @@ def download_callback(
                                 if fetched_lyrics:
                                     if CONFIG.metadata.save_lyrics and (not lrc_exists or REWRITE_METADATA):
                                         try:
+                                            anchor.assert_write_allowed(
+                                                item_root, lrc_path,
+                                                CONFIG.download.destination_identity,
+                                            )
                                             lrc_path.write_text(fetched_lyrics, encoding="utf-8")
+                                        except anchor.DestinationNotTrusted as e:
+                                            identity_tracker.mark_refused(e.check)
+                                            identity_refused = True
+                                            log.warning(
+                                                f"[destination-identity] refused .lrc write "
+                                                f"for {lrc_path}: {e.check.reason}"
+                                            )
                                         except Exception as e:
                                             log.error(f"Could not save .lrc file: {e}")
                                     
@@ -692,47 +741,76 @@ def download_callback(
                                 track_metadata.cover_data = b""
 
                         if REWRITE_METADATA or was_downloaded:
-                            for _attempt in range(3):
-                                try:
-                                    await asyncio.to_thread(
-                                        add_track_metadata,
-                                        path=download_path,
-                                        track=item,
-                                        lyrics=lyrics_subtitles,
-                                        album_artist=track_metadata.artist,
-                                        cover_data=track_metadata.cover_data,
-                                        date=track_metadata.date,
-                                        credits=track_metadata.credits,
-                                        comment=track_metadata.album_review,
-                                        genre=track_metadata.genre,
-                                        artist_separator=CONFIG.templates.artist_separator,
-                                    )
-                                    break
-                                except Exception as e:
-                                    # mutagen envuelve el PermissionError del SO (lock de slskd/AV en NAS/SMB)
-                                    # en su propia excepcion, asi que detectamos el lock por tipo O por mensaje.
-                                    _locked = isinstance(e, (PermissionError, OSError)) or "Permission denied" in str(e) or "Errno 13" in str(e) or "WinError 5" in str(e)
-                                    if _locked and _attempt < 2:
-                                        log.warning(f"Metadata write blocked (attempt {_attempt + 1}/3), retrying in 2s: {download_path}")
-                                        await asyncio.sleep(2)
-                                    elif _locked:
-                                        log.warning(f"Could not write metadata after 3 attempts (file locked by another process), skipping: {download_path} — {e}")
+                            try:
+                                anchor.assert_write_allowed(
+                                    item_root, download_path,
+                                    CONFIG.download.destination_identity,
+                                )
+                            except anchor.DestinationNotTrusted as e:
+                                identity_tracker.mark_refused(e.check)
+                                identity_refused = True
+                                log.warning(
+                                    f"[destination-identity] refused track metadata "
+                                    f"write for {download_path}: {e.check.reason}"
+                                )
+                            else:
+                                for _attempt in range(3):
+                                    try:
+                                        await asyncio.to_thread(
+                                            add_track_metadata,
+                                            path=download_path,
+                                            track=item,
+                                            lyrics=lyrics_subtitles,
+                                            album_artist=track_metadata.artist,
+                                            cover_data=track_metadata.cover_data,
+                                            date=track_metadata.date,
+                                            credits=track_metadata.credits,
+                                            comment=track_metadata.album_review,
+                                            genre=track_metadata.genre,
+                                            artist_separator=CONFIG.templates.artist_separator,
+                                        )
                                         break
-                                    else:
-                                        log.warning(f"Metadata write failed for {download_path}, skipping: {e}")
-                                        break
+                                    except Exception as e:
+                                        # mutagen envuelve el PermissionError del SO (lock de slskd/AV en NAS/SMB)
+                                        # en su propia excepcion, asi que detectamos el lock por tipo O por mensaje.
+                                        _locked = isinstance(e, (PermissionError, OSError)) or "Permission denied" in str(e) or "Errno 13" in str(e) or "WinError 5" in str(e)
+                                        if _locked and _attempt < 2:
+                                            log.warning(f"Metadata write blocked (attempt {_attempt + 1}/3), retrying in 2s: {download_path}")
+                                            await asyncio.sleep(2)
+                                        elif _locked:
+                                            log.warning(f"Could not write metadata after 3 attempts (file locked by another process), skipping: {download_path} — {e}")
+                                            break
+                                        else:
+                                            log.warning(f"Metadata write failed for {download_path}, skipping: {e}")
+                                            break
 
                     elif isinstance(item, Video):
                         if REWRITE_METADATA or was_downloaded:
-                            await asyncio.to_thread(add_video_metadata, path=download_path, video=item, artist_separator=CONFIG.templates.artist_separator)
+                            try:
+                                anchor.assert_write_allowed(
+                                    item_root, download_path,
+                                    CONFIG.download.destination_identity,
+                                )
+                                await asyncio.to_thread(add_video_metadata, path=download_path, video=item, artist_separator=CONFIG.templates.artist_separator)
+                            except anchor.DestinationNotTrusted as e:
+                                identity_tracker.mark_refused(e.check)
+                                identity_refused = True
+                                log.warning(
+                                    f"[destination-identity] refused video metadata "
+                                    f"write for {download_path}: {e.check.reason}"
+                                )
 
                 # Mark complete in the skip-existing DB only *after* metadata has
                 # been attempted (see downloader.download()'s docstring). If the
                 # process dies before this line, the DB stays clean and a re-run
                 # will find the file via the directory-scan fallback and retry
                 # writing its metadata, instead of silently leaving it untagged
-                # forever.
-                if download_path and was_downloaded:
+                # forever. Class B (v2.3 §3): the same withholding now also
+                # covers a destination-identity refusal at .lrc/metadata above
+                # — identity_refused stays False (a no-op) whenever
+                # CONFIG.download.destination_identity == "off", so this adds
+                # no behavior change for anyone not using the feature.
+                if download_path and was_downloaded and not identity_refused:
                     if isinstance(item, Track):
                         downloader._db_insert(item.id, download_path, str(item.audioQuality))
                     elif isinstance(item, Video):
@@ -740,7 +818,20 @@ def download_callback(
 
                 if download_path and CONFIG.download.update_mtime:
                     try:
+                        anchor.assert_write_allowed(
+                            item_root, download_path,
+                            CONFIG.download.destination_identity,
+                        )
                         os.utime(download_path, None)
+                    except anchor.DestinationNotTrusted as e:
+                        # Operation 9 (v2.3 §1): unlike 4/5/6 above, this never
+                        # sets identity_refused — a stale mtime is cosmetic,
+                        # never suppresses the _db_insert that already ran.
+                        identity_tracker.mark_refused(e.check)
+                        log.warning(
+                            f"[destination-identity] refused mtime update for "
+                            f"{download_path}: {e.check.reason}"
+                        )
                     except Exception:
                         log.warning(f"could not update mtime for {download_path}")
 
@@ -1033,14 +1124,32 @@ def download_callback(
                 )
 
                 if save_cover and cover:
-                    await asyncio.to_thread(
-                        cover.save_to_directory,
-                        DOWNLOAD_PATH
-                        / format_template(
-                            template=CONFIG.cover.templates.album, album=album,
-                            artist_separator=CONFIG.templates.artist_separator,
-                        ),
+                    _album_cover_path = DOWNLOAD_PATH / format_template(
+                        template=CONFIG.cover.templates.album, album=album,
+                        artist_separator=CONFIG.templates.artist_separator,
                     )
+                    # Operation 8 (v2.2 §1): checked synchronously here, BEFORE
+                    # the asyncio.to_thread dispatch below — never inside
+                    # Cover.save_to_directory itself, which runs in a worker
+                    # thread. This is what keeps identity_tracker.mark_refused()
+                    # off any to_thread worker (v2.4 mandatory safeguard #2),
+                    # by construction rather than a catch-after-to_thread
+                    # pattern: if this raises, the thread is never dispatched.
+                    try:
+                        anchor.assert_write_allowed(
+                            DOWNLOAD_PATH, _album_cover_path,
+                            CONFIG.download.destination_identity,
+                        )
+                    except anchor.DestinationNotTrusted as e:
+                        identity_tracker.mark_refused(e.check)
+                        log.warning(
+                            f"[destination-identity] refused album cover write "
+                            f"for {_album_cover_path}: {e.check.reason}"
+                        )
+                    else:
+                        await asyncio.to_thread(
+                            cover.save_to_directory, _album_cover_path,
+                        )
 
             # resources should be collected from a distinct function
             # that would yield the resources.
@@ -1080,14 +1189,27 @@ def download_callback(
                     and track.album.cover
                 ):
                     _track_cover = Cover(track.album.cover, size=CONFIG.cover.size)
-                    await asyncio.to_thread(
-                        _track_cover.save_to_directory,
-                        DOWNLOAD_PATH
-                        / format_template(
-                            CONFIG.cover.templates.track, item=track, album=album,
-                            artist_separator=CONFIG.templates.artist_separator,
-                        ),
+                    _track_cover_path = DOWNLOAD_PATH / format_template(
+                        CONFIG.cover.templates.track, item=track, album=album,
+                        artist_separator=CONFIG.templates.artist_separator,
                     )
+                    # Operation 8 (v2.2 §1) — see the album cover site above
+                    # for why this check runs before, not inside, to_thread.
+                    try:
+                        anchor.assert_write_allowed(
+                            DOWNLOAD_PATH, _track_cover_path,
+                            CONFIG.download.destination_identity,
+                        )
+                    except anchor.DestinationNotTrusted as e:
+                        identity_tracker.mark_refused(e.check)
+                        log.warning(
+                            f"[destination-identity] refused track cover write "
+                            f"for {_track_cover_path}: {e.check.reason}"
+                        )
+                    else:
+                        await asyncio.to_thread(
+                            _track_cover.save_to_directory, _track_cover_path,
+                        )
 
             elif resource_type == "video":
                 video = await asyncio.to_thread(ctx.obj.api.get_video, resource.id)
@@ -1626,15 +1748,28 @@ def download_callback(
                     and playlist.squareImage
                 ):
                     _pl_cover = Cover(playlist.squareImage, size=max(CONFIG.cover.size, 1080))
-                    await asyncio.to_thread(
-                        _pl_cover.save_to_directory,
-                        DOWNLOAD_PATH
-                        / format_template(
-                            template=CONFIG.cover.templates.playlist,
-                            playlist=playlist,
-                            artist_separator=CONFIG.templates.artist_separator,
-                        ),
+                    _pl_cover_path = DOWNLOAD_PATH / format_template(
+                        template=CONFIG.cover.templates.playlist,
+                        playlist=playlist,
+                        artist_separator=CONFIG.templates.artist_separator,
                     )
+                    # Operation 8 (v2.2 §1) — see the album cover site above
+                    # for why this check runs before, not inside, to_thread.
+                    try:
+                        anchor.assert_write_allowed(
+                            DOWNLOAD_PATH, _pl_cover_path,
+                            CONFIG.download.destination_identity,
+                        )
+                    except anchor.DestinationNotTrusted as e:
+                        identity_tracker.mark_refused(e.check)
+                        log.warning(
+                            f"[destination-identity] refused playlist cover write "
+                            f"for {_pl_cover_path}: {e.check.reason}"
+                        )
+                    else:
+                        await asyncio.to_thread(
+                            _pl_cover.save_to_directory, _pl_cover_path,
+                        )
 
                 ctx.obj.console.print(f"\n[bold green]✅ Playlist download completed:[/] {playlist.title}")
                 ctx.obj.console.print(f"   • Downloaded: {len(tracks_with_path)} items")
@@ -1785,6 +1920,10 @@ def download_callback(
 
         rich_output.show_stats()
 
+        # v2.4 §2: checked once, after every per-item and per-resource task
+        # has completed — not by scanning output or counting log lines.
+        return identity_tracker.any_refused
+
     def run():
         # Sin recursos no hay nada que descargar: evita pintar los paneles
         # vacíos de progreso (que entierran el mensaje de error de Click
@@ -1796,12 +1935,20 @@ def download_callback(
         if sys.platform == "win32":
             warnings.filterwarnings("ignore", category=ResourceWarning)
         try:
-            asyncio.run(download_resources())
+            any_identity_refused = asyncio.run(download_resources())
         except KeyboardInterrupt:
             ctx.obj.console.print("\n[yellow]Download interrupted by user.[/]")
         except Exception as e:
             ctx.obj.console.print(f"\n[red]Unexpected error during download: {e}[/]")
             import traceback
             log.error(traceback.format_exc())
+        else:
+            if any_identity_refused:
+                ctx.obj.console.print(
+                    "[red]One or more destination-identity checks refused a write "
+                    "this run — see the warnings above. Nothing was lost (retryable "
+                    "copies were retained where applicable); exiting non-zero.[/]"
+                )
+                sys.exit(1)
 
     ctx.call_on_close(run)

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -43,7 +43,7 @@ CHUNK_SIZE = 1024**2
 MAX_RETRIES = 3  # Maximum number of retries for corrupt files
 
 
-def _guarded_mkdir(root: Path, path: Path, mode: str) -> None:
+def _guarded_mkdir(root: Path, path: Path, mode: str) -> "anchor.AnchorCheck":
     """Operations 1/2 (destination-volume identity, v2.2 §1): checked
     immediately before creating this item's directory — a refusal here is
     root-level (every quality attempt would hit the same untrusted root),
@@ -53,9 +53,19 @@ def _guarded_mkdir(root: Path, path: Path, mode: str) -> None:
     in `Downloader.download()`) so it's directly unit-testable without the
     surrounding streaming/quality-retry machinery — see
     tests/test_guarded_writes.py (implementation-audit P2 finding, missing
-    direct coverage for operations 1/2)."""
-    anchor.assert_write_allowed(root, path, mode)
+    direct coverage for operations 1/2).
+
+    Returns the successful `AnchorCheck` (second implementation-audit
+    finding, 2026-08-18, P1 #1): the caller must capture `root_key`/
+    `anchor_id` from THIS check, at this pre-staging moment, into the
+    `DownloadTask` it constructs right after — not re-derive it later from
+    operation 3's check, which runs only after the (possibly long) download
+    has already been staged and can refuse for an unrelated reason (the
+    destination disappearing mid-download), silently losing an identity
+    that WAS genuinely verified before staging began."""
+    check = anchor.assert_write_allowed(root, path, mode)
     path.parent.mkdir(exist_ok=True, parents=True)
+    return check
 
 
 def _normalize_dir(path: Path) -> str:
@@ -139,17 +149,32 @@ class DownloadTask:
     # silent bypass of a real download's guard (both real call sites always
     # set it).
     root: Optional[Path] = None
-    # Captured from the operation-3 guard in _publish_staged() the moment it
-    # passes with reason == "trusted" — i.e. this task's write was actually
-    # verified against a live, currently-trusted anchor, not just "no root
-    # was configured." (Implementation-audit finding, 2026-08-18: these were
-    # never captured, so every retained entry from a real download fell back
-    # to "legacy" under strict recovery regardless of destination_identity.)
+    # Captured at operation 1/2's PRE-STAGING guard (Downloader.download(),
+    # via `_guarded_mkdir`'s returned AnchorCheck), immediately after
+    # construction, the moment that check passes with reason == "trusted" —
+    # i.e. this task's destination was verified against a live,
+    # currently-trusted anchor BEFORE the (possibly long) network download
+    # even started. Operation 3's guard in _publish_staged() may REFRESH
+    # both fields on its own "trusted" pass (the anchor could have been
+    # re-verified, or even legitimately re-established, since staging
+    # began), but a refusal there must never erase this pre-staging value —
+    # _publish_staged()'s except branch never touches these fields, by
+    # construction.
+    #
+    # (Second implementation-audit finding, 2026-08-18, P1 #1: capturing
+    # ONLY at operation 3 was too late — a root trusted before staging that
+    # disappears during the download would refuse at operation 3 with
+    # nothing ever captured, and the resulting PUBLISH_PENDING entry would
+    # be written as legacy despite having been genuinely verified before
+    # staging began. First implementation-audit finding, 2026-08-18: before
+    # that, these fields didn't exist at all, so every retained entry fell
+    # back to "legacy" under strict recovery regardless of
+    # destination_identity.)
+    #
     # Both stay None when: mode == "off" (no anchor I/O happens, so there is
-    # nothing to capture — matches "off never persists identity"); task.root
-    # is None (guard skipped entirely); or the guard refused (in which case
-    # _publish_staged returns before ever reaching publish, so no retained-
-    # registry entry citing a verified anchor is ever created for it).
+    # nothing to capture); task.root is None (guard skipped entirely); or
+    # the operation-1/2 guard itself refused (in which case the item is
+    # aborted before a DownloadTask is even constructed for it).
     verified_root_key: Optional[str] = None
     verified_anchor_id: Optional[str] = None
 
@@ -697,12 +722,16 @@ class Downloader:
                     task.root, task.output_path, self.destination_identity,
                 )
                 if check.reason == "trusted":
-                    # Capture NOW, at the moment identity was actually
-                    # verified — not re-derived later, and not skipped just
-                    # because the publish below might still fail for an
-                    # unrelated I/O reason. A retained entry from that later
-                    # failure is still correctly attributable to this
-                    # verified anchor.
+                    # REFRESH (not the only capture point — see
+                    # DownloadTask.verified_root_key's docstring, second
+                    # implementation-audit finding, P1 #1): operations 1/2
+                    # already captured this pre-staging, at construction
+                    # time. This overwrites with the freshly-reverified
+                    # value here, closer to the actual write — not re-
+                    # derived later, and not skipped just because the
+                    # publish below might still fail for an unrelated I/O
+                    # reason. A retained entry from that later failure is
+                    # still correctly attributable to this verified anchor.
                     task.verified_root_key = anchor.root_key(task.root)
                     task.verified_anchor_id = check.anchor_id
             except anchor.DestinationNotTrusted as e:
@@ -713,6 +742,14 @@ class Downloader:
                 # refusal IS a publish failure, not a new failure mode with
                 # its own recovery mechanics. Distinguishable message so this
                 # is never mistaken for a generic I/O error.
+                #
+                # Deliberately does NOT touch task.verified_root_key/
+                # verified_anchor_id: if operations 1/2 captured a genuinely
+                # verified pre-staging identity, THIS refusal (the
+                # destination disappearing during staging) must never erase
+                # it — the retained PUBLISH_PENDING entry below still cites
+                # the anchor that really was trusted before the download
+                # started (second implementation-audit finding, P1 #1).
                 self.identity_tracker.mark_refused(e.check)
                 task.error_message = f"destination not trusted ({e.check.reason})"
                 _detail = f" ({e.check.detail})" if e.check.detail else ""
@@ -1254,7 +1291,7 @@ class Downloader:
                     # identically at a lower quality, so abort the item
                     # outright rather than retrying.
                     try:
-                        _guarded_mkdir(
+                        mkdir_check = _guarded_mkdir(
                             self.download_path, download_path, self.destination_identity,
                         )
                     except anchor.DestinationNotTrusted as e:
@@ -1277,6 +1314,12 @@ class Downloader:
                         track_title=display_title,
                         max_attempts=MAX_RETRIES
                     )
+                    if mkdir_check.reason == "trusted":
+                        # Capture NOW, pre-staging — see DownloadTask.
+                        # verified_root_key's docstring (second
+                        # implementation-audit finding, P1 #1).
+                        task.verified_root_key = anchor.root_key(self.download_path)
+                        task.verified_anchor_id = mkdir_check.anchor_id
 
                     download_success = await self._download_with_retry(
                         task=task,
@@ -1366,7 +1409,7 @@ class Downloader:
                     # operation 1 above: a refusal here is root-level, so
                     # abort the item instead of trying another video quality.
                     try:
-                        _guarded_mkdir(
+                        mkdir_check = _guarded_mkdir(
                             video_base, download_path, self.destination_identity,
                         )
                     except anchor.DestinationNotTrusted as e:
@@ -1397,6 +1440,12 @@ class Downloader:
                         track_title=display_title,
                         max_attempts=MAX_RETRIES
                     )
+                    if mkdir_check.reason == "trusted":
+                        # Capture NOW, pre-staging — see DownloadTask.
+                        # verified_root_key's docstring (second
+                        # implementation-audit finding, P1 #1).
+                        video_task.verified_root_key = anchor.root_key(video_base)
+                        video_task.verified_anchor_id = mkdir_check.anchor_id
 
                     download_success = await self._download_with_retry(
                         task=video_task,

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -43,6 +43,21 @@ CHUNK_SIZE = 1024**2
 MAX_RETRIES = 3  # Maximum number of retries for corrupt files
 
 
+def _guarded_mkdir(root: Path, path: Path, mode: str) -> None:
+    """Operations 1/2 (destination-volume identity, v2.2 §1): checked
+    immediately before creating this item's directory — a refusal here is
+    root-level (every quality attempt would hit the same untrusted root),
+    so the caller aborts the item outright rather than retrying at a lower
+    quality. Raises `DestinationNotTrusted`; the caller catches it, marks
+    the tracker, and returns. Standalone module-level function (not inlined
+    in `Downloader.download()`) so it's directly unit-testable without the
+    surrounding streaming/quality-retry machinery — see
+    tests/test_guarded_writes.py (implementation-audit P2 finding, missing
+    direct coverage for operations 1/2)."""
+    anchor.assert_write_allowed(root, path, mode)
+    path.parent.mkdir(exist_ok=True, parents=True)
+
+
 def _normalize_dir(path: Path) -> str:
     """Canonical form of a directory path for equality checks.
 
@@ -1233,14 +1248,13 @@ class Downloader:
 
                     task_id = self.rich_output.download_start(f"[{vibrant_color}]{display_title} {quality}")
 
-                    # Operation 1 (destination-volume identity, v2.2 §1): checked
-                    # before this item's own directory even exists. A refusal
-                    # here means every quality attempt would hit the same
-                    # untrusted root, so abort the item outright rather than
-                    # retrying at a lower quality (which _prepare_long_path's
-                    # alias-stripping-aware comparison would refuse identically).
+                    # Operation 1 — via the guarded helper (see
+                    # _guarded_mkdir's docstring): _prepare_long_path's
+                    # alias-stripping-aware comparison would refuse
+                    # identically at a lower quality, so abort the item
+                    # outright rather than retrying.
                     try:
-                        anchor.assert_write_allowed(
+                        _guarded_mkdir(
                             self.download_path, download_path, self.destination_identity,
                         )
                     except anchor.DestinationNotTrusted as e:
@@ -1254,8 +1268,6 @@ class Downloader:
                             f"[red]❌ Destination not trusted ({e.check.reason})[/] {display_title}"
                         )
                         return None, False
-
-                    download_path.parent.mkdir(exist_ok=True, parents=True)
 
                     task = DownloadTask(
                         url=urls[0] if urls else "",
@@ -1349,11 +1361,12 @@ class Downloader:
                     if sys.platform == "win32":
                         download_path = Path(_prepare_long_path(str(download_path.absolute())))
 
-                    # Operation 2 (destination-volume identity, v2.2 §1) — same
-                    # reasoning as operation 1 above: a refusal here is root-level,
-                    # so abort the item instead of trying another video quality.
+                    # Operation 2 — via the guarded helper (see
+                    # _guarded_mkdir's docstring); same reasoning as
+                    # operation 1 above: a refusal here is root-level, so
+                    # abort the item instead of trying another video quality.
                     try:
-                        anchor.assert_write_allowed(
+                        _guarded_mkdir(
                             video_base, download_path, self.destination_identity,
                         )
                     except anchor.DestinationNotTrusted as e:
@@ -1366,8 +1379,6 @@ class Downloader:
                             f"[red]❌ Destination not trusted ({e.check.reason})[/] {display_title}"
                         )
                         return None, False
-
-                    download_path.parent.mkdir(exist_ok=True, parents=True)
 
                     # Parse M3U8 to get segment URLs (blocking I/O → thread)
                     try:

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -33,6 +33,7 @@ from tiddl.core.api.playback import report_playback
 from tiddl.core.utils.fsio import _safe_unlink
 from tiddl.core.utils.publish import publish_verified_file
 from tiddl.core.utils import retained_registry
+from tiddl.core.utils import destination_anchor as anchor
 
 from .output import RichOutput
 
@@ -113,6 +114,16 @@ class DownloadTask:
     # Set when the download succeeded but the destination could not be published:
     # the verified local file is kept here for recovery/re-publish (never deleted).
     retained_staging: Optional[Path] = None
+    # The configured destination root this task's output_path must live under
+    # (self.download_path, or video_base for videos) — see
+    # tiddl.core.utils.destination_anchor. Set by both real construction sites
+    # in Downloader.download() below; left None only by hand-constructed
+    # DownloadTask instances (mostly tests) that don't exercise the
+    # destination-identity guard — _publish_staged() skips the check entirely
+    # when this is None, which is exactly pre-feature behavior, never a
+    # silent bypass of a real download's guard (both real call sites always
+    # set it).
+    root: Optional[Path] = None
 
     @property
     def progress_percentage(self) -> float:
@@ -266,6 +277,8 @@ class Downloader:
     download_path: Path
     scan_path: Path
     video_download_path: Optional[Path]
+    destination_identity: Literal["off", "strict"]
+    identity_tracker: "anchor.IdentityFailureTracker"
 
     def __init__(
         self,
@@ -280,6 +293,8 @@ class Downloader:
         scan_path: Path,
         video_download_path: Optional[Path] = None,
         fallback_api: Optional[TidalAPI] = None,
+        destination_identity: Literal["off", "strict"] = "off",
+        identity_tracker: Optional["anchor.IdentityFailureTracker"] = None,
     ) -> None:
         self.api = tidal_api
         # Modo hibrido: cliente TV (lossless) para cuando el primario (HiRes)
@@ -294,6 +309,14 @@ class Downloader:
         self.download_path = download_path
         self.scan_path = scan_path
         self.video_download_path = video_download_path
+        self.destination_identity = destination_identity
+        # One tracker per `tiddl download` invocation, passed explicitly by
+        # the caller (never a module global — v2.4 mandatory safeguard #2).
+        # Falls back to a throwaway instance so a Downloader constructed
+        # without one (tests, or any future caller that doesn't care about
+        # this feature) never hits an AttributeError — its any_refused is
+        # simply never observed by anything outside this instance.
+        self.identity_tracker = identity_tracker or anchor.IdentityFailureTracker()
         self.dir_cache: dict[Path, set[str]] = {}
         # Flat index: stem → set of extensions, para lookup de alternativas sin re-escanear
         self._stem_index: dict[str, set[str]] = {}
@@ -609,6 +632,35 @@ class Downloader:
             task.error_message = f"local file invalid: {err}"
             _safe_unlink(staging)
             return False, None
+
+        # Operation 3 (destination-volume identity, v2.2 §1): a second, tighter
+        # check closer to the actual write than the directory-creation checks
+        # (operations 1/2, in download() below) — narrows the gap between
+        # those and the moment bytes actually land, since staging/verification
+        # above takes real time. Skipped entirely (no I/O, per check_write_
+        # allowed's own "off" no-op) when task.root wasn't set — see
+        # DownloadTask.root's docstring above.
+        if task.root is not None:
+            try:
+                anchor.assert_write_allowed(
+                    task.root, task.output_path, self.destination_identity,
+                )
+            except anchor.DestinationNotTrusted as e:
+                # Class A (v2.3 §3): the track/video itself did not complete.
+                # Reported and retained via the exact same path an ordinary
+                # "destination could not be published" failure already takes
+                # below (retained_registry.PUBLISH_PENDING) — an identity
+                # refusal IS a publish failure, not a new failure mode with
+                # its own recovery mechanics. Distinguishable message so this
+                # is never mistaken for a generic I/O error.
+                self.identity_tracker.mark_refused(e.check)
+                task.error_message = f"destination not trusted ({e.check.reason})"
+                _detail = f" ({e.check.detail})" if e.check.detail else ""
+                log.warning(
+                    f"[destination-identity] refused to publish '{task.track_title}' "
+                    f"to {task.output_path}: {e.check.reason}{_detail}"
+                )
+                return False, staging
 
         # 2/3. Same-volume atomic rename, or cross-filesystem copy -> fsync ->
         #      verify -> atomic replace. Extracted to `publish_verified_file`
@@ -1132,11 +1184,34 @@ class Downloader:
 
                     task_id = self.rich_output.download_start(f"[{vibrant_color}]{display_title} {quality}")
 
+                    # Operation 1 (destination-volume identity, v2.2 §1): checked
+                    # before this item's own directory even exists. A refusal
+                    # here means every quality attempt would hit the same
+                    # untrusted root, so abort the item outright rather than
+                    # retrying at a lower quality (which _prepare_long_path's
+                    # alias-stripping-aware comparison would refuse identically).
+                    try:
+                        anchor.assert_write_allowed(
+                            self.download_path, download_path, self.destination_identity,
+                        )
+                    except anchor.DestinationNotTrusted as e:
+                        self.identity_tracker.mark_refused(e.check)
+                        self.rich_output.download_finish(task_id=task_id)
+                        log.warning(
+                            f"[destination-identity] refused to create directory for "
+                            f"'{display_title}': {e.check.reason}"
+                        )
+                        self.rich_output.console.print(
+                            f"[red]❌ Destination not trusted ({e.check.reason})[/] {display_title}"
+                        )
+                        return None, False
+
                     download_path.parent.mkdir(exist_ok=True, parents=True)
 
                     task = DownloadTask(
                         url=urls[0] if urls else "",
                         output_path=download_path,
+                        root=self.download_path,
                         track_id=item.id,
                         track_title=display_title,
                         max_attempts=MAX_RETRIES
@@ -1225,6 +1300,24 @@ class Downloader:
                     if sys.platform == "win32":
                         download_path = Path(_prepare_long_path(str(download_path.absolute())))
 
+                    # Operation 2 (destination-volume identity, v2.2 §1) — same
+                    # reasoning as operation 1 above: a refusal here is root-level,
+                    # so abort the item instead of trying another video quality.
+                    try:
+                        anchor.assert_write_allowed(
+                            video_base, download_path, self.destination_identity,
+                        )
+                    except anchor.DestinationNotTrusted as e:
+                        self.identity_tracker.mark_refused(e.check)
+                        log.warning(
+                            f"[destination-identity] refused to create directory for "
+                            f"'{display_title}': {e.check.reason}"
+                        )
+                        self.rich_output.console.print(
+                            f"[red]❌ Destination not trusted ({e.check.reason})[/] {display_title}"
+                        )
+                        return None, False
+
                     download_path.parent.mkdir(exist_ok=True, parents=True)
 
                     # Parse M3U8 to get segment URLs (blocking I/O → thread)
@@ -1239,6 +1332,7 @@ class Downloader:
                     video_task = DownloadTask(
                         url=urls[0] if urls else "",
                         output_path=download_path,
+                        root=video_base,
                         track_id=item.id,
                         track_title=display_title,
                         max_attempts=MAX_RETRIES

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -650,10 +650,33 @@ class Downloader:
         # check closer to the actual write than the directory-creation checks
         # (operations 1/2, in download() below) — narrows the gap between
         # those and the moment bytes actually land, since staging/verification
-        # above takes real time. Skipped entirely (no I/O, per check_write_
-        # allowed's own "off" no-op) when task.root wasn't set — see
-        # DownloadTask.root's docstring above.
-        if task.root is not None:
+        # above takes real time.
+        if task.root is None:
+            # Implementation-audit finding, P1 #2: a task with no configured
+            # root previously bypassed this guard ENTIRELY, including in
+            # strict mode — "no root was given" is not the same thing as
+            # "off mode," and must never silently publish unverified. Both
+            # current production DownloadTask() construction sites always
+            # set root (self.download_path / video_base); this branch exists
+            # only to catch a future constructor, refactor, or plugin that
+            # forgets to, and to fail closed rather than fail open when that
+            # happens under strict mode. Root-less tasks may still proceed
+            # unchecked under "off" — matches check_write_allowed's own
+            # "off" no-op (no anchor I/O either way).
+            if self.destination_identity == "strict":
+                synthetic_check = anchor.AnchorCheck(
+                    False, "no_root_configured", task.output_path,
+                    "task has no configured destination root; refusing in strict mode",
+                )
+                self.identity_tracker.mark_refused(synthetic_check)
+                task.error_message = "destination not trusted (no_root_configured)"
+                log.warning(
+                    f"[destination-identity] refused to publish '{task.track_title}' "
+                    f"to {task.output_path}: no destination root was configured for "
+                    f"this task while running in strict mode"
+                )
+                return False, staging
+        else:
             try:
                 check = anchor.assert_write_allowed(
                     task.root, task.output_path, self.destination_identity,

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -124,6 +124,19 @@ class DownloadTask:
     # silent bypass of a real download's guard (both real call sites always
     # set it).
     root: Optional[Path] = None
+    # Captured from the operation-3 guard in _publish_staged() the moment it
+    # passes with reason == "trusted" — i.e. this task's write was actually
+    # verified against a live, currently-trusted anchor, not just "no root
+    # was configured." (Implementation-audit finding, 2026-08-18: these were
+    # never captured, so every retained entry from a real download fell back
+    # to "legacy" under strict recovery regardless of destination_identity.)
+    # Both stay None when: mode == "off" (no anchor I/O happens, so there is
+    # nothing to capture — matches "off never persists identity"); task.root
+    # is None (guard skipped entirely); or the guard refused (in which case
+    # _publish_staged returns before ever reaching publish, so no retained-
+    # registry entry citing a verified anchor is ever created for it).
+    verified_root_key: Optional[str] = None
+    verified_anchor_id: Optional[str] = None
 
     @property
     def progress_percentage(self) -> float:
@@ -642,9 +655,18 @@ class Downloader:
         # DownloadTask.root's docstring above.
         if task.root is not None:
             try:
-                anchor.assert_write_allowed(
+                check = anchor.assert_write_allowed(
                     task.root, task.output_path, self.destination_identity,
                 )
+                if check.reason == "trusted":
+                    # Capture NOW, at the moment identity was actually
+                    # verified — not re-derived later, and not skipped just
+                    # because the publish below might still fail for an
+                    # unrelated I/O reason. A retained entry from that later
+                    # failure is still correctly attributable to this
+                    # verified anchor.
+                    task.verified_root_key = anchor.root_key(task.root)
+                    task.verified_anchor_id = check.anchor_id
             except anchor.DestinationNotTrusted as e:
                 # Class A (v2.3 §3): the track/video itself did not complete.
                 # Reported and retained via the exact same path an ordinary
@@ -831,6 +853,8 @@ class Downloader:
                             retained, task.output_path,
                             retained_registry.RetainReason.CLEANUP_PENDING,
                             track_title=task.track_title,
+                            destination_root=task.verified_root_key,
+                            destination_anchor_id=task.verified_anchor_id,
                         )
                         task.retained_staging = result.actual_path
                     if attempt > 1:
@@ -856,6 +880,8 @@ class Downloader:
                         retained, task.output_path,
                         retained_registry.RetainReason.PUBLISH_PENDING,
                         track_title=task.track_title,
+                        destination_root=task.verified_root_key,
+                        destination_anchor_id=task.verified_anchor_id,
                     )
                     task.retained_staging = result.actual_path
                     log.error(

--- a/tiddl/cli/commands/recover.py
+++ b/tiddl/cli/commands/recover.py
@@ -539,8 +539,6 @@ def recover(
                 )
                 raise typer.Exit(1)
 
-            _, live_anchor_id, _ = anchor.read_marker(root)
-
             console.print(
                 f"About to bind {entry.id[:8]} ({entry.output_path}) to trusted root {root}."
             )
@@ -548,13 +546,39 @@ def recover(
                 console.print("[yellow]Aborted — nothing changed.[/]")
                 raise typer.Exit(1)
 
+            # Implementation-audit finding (2026-08-18), P1 #4: the original
+            # code re-read the marker independently here
+            # (`anchor.read_marker(root)`), uncoordinated with the
+            # `check_write_allowed` call above — the marker could disappear
+            # or change between those two reads, letting a `None`
+            # live_anchor_id pair with a non-None destination_root and
+            # violate the registry's both-or-neither invariant. It also
+            # never accounted for the confirmation prompt itself taking
+            # arbitrary real time, during which the pre-prompt check could
+            # go stale.
+            #
+            # Fix: re-run ONE fresh, structured `check_write_allowed` right
+            # here, after confirmation, and persist the root/id pair from
+            # THAT SAME result — never a second, separate `read_marker()`
+            # call. This never ignores read_marker()'s status: check.reason
+            # is derived directly from it (marker_absent/marker_unreadable/
+            # marker_invalid/trusted), just never re-derived independently.
+            check = anchor.check_write_allowed(root, root, mode="strict")
+            if not check.allowed:
+                console.print(
+                    f"[red]'{root}' is no longer trusted ({check.reason}) — nothing "
+                    "was changed. Re-run 'tiddl destination trust' and try again.[/]"
+                )
+                raise typer.Exit(1)
+
             await asyncio.to_thread(
                 registry.update_entry, entry.id,
                 destination_root=anchor.root_key(root),
-                destination_anchor_id=live_anchor_id,
+                destination_anchor_id=check.anchor_id,
             )
             console.print(
-                f"[green]✓[/] Bound {entry.id[:8]} to {root} (anchor {live_anchor_id[:8]}...)."
+                f"[green]✓[/] Bound {entry.id[:8]} to {root} "
+                f"(anchor {check.anchor_id[:8]}...)."
             )
             return
 

--- a/tiddl/cli/commands/recover.py
+++ b/tiddl/cli/commands/recover.py
@@ -33,7 +33,9 @@ import typer
 from filelock import Timeout as FileLockTimeout
 from typing_extensions import Annotated
 
+from tiddl.cli.config import CONFIG
 from tiddl.cli.ctx import Context
+from tiddl.core.utils import destination_anchor as anchor
 from tiddl.core.utils import retained_registry as registry
 from tiddl.core.utils.publish import publish_verified_file
 
@@ -174,7 +176,7 @@ async def _reverify_against_entry(entry, candidate: Path) -> tuple[bool, Optiona
     return True, None
 
 
-async def _recover_one(console, re) -> bool:
+async def _recover_one(console, re, tracker: "anchor.IdentityFailureTracker") -> bool:
     """[P2, third audit finding #7] Wraps `_recover_one_inner` so a single
     entry's unexpected I/O failure (e.g. a file vanishing mid-hash due to an
     unrelated concurrent process, a transient network-share error) can't
@@ -190,13 +192,13 @@ async def _recover_one(console, re) -> bool:
     didn't fully complete."""
     entry = re.entry
     try:
-        return await _recover_one_inner(console, re)
+        return await _recover_one_inner(console, re, tracker)
     except OSError as e:
         console.print(f"[red]✗[/] {entry.id[:8]}: unexpected I/O error during recovery: {e}")
         return False
 
 
-async def _recover_one_inner(console, re) -> bool:
+async def _recover_one_inner(console, re, tracker: "anchor.IdentityFailureTracker") -> bool:
     entry = re.entry
     warnings: list = []
 
@@ -254,6 +256,38 @@ async def _recover_one_inner(console, re) -> bool:
     # PUBLISH_PENDING
     source = Path(entry.staging_path)
     destination = Path(entry.output_path)
+
+    # Destination-volume identity — triple-identity check (PROPOSAL
+    # v2.1 §7, kept local/untracked): entry.destination_anchor_id must equal
+    # BOTH the root's current local-state anchor id AND the marker actually
+    # on disk right now, not just "is the root currently trusted" — this is
+    # what catches a root that was forget-ten and re-trusted with a
+    # DIFFERENT anchor since the entry was staged/bound. `off` mode performs
+    # no anchor I/O at all (unchanged existing behavior, per
+    # destination_anchor.check_write_allowed's own "off" short-circuit).
+    if CONFIG.download.destination_identity == "strict":
+        if entry.destination_root is None:
+            console.print(
+                f"[red]✗[/] {entry.id[:8]}: no destination identity recorded for this "
+                f"legacy entry — refusing in strict mode. Run 'tiddl recover --bind-root "
+                f"{entry.id[:8]} --root <trusted-root>' first."
+            )
+            tracker.mark_refused(
+                anchor.AnchorCheck(False, "unknown_root", destination, "legacy entry")
+            )
+            return False
+        check = anchor.check_write_allowed(
+            Path(entry.destination_root), destination, mode="strict",
+            expected_anchor_id=entry.destination_anchor_id,
+        )
+        if not check.allowed:
+            console.print(
+                f"[red]✗[/] {entry.id[:8]}: destination identity check failed "
+                f"({check.reason}); refusing to publish to {destination}. Nothing was "
+                "changed — the retained local copy and registry entry are untouched."
+            )
+            tracker.mark_refused(check)
+            return False
 
     def _on_warning(msg: str) -> None:
         warnings.append(msg)
@@ -341,6 +375,28 @@ def recover(
             ),
         ),
     ] = None,
+    do_bind_root: Annotated[
+        Optional[str],
+        typer.Option(
+            "--bind-root",
+            help=(
+                "Bind a legacy retained entry (id or id prefix, no destination identity "
+                "recorded) to an already-trusted destination root. Requires --root; "
+                "the root must already be trusted via 'tiddl destination trust'."
+            ),
+        ),
+    ] = None,
+    bind_root_target: Annotated[
+        Optional[Path],
+        typer.Option("--root", help="The trusted root to bind --bind-root's entry to."),
+    ] = None,
+    bind_confirm: Annotated[
+        bool,
+        typer.Option(
+            "--confirm",
+            help="Skip the confirmation prompt for --bind-root (scripted/unattended use).",
+        ),
+    ] = False,
 ):
     """List retained files from a previous session, or recover/purge them.
 
@@ -353,12 +409,23 @@ def recover(
     recovery attempt already succeeded but crashed before it could update
     the registry — see `retained_registry.reconcile`). `--purge <id>`
     removes one acknowledged `gone`/`corrupt` entry from the registry —
-    never an `ok` or `already_published` one.
+    never an `ok` or `already_published` one. `--bind-root <id> --root
+    <trusted-root>` binds a legacy entry (staged before destination-volume
+    identity existed, or while it was set to "off") to an already-trusted
+    root, so it becomes recoverable under `destination_identity = "strict"`.
     """
     console = ctx.obj.console
+    # One tracker per `tiddl recover` invocation - command-scoped, not a
+    # module global (PROPOSAL_destination_volume_identity_v2_4.md section 2,
+    # kept local/untracked). Only ever touched from this event loop: every
+    # identity check this command performs is a plain synchronous call, not
+    # dispatched to asyncio.to_thread.
+    tracker = anchor.IdentityFailureTracker()
 
     async def _run() -> None:
-        if do_purge is None and do_publish is None and not do_all:
+        if (
+            do_purge is None and do_publish is None and not do_all and do_bind_root is None
+        ):
             # Read-only listing: no mutation, no need for the cross-process
             # recovery lock — reconcile and print against a single snapshot.
             _print_list(console, await registry.reconcile())
@@ -429,6 +496,67 @@ def recover(
 
     async def _run_mutating(console) -> None:
         report = await registry.reconcile()
+
+        if do_bind_root is not None:
+            if bind_root_target is None:
+                console.print("[red]--bind-root requires --root <trusted-root>.[/]")
+                raise typer.Exit(1)
+
+            match = _resolve(do_bind_root, report.entries)
+            if match is None:
+                console.print(f"[red]No unique retained entry matches id '{do_bind_root}'.[/]")
+                raise typer.Exit(1)
+            entry = match.entry
+
+            # v2.2 audit's explicit correction: --bind-root stays
+            # legacy-only in this PR. An already-identified entry (even one
+            # whose triple-identity check would now fail, e.g. after a
+            # forget+re-trust with a different anchor) refuses here, with
+            # no rebind path — deliberate, documented scope for this
+            # release, not a silent gap.
+            if entry.destination_root is not None or entry.destination_anchor_id is not None:
+                console.print(
+                    f"[red]{entry.id[:8]} already has a destination identity recorded "
+                    f"({entry.destination_root}) — refusing to rebind. This release "
+                    "has no rebind command; resolve manually if the recorded identity "
+                    "is genuinely wrong.[/]"
+                )
+                raise typer.Exit(1)
+
+            root = Path(bind_root_target)
+            check = anchor.check_write_allowed(root, root, mode="strict")
+            if not check.allowed:
+                console.print(
+                    f"[red]'{root}' is not currently trusted ({check.reason}). Run "
+                    f"'tiddl destination trust {root}' first.[/]"
+                )
+                raise typer.Exit(1)
+
+            if not anchor.is_contained(root, Path(entry.output_path)):
+                console.print(
+                    f"[red]{entry.output_path} is not contained under {root} — "
+                    "refusing to bind.[/]"
+                )
+                raise typer.Exit(1)
+
+            _, live_anchor_id, _ = anchor.read_marker(root)
+
+            console.print(
+                f"About to bind {entry.id[:8]} ({entry.output_path}) to trusted root {root}."
+            )
+            if not bind_confirm and not typer.confirm("Proceed?"):
+                console.print("[yellow]Aborted — nothing changed.[/]")
+                raise typer.Exit(1)
+
+            await asyncio.to_thread(
+                registry.update_entry, entry.id,
+                destination_root=anchor.root_key(root),
+                destination_anchor_id=live_anchor_id,
+            )
+            console.print(
+                f"[green]✓[/] Bound {entry.id[:8]} to {root} (anchor {live_anchor_id[:8]}...)."
+            )
+            return
 
         if do_purge is not None:
             match = _resolve(do_purge, report.entries)
@@ -514,7 +642,7 @@ def recover(
             # exit non-zero — not just `--all` batches.
             all_ok = True
             for re in targets:
-                ok = await _recover_one(console, re)
+                ok = await _recover_one(console, re, tracker)
                 all_ok = all_ok and ok
             if not all_ok:
                 console.print(

--- a/tiddl/cli/config.py
+++ b/tiddl/cli/config.py
@@ -1,8 +1,9 @@
 import os
 from logging import getLogger
 from pathlib import Path
-from pydantic import BaseModel, validator, Field
 from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, validator
 
 # Python 3.11+ has tomllib built-in, but 3.10 needs tomli package
 try:
@@ -73,6 +74,16 @@ class Config(BaseModel):
         videos_filter: VIDEOS_FILTER_LITERAL = "none"
         update_mtime: bool = False
         rewrite_metadata: bool = False
+        # Destination-volume identity (see tiddl.core.utils.destination_anchor).
+        # "off" (default): unchanged pre-existing behavior, no anchor I/O at all.
+        # "strict": every guarded write site must resolve to a currently-trusted
+        # anchor for its configured root, or the write is refused. There is no
+        # "warn" mode — see PROPOSAL_destination_volume_identity_v2_1.md §1 for
+        # why (an unresolved identity-pair ambiguity for roots never actually
+        # trusted). An unrecognized value is a config validation error at load
+        # time, same as any other invalid field here — pydantic enforces this
+        # via the Literal type below, no extra validator needed.
+        destination_identity: Literal["off", "strict"] = "off"
         artist_concurrency: int = 1
         artist_delay: float = 8.0
         track_delay: float = 3.0

--- a/tiddl/core/metadata/__init__.py
+++ b/tiddl/core/metadata/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from .track import add_track_metadata
 from .video import add_video_metadata
-from .cover import Cover
+from .cover import Cover, CoverDataNotPrefetched
 
-__all__ = ["add_track_metadata", "add_video_metadata", "Cover"]
+__all__ = ["add_track_metadata", "add_video_metadata", "Cover", "CoverDataNotPrefetched"]

--- a/tiddl/core/metadata/cover.py
+++ b/tiddl/core/metadata/cover.py
@@ -74,6 +74,30 @@ class Cover:
         if not self.data:
             self.data = self._get_data()
 
+        self.write_prefetched(path)
+
+    def write_prefetched(self, path: Path) -> None:
+        """The pure mutation half of `save_to_directory`, split out so a
+        caller that needs to run a check immediately before the write (e.g.
+        a destination-identity guard) can fetch `self.data` well ahead of
+        time and call this with no network I/O in between — a network fetch
+        between a passing check and the actual write would otherwise widen
+        the check-to-write window by however long the fetch's retry backoff
+        took (implementation-audit finding, 2026-08-18, P1 #3).
+
+        Assumes `self.data` is already populated (via `_get_data()`); falls
+        back to fetching it here only as a defensive no-op-avoidance, never
+        as the expected path for a guarded caller.
+        """
+        file = path.with_suffix(".jpg")
+
+        if file.exists():
+            log.debug(f"cover exists ({file})")
+            return
+
+        if not self.data:
+            self.data = self._get_data()
+
         file.parent.mkdir(parents=True, exist_ok=True)
 
         try:

--- a/tiddl/core/metadata/cover.py
+++ b/tiddl/core/metadata/cover.py
@@ -9,6 +9,14 @@ from requests.exceptions import RequestException
 log = getLogger(__name__)
 
 
+class CoverDataNotPrefetched(Exception):
+    """Raised by `Cover.write_prefetched()` when called with no data
+    already fetched. `write_prefetched()` must never perform network I/O
+    itself (implementation-audit finding, 2026-08-18, P1 #2) — a caller
+    that needs a guarded, network-free write must fetch first and is
+    expected to check the result before calling this."""
+
+
 class Cover:
     uid: str
     url: str
@@ -74,6 +82,10 @@ class Cover:
         if not self.data:
             self.data = self._get_data()
 
+        if not self.data:
+            log.warning(f"no cover data available, skipping write for {file}")
+            return
+
         self.write_prefetched(path)
 
     def write_prefetched(self, path: Path) -> None:
@@ -85,9 +97,18 @@ class Cover:
         the check-to-write window by however long the fetch's retry backoff
         took (implementation-audit finding, 2026-08-18, P1 #3).
 
-        Assumes `self.data` is already populated (via `_get_data()`); falls
-        back to fetching it here only as a defensive no-op-avoidance, never
-        as the expected path for a guarded caller.
+        This method NEVER performs network I/O — it does not call
+        `_get_data()` under any circumstance. An earlier version had a
+        "defensive" fallback (`if not self.data: self.data =
+        self._get_data()`) that looked harmless but was NOT: `_get_data()`
+        returns `b""` on a network/HTTP failure WITHOUT ever assigning
+        `self.data`, so `not self.data` stayed True and every legitimately-
+        empty first fetch triggered a second network fetch here — silently
+        reopening the exact check-to-write race this split was meant to
+        close (second implementation-audit finding, 2026-08-18, P1 #2).
+        Raises `CoverDataNotPrefetched` instead if `self.data` isn't
+        already a non-empty `bytes` — a programming-error signal to the
+        caller, never a silent no-op or a silent fetch.
         """
         file = path.with_suffix(".jpg")
 
@@ -96,7 +117,12 @@ class Cover:
             return
 
         if not self.data:
-            self.data = self._get_data()
+            raise CoverDataNotPrefetched(
+                "write_prefetched() requires self.data to already be "
+                "populated with a non-empty fetch result — it will not "
+                "fetch it itself. Call _get_data() (or set .data directly) "
+                "and check the result before calling this."
+            )
 
         file.parent.mkdir(parents=True, exist_ok=True)
 

--- a/tiddl/core/utils/destination_anchor.py
+++ b/tiddl/core/utils/destination_anchor.py
@@ -532,6 +532,16 @@ class AnchorCheck(NamedTuple):
     reason: AnchorCheckReason
     root: Path
     detail: Optional[str] = None
+    #: Set only when reason == "trusted" — the live, verified anchor id
+    #: (i.e. local-state record and on-disk marker already agreed, and
+    #: matched expected_anchor_id when one was given). None for every other
+    #: reason, including "disabled" (off mode never reads it) — a caller
+    #: that wants to persist "this write happened against a verified
+    #: anchor" (e.g. retained_registry.register_retained_file's
+    #: destination_root/destination_anchor_id pair) reads this field
+    #: instead of re-deriving it, added after an audit finding that no
+    #: caller could actually recover this value from a passing check.
+    anchor_id: Optional[str] = None
 
 
 class DestinationNotTrusted(Exception):
@@ -601,7 +611,7 @@ def check_write_allowed(
             "the recorded entry's anchor id does not match the currently live anchor",
         )
 
-    return AnchorCheck(True, "trusted", root)
+    return AnchorCheck(True, "trusted", root, anchor_id=marker_anchor_id)
 
 
 def assert_write_allowed(

--- a/tiddl/core/utils/destination_anchor.py
+++ b/tiddl/core/utils/destination_anchor.py
@@ -1,0 +1,664 @@
+"""Destination-volume identity — protects against `publish_verified_file`
+(and the `mkdir`s that precede it) silently landing bytes on local disk when
+a configured destination root (a NAS share, a removable drive) is supposed
+to be mounted there but isn't.
+
+Design history (kept local/untracked in the repo, not part of this diff):
+`PROPOSAL_destination_volume_identity.md` (v1) through `..._v2_4.md`, each
+reviewed by an independent audit before the next revision. This module
+implements the contract closed across those rounds — see each file's
+"Self-check" section for the exact decision each closed and which audit
+finding it responds to. The short version:
+
+* An anchor is a small marker file, `<root>/.tiddl-anchor`, written once
+  when a user explicitly runs `tiddl destination trust <root>`. A download
+  or `tiddl recover` NEVER creates, replaces, or rotates this file — only
+  the `destination` command group mutates it. This is what avoids the v1
+  design's real safety hole (an automatic in-download confirmation prompt
+  could auto-approve and permanently trust a stale local directory that
+  merely happens to sit where the real mount used to be).
+* Trust in a root is recorded twice: on the destination itself (the marker
+  file, shared by every installation pointed at that root) and locally
+  (`APP_PATH/destination_anchors.json`, per-machine, never synced). A write
+  is only ever allowed when both agree with each other (and, for recovery,
+  with what a `RetainedEntry` was staged against) — see `check_write_allowed`.
+* Everything here is read-only except `establish_anchor`/`adopt_anchor`
+  (called only from `tiddl destination trust`) and `forget_anchor` (called
+  only from `tiddl destination forget`). `check_write_allowed`/
+  `assert_write_allowed` — what every guarded write site in the download and
+  recovery paths actually calls — never mutate anything and never prompt.
+* Fail-closed throughout, mirroring `retained_registry.py`'s own proven
+  discipline: an I/O failure while reading the local state file is
+  'unreadable' (refuse, don't guess); successfully-read-but-invalid content
+  is 'unreadable'/'invalid' for the marker and 'corrupt'/'unsupported_version'
+  for local state (still refuse, but this end is safe to overwrite via a
+  deliberate `trust` re-run). Every expected filesystem failure a guarded
+  write-site check can hit is converted into one of these structured
+  outcomes INSIDE this module (see `read_state`/`read_marker`) — nothing
+  currently expected propagates as a bare `OSError` out of
+  `check_write_allowed`, so a caller's own pre-existing generic
+  `except Exception` can never accidentally swallow an identity refusal
+  (v2.4 audit, mandatory implementation safeguard #1).
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from logging import getLogger
+from pathlib import Path
+from typing import Literal, NamedTuple, Optional
+from uuid import uuid4
+
+from filelock import FileLock
+from filelock import Timeout as FileLockTimeout
+
+from tiddl.cli.const import APP_PATH
+
+from .fsio import atomic_write_bytes
+
+log = getLogger(__name__)
+
+#: Local-state file schema version. Bumped independently of
+#: `retained_registry.REGISTRY_VERSION` — the two files have no shared
+#: schema and no reason to version in lockstep.
+ANCHOR_STATE_VERSION = 1
+DEFAULT_LOCK_TIMEOUT = 10.0
+
+MARKER_FILENAME = ".tiddl-anchor"
+MARKER_FORMAT = "tiddl-destination-anchor"
+MARKER_VERSION = 1
+#: Enforced BEFORE parsing (PROPOSAL v2.1 §3) — an oversized file is
+#: 'invalid', never truncated-and-parsed.
+MARKER_MAX_BYTES = 4096
+
+
+def anchor_state_path() -> Path:
+    return APP_PATH / "destination_anchors.json"
+
+
+def _lock_path() -> Path:
+    return APP_PATH / "destination_anchors.json.lock"
+
+
+def marker_path(root: Path) -> Path:
+    return Path(root) / MARKER_FILENAME
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canonical_for_comparison(path) -> str:
+    """Lexical, comparison-only canonicalization. No `.resolve()`, no
+    symlink resolution, no network I/O — deliberately mirrors
+    `DownloadConfig.str_to_path`'s own reasoning (`tiddl/cli/config.py`):
+    `.resolve()` round-trips over the network for a mapped/NAS drive and
+    has already caused a real outage (`WinError 64`) in this codebase.
+
+    Also strips the Windows extended-length aliases `_prepare_long_path()`
+    (`tiddl/core/utils/format.py`) may already have applied to a path by the
+    time it reaches a guard call downstream of the two `downloader.py` mkdir
+    sites (PROPOSAL v2.3 §2) — the same alias-stripping
+    `downloader._normalize_dir` already does for its own DB-path comparisons,
+    duplicated here (not imported) so this module has no dependency on the
+    download package and stays usable from `tiddl recover`/`tiddl destination`
+    without constructing a `Downloader`."""
+    s = str(path)
+    if s.startswith("\\\\?\\UNC\\"):
+        s = "\\\\" + s[len("\\\\?\\UNC\\"):]
+    elif s.startswith("\\\\?\\"):
+        s = s[len("\\\\?\\"):]
+    return os.path.normcase(os.path.normpath(os.path.abspath(s)))
+
+
+def root_key(path) -> str:
+    """Public: the normalized lookup key, used both for local-state storage
+    and for every comparison this module makes. Mapped-drive letters and
+    their UNC equivalents normalize to DIFFERENT keys and are treated as
+    genuinely distinct roots — not silently unified (PROPOSAL v2.1 §8)."""
+    return _canonical_for_comparison(path)
+
+
+def is_contained(root: Path, output_path: Path) -> bool:
+    """`os.path.commonpath`-based containment — never `str.startswith()`,
+    which would treat `/mnt/nas/music-backup` as contained under
+    `/mnt/nas/music` (PROPOSAL v2.1 §8). Catches the `ValueError`
+    `os.path.commonpath` raises on Windows when the two paths are on
+    different drives, treating that exactly like "not contained"
+    (PROPOSAL v2.2 §2)."""
+    norm_root = root_key(root)
+    norm_output = root_key(output_path)
+    try:
+        return os.path.commonpath([norm_root, norm_output]) == norm_root
+    except ValueError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Marker file (`<root>/.tiddl-anchor`) — the shared, destination-side artifact.
+# ---------------------------------------------------------------------------
+
+#: 'trusted': the marker was read successfully and is well-formed (this is
+#: purely about the MARKER's own readability/shape — whether its anchor_id
+#: actually matches local state is a separate comparison one layer up, in
+#: `check_write_allowed`). 'absent': no marker file exists yet (first-use
+#: case). 'unreadable': the marker could not be physically read at all —
+#: permission error, I/O error, or a symlink (refused, never followed, POSIX
+#: `Path.is_symlink()` — PROPOSAL v2.1 §3). 'invalid': the marker WAS read
+#: but its content doesn't match the structured schema, or exceeds the size
+#: cap — mirrors `retained_registry.ReadResult`'s own
+#: unreadable-vs-corrupt distinction, applied here from the start
+#: (PROPOSAL v2.2 §6).
+MarkerStatus = Literal["trusted", "absent", "unreadable", "invalid"]
+
+
+def read_marker(root: Path) -> "tuple[MarkerStatus, Optional[str], Optional[str]]":
+    """Read-only. Returns `(status, anchor_id_or_None, detail_or_None)`.
+    Never raises — every filesystem failure this function can encounter
+    (permission error, I/O error, a symlink) is converted into a structured
+    'unreadable' result here, not left for a caller to catch."""
+    p = marker_path(root)
+    try:
+        if p.is_symlink():
+            return "unreadable", None, f"{p} is a symlink; refused, never followed"
+    except OSError as e:
+        return "unreadable", None, f"could not check {p} for symlink: {e}"
+
+    try:
+        raw = p.read_bytes()
+    except FileNotFoundError:
+        return "absent", None, None
+    except OSError as e:
+        return "unreadable", None, f"could not read {p}: {e}"
+
+    if len(raw) > MARKER_MAX_BYTES:
+        return "invalid", None, f"{p} exceeds the {MARKER_MAX_BYTES}-byte limit"
+
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        return "invalid", None, f"{p} is not valid UTF-8/JSON: {e}"
+
+    if (
+        not isinstance(data, dict)
+        or data.get("format") != MARKER_FORMAT
+        or data.get("version") != MARKER_VERSION
+    ):
+        return "invalid", None, f"{p} has an unexpected format/version"
+
+    anchor_id = data.get("anchor_id")
+    if not isinstance(anchor_id, str) or not anchor_id:
+        return "invalid", None, f"{p} is missing a valid anchor_id"
+
+    return "trusted", anchor_id, None
+
+
+class AnchorAlreadyExists(Exception):
+    """Raised by `establish_anchor` when the marker already exists — either
+    a stale precondition check (something else created it since) or a
+    genuine race with another process. Creation is exclusive-only; there is
+    no 'atomic replace' path for the marker in this design."""
+
+
+def establish_anchor(root: Path) -> str:
+    """Exclusive create: writes `root/.tiddl-anchor` with a fresh anchor id,
+    fsyncs it, then records `root -> anchor_id` in local state. Mechanical
+    only — the caller (`tiddl destination trust`) is responsible for
+    explicit user confirmation BEFORE calling this (PROPOSAL v2.1 §2).
+
+    If the local-state write fails AFTER the marker was created, the marker
+    is left in place — it's the authoritative artifact; re-running `trust
+    --adopt-existing` picks it back up (PROPOSAL v2.1 §13)."""
+    root = Path(root)
+    anchor_id = uuid4().hex
+    payload = json.dumps(
+        {"format": MARKER_FORMAT, "version": MARKER_VERSION, "anchor_id": anchor_id}
+    ).encode("utf-8")
+    mpath = marker_path(root)
+    try:
+        fd = os.open(str(mpath), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+    except FileExistsError as e:
+        raise AnchorAlreadyExists(str(mpath)) from e
+    with os.fdopen(fd, "wb") as f:
+        f.write(payload)
+        f.flush()
+        os.fsync(f.fileno())
+    _record_root_locally(root, anchor_id)
+    return anchor_id
+
+
+def adopt_anchor(root: Path) -> str:
+    """`trust --adopt-existing`: reads the existing marker's anchor id and
+    records it in THIS machine's local state only — never writes the
+    destination file (PROPOSAL v2.1 §2)."""
+    status, anchor_id, detail = read_marker(root)
+    if status != "trusted" or anchor_id is None:
+        raise ValueError(
+            f"no valid existing marker to adopt at {marker_path(root)} ({status}: {detail})"
+        )
+    _record_root_locally(root, anchor_id)
+    return anchor_id
+
+
+# ---------------------------------------------------------------------------
+# Local state (`APP_PATH/destination_anchors.json`) — per-machine, never
+# shared or synced. Same fail-closed contract as `retained_registry.py`,
+# deliberately duplicated rather than shared (PROPOSAL v2.1 §4: extracting a
+# primitive out of a merged, four-round-hardened module as a side effect of
+# an unrelated feature risks destabilizing it for a marginal reduction in
+# near-identical, independently-testable code).
+# ---------------------------------------------------------------------------
+
+LocalStateStatus = Literal["missing", "valid", "corrupt", "unsupported_version", "unreadable"]
+
+
+@dataclass
+class AnchorRecord:
+    root_key: str
+    root_display: str
+    anchor_id: str
+    trusted_at: str = field(default_factory=_utcnow_iso)
+
+    def to_json_dict(self) -> dict:
+        return asdict(self)
+
+    @staticmethod
+    def from_json_dict(d: dict) -> "AnchorRecord":
+        """Raises ValueError/TypeError/KeyError on a schema violation —
+        callers treat any such failure as making the WHOLE local-state file
+        corrupt, not just this one record, matching
+        `RetainedEntry.from_json_dict`'s own discipline: a state file that
+        can silently drop a malformed record while reporting itself valid
+        could lose track of a trusted root with no visible warning."""
+        d = dict(d)
+
+        key = d.get("root_key")
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"invalid 'root_key': {key!r}")
+        if not os.path.isabs(key):
+            raise ValueError(f"'root_key' is not absolute: {key!r}")
+
+        display = d.get("root_display")
+        if not isinstance(display, str) or not display:
+            raise ValueError(f"invalid 'root_display': {display!r}")
+
+        anchor_id = d.get("anchor_id")
+        if not isinstance(anchor_id, str) or not anchor_id:
+            raise ValueError(f"invalid 'anchor_id': {anchor_id!r}")
+
+        trusted_at = d.get("trusted_at")
+        if not isinstance(trusted_at, str):
+            raise ValueError(f"invalid 'trusted_at': {trusted_at!r}")
+        try:
+            parsed = datetime.fromisoformat(trusted_at)
+        except ValueError as e:
+            raise ValueError(f"'trusted_at' is not a valid ISO timestamp: {trusted_at!r}") from e
+        if parsed.tzinfo is None:
+            raise ValueError(f"'trusted_at' must be timezone-aware: {trusted_at!r}")
+
+        return AnchorRecord(
+            root_key=key, root_display=display, anchor_id=anchor_id, trusted_at=trusted_at
+        )
+
+
+@dataclass
+class LocalStateReadResult:
+    status: LocalStateStatus
+    records: list  # list[AnchorRecord]
+    #: Exact original bytes, for `_preserve_unreadable_state` — same
+    #: byte-for-byte-backup discipline as `retained_registry.ReadResult`.
+    raw_bytes: Optional[bytes] = None
+
+
+def _parse_state_text(text: str, raw_bytes: bytes) -> LocalStateReadResult:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        log.warning(
+            f"Destination-anchor local state at {anchor_state_path()} is not valid JSON: {e}"
+        )
+        return LocalStateReadResult(status="corrupt", records=[], raw_bytes=raw_bytes)
+
+    try:
+        version = data["version"]
+        raw_roots = data["roots"]
+        if not isinstance(raw_roots, list):
+            raise TypeError("'roots' is not a list")
+    except (KeyError, TypeError) as e:
+        log.warning(
+            f"Destination-anchor local state at {anchor_state_path()} has an unexpected shape: {e}"
+        )
+        return LocalStateReadResult(status="corrupt", records=[], raw_bytes=raw_bytes)
+
+    # Version 1 is the only version this build ever wrote or reads. Unlike
+    # `retained_registry.py`, there is no legacy pre-feature format to stay
+    # compatible with here — this file did not exist before this feature.
+    if version != ANCHOR_STATE_VERSION:
+        log.warning(
+            f"Destination-anchor local state at {anchor_state_path()} is version {version!r}, "
+            f"this build understands version {ANCHOR_STATE_VERSION}. Leaving it untouched."
+        )
+        return LocalStateReadResult(status="unsupported_version", records=[], raw_bytes=raw_bytes)
+
+    records = []
+    seen_keys = set()
+    for raw in raw_roots:
+        try:
+            record = AnchorRecord.from_json_dict(raw)
+        except (KeyError, TypeError, ValueError) as e:
+            log.warning(
+                f"Destination-anchor local state at {anchor_state_path()} has an unreadable "
+                f"entry ({e}); treating the whole file as corrupt so nothing is silently dropped."
+            )
+            return LocalStateReadResult(status="corrupt", records=[], raw_bytes=raw_bytes)
+        if record.root_key in seen_keys:
+            # Can only happen via manual tampering or a bug — silently
+            # picking one would hide that (PROPOSAL v2.1 §4).
+            log.warning(
+                f"Destination-anchor local state at {anchor_state_path()} has a duplicate "
+                f"root_key ({record.root_key!r}); treating the whole file as corrupt."
+            )
+            return LocalStateReadResult(status="corrupt", records=[], raw_bytes=raw_bytes)
+        seen_keys.add(record.root_key)
+        records.append(record)
+
+    return LocalStateReadResult(status="valid", records=records, raw_bytes=raw_bytes)
+
+
+def read_state() -> LocalStateReadResult:
+    """Read-only. Never raises — an I/O failure is 'unreadable' (nothing to
+    back up, no way to know it's safe to replace); successfully-read-but-
+    invalid content is 'corrupt'/'unsupported_version' (safe to back up and
+    replace on a future mutation). Same byte-first-then-decode split as
+    `retained_registry.read_entries` (that module's own fourth-audit-round
+    fix, applied here from the start)."""
+    path = anchor_state_path()
+    try:
+        raw_bytes = path.read_bytes()
+    except FileNotFoundError:
+        return LocalStateReadResult(status="missing", records=[])
+    except OSError as e:
+        log.warning(f"Could not read the destination-anchor local state at {path}: {e}")
+        return LocalStateReadResult(status="unreadable", records=[])
+
+    try:
+        text = raw_bytes.decode("utf-8")
+    except UnicodeDecodeError as e:
+        log.warning(f"Destination-anchor local state at {path} is not valid UTF-8: {e}")
+        return LocalStateReadResult(status="corrupt", records=[], raw_bytes=raw_bytes)
+
+    return _parse_state_text(text, raw_bytes)
+
+
+def find_record(records: list, key: str) -> Optional[AnchorRecord]:
+    for r in records:
+        if r.root_key == key:
+            return r
+    return None
+
+
+def _write_state(records: list) -> None:
+    payload = {
+        "version": ANCHOR_STATE_VERSION,
+        "roots": [r.to_json_dict() for r in records],
+    }
+    data = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    atomic_write_bytes(anchor_state_path(), data, fsync_dir=True)
+
+
+class LocalStatePreservationError(Exception):
+    """Raised when a corrupt/unsupported-version local-state file could not
+    be backed up before a mutation would otherwise overwrite it. The
+    mutation is aborted; the original file is untouched."""
+
+
+def _preserve_unreadable_state(read: LocalStateReadResult) -> None:
+    if read.raw_bytes is None:
+        return
+    ts = _utcnow_iso().replace(":", "").replace("-", "")
+    backup = anchor_state_path().with_name(f"{anchor_state_path().name}.{read.status}-{ts}.bak")
+    try:
+        atomic_write_bytes(backup, read.raw_bytes, fsync_dir=True)
+        if backup.read_bytes() != read.raw_bytes:
+            raise OSError(f"backup at {backup} did not read back identical to what was written")
+    except OSError as e:
+        log.error(
+            f"Destination-anchor local state was {read.status} AND the backup copy could "
+            f"not be written and verified ({e}); refusing to proceed with this mutation so "
+            f"the original content at {anchor_state_path()} is not lost."
+        )
+        raise LocalStatePreservationError(str(e)) from e
+    log.warning(
+        f"Destination-anchor local state was {read.status}; preserved and verified the "
+        f"original at {backup} before writing a fresh one."
+    )
+
+
+class LocalStateLockTimeout(Exception):
+    """Raised when a local-state mutation could not acquire the transaction
+    lock in time."""
+
+
+class LocalStateReadError(Exception):
+    """Raised when a local-state mutation could not even READ the file (as
+    opposed to reading it and finding invalid content). Nothing is written —
+    same reasoning as `retained_registry.RegistryReadError`."""
+
+
+def _transaction(timeout: Optional[float] = None):
+    from contextlib import contextmanager
+
+    if timeout is None:
+        timeout = DEFAULT_LOCK_TIMEOUT
+
+    @contextmanager
+    def _cm():
+        lock = FileLock(str(_lock_path()), timeout=timeout)
+        try:
+            with lock:
+                result = read_state()
+                if result.status == "unreadable":
+                    log.error(
+                        f"Refusing to mutate the destination-anchor local state at "
+                        f"{anchor_state_path()}: it could not be read, so there is nothing "
+                        "to safely back up and no way to know this mutation wouldn't "
+                        "silently discard whatever is actually on disk. Nothing was written."
+                    )
+                    raise LocalStateReadError(
+                        f"could not read {anchor_state_path()} before mutating it"
+                    )
+                if result.status in ("corrupt", "unsupported_version"):
+                    _preserve_unreadable_state(result)
+                    records = []
+                else:
+                    records = list(result.records)
+                box = {"records": records}
+                yield box
+                _write_state(box["records"])
+        except FileLockTimeout as e:
+            log.warning(
+                f"Could not acquire the destination-anchor local-state lock within "
+                f"{timeout}s ({e}); skipping this update (best-effort — the file itself, "
+                "if any, is untouched)."
+            )
+            raise LocalStateLockTimeout(str(e)) from e
+
+    return _cm()
+
+
+def _record_root_locally(root: Path, anchor_id: str) -> None:
+    record = AnchorRecord(root_key=root_key(root), root_display=str(root), anchor_id=anchor_id)
+    with _transaction() as box:
+        box["records"] = [r for r in box["records"] if r.root_key != record.root_key]
+        box["records"].append(record)
+
+
+def forget_anchor(root: Path) -> bool:
+    """Removes `root` from LOCAL state only. Never touches the shared
+    marker file — another installation, or this same machine later, may
+    still depend on it existing (PROPOSAL v2.1 §2)."""
+    key = root_key(root)
+    removed = False
+    with _transaction() as box:
+        before = len(box["records"])
+        box["records"] = [r for r in box["records"] if r.root_key != key]
+        removed = len(box["records"]) != before
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# The guard — every write site in the download and recovery paths calls
+# `assert_write_allowed`, never anything else in this module directly.
+# ---------------------------------------------------------------------------
+
+AnchorCheckReason = Literal[
+    "disabled",                # mode == "off" — allowed, unverified, no anchor I/O
+    "trusted",                 # allowed — local/marker agree (and expected_anchor_id, if given)
+    "not_contained",           # output_path is not under root at all
+    "unknown_root",            # no local-state record exists for this root yet
+    "local_state_unreadable",  # local state file exists but couldn't be read
+    "local_state_invalid",     # local state file read but corrupt/unsupported-version
+    "marker_absent",           # no marker at root at all
+    "marker_unreadable",       # marker could not be physically read (or is a symlink)
+    "marker_invalid",          # marker read but structurally wrong
+    "id_mismatch",             # local record, marker, and/or expected_anchor_id disagree
+]
+
+
+class AnchorCheck(NamedTuple):
+    allowed: bool
+    reason: AnchorCheckReason
+    root: Path
+    detail: Optional[str] = None
+
+
+class DestinationNotTrusted(Exception):
+    """Raised only by `assert_write_allowed`. Carries the full structured
+    `AnchorCheck` that caused the refusal (never a bare string) so a
+    catching call site can read `check.reason`/`check.root` for CLI/log
+    messages without re-deriving anything."""
+
+    def __init__(self, check: AnchorCheck) -> None:
+        self.check = check
+        super().__init__(f"destination write refused ({check.reason}) for root {check.root}")
+
+
+def check_write_allowed(
+    root: Path,
+    output_path: Path,
+    mode: Literal["off", "strict"],
+    expected_anchor_id: Optional[str] = None,
+) -> AnchorCheck:
+    """Pure, read-only decision. Never raises for any anchor-domain outcome
+    — including every "expected untrusted" case (unknown root, absent/
+    invalid marker, id mismatch) AND every expected filesystem failure
+    while checking (an unreadable local-state file, an unreadable/symlinked
+    marker) — all of those become a structured `AnchorCheck` with
+    `allowed=False`, never a propagated `OSError` (v2.4 audit, mandatory
+    safeguard #1: `read_state`/`read_marker` already convert every I/O
+    failure they can encounter into a structured result before it ever
+    reaches this function). A genuinely unexpected exception (a bug in this
+    module itself) is not something this function tries to catch."""
+    root = Path(root)
+    output_path = Path(output_path)
+
+    if mode == "off":
+        return AnchorCheck(True, "disabled", root)
+
+    if not is_contained(root, output_path):
+        return AnchorCheck(False, "not_contained", root, f"{output_path} is not under {root}")
+
+    state = read_state()
+    if state.status == "unreadable":
+        return AnchorCheck(
+            False, "local_state_unreadable", root, "local anchor state could not be read"
+        )
+    if state.status in ("corrupt", "unsupported_version"):
+        return AnchorCheck(
+            False, "local_state_invalid", root, f"local anchor state is {state.status}"
+        )
+
+    record = find_record(state.records, root_key(root))
+    if record is None:
+        return AnchorCheck(False, "unknown_root", root, "no trust record for this root")
+
+    marker_status, marker_anchor_id, marker_detail = read_marker(root)
+    if marker_status == "absent":
+        return AnchorCheck(False, "marker_absent", root, marker_detail)
+    if marker_status == "unreadable":
+        return AnchorCheck(False, "marker_unreadable", root, marker_detail)
+    if marker_status == "invalid":
+        return AnchorCheck(False, "marker_invalid", root, marker_detail)
+
+    # marker_status == "trusted" (present & well-formed) from here on.
+    if marker_anchor_id != record.anchor_id:
+        return AnchorCheck(False, "id_mismatch", root, "local state and marker anchor ids disagree")
+    if expected_anchor_id is not None and expected_anchor_id != marker_anchor_id:
+        return AnchorCheck(
+            False, "id_mismatch", root,
+            "the recorded entry's anchor id does not match the currently live anchor",
+        )
+
+    return AnchorCheck(True, "trusted", root)
+
+
+def assert_write_allowed(
+    root: Path,
+    output_path: Path,
+    mode: Literal["off", "strict"],
+    expected_anchor_id: Optional[str] = None,
+) -> AnchorCheck:
+    """Thin wrapper: every one of the guarded write sites calls THIS
+    function, never `check_write_allowed` directly — a site's job is
+    'proceed' or 'stop this operation', which is exactly what a raise/return
+    split gives without a separate if-allowed branch at every call site."""
+    check = check_write_allowed(root, output_path, mode, expected_anchor_id)
+    if not check.allowed:
+        raise DestinationNotTrusted(check)
+    return check
+
+
+def anchor_status(root: Path) -> AnchorCheck:
+    """Read-only status report for `tiddl destination status`. Always
+    evaluated as if mode='strict', regardless of the configured
+    `destination_identity` — status reporting must reflect the real state
+    of the world, not whatever a user currently has downloads set to."""
+    root = Path(root)
+    return check_write_allowed(root, root, mode="strict")
+
+
+# ---------------------------------------------------------------------------
+# Command-scoped, monotonic partial-failure tracking for concurrent
+# downloads (PROPOSAL v2.4 §2). One instance per `tiddl download`/`tiddl
+# recover` invocation, passed explicitly by the caller — never a module
+# global. Only ever touched from the event-loop thread: every guarded call
+# site in this feature places its `assert_write_allowed()` check BEFORE
+# dispatching the corresponding write to `asyncio.to_thread(...)`, never
+# inside the threaded function itself (see downloader.py/download/__init__.py
+# for the call sites) — so `mark_refused` is never invoked from a worker
+# thread by construction, and a plain `asyncio.Event` is safe (v2.4 audit,
+# mandatory implementation safeguard #2).
+# ---------------------------------------------------------------------------
+
+
+class IdentityFailureTracker:
+    def __init__(self) -> None:
+        import asyncio
+
+        self._event = asyncio.Event()
+        self._first: Optional[AnchorCheck] = None
+
+    def mark_refused(self, check: AnchorCheck) -> None:
+        if not self._event.is_set():
+            self._first = check
+        self._event.set()
+
+    @property
+    def any_refused(self) -> bool:
+        return self._event.is_set()
+
+    @property
+    def first_refusal(self) -> Optional[AnchorCheck]:
+        return self._first

--- a/tiddl/core/utils/destination_anchor.py
+++ b/tiddl/core/utils/destination_anchor.py
@@ -524,6 +524,15 @@ AnchorCheckReason = Literal[
     "marker_unreadable",       # marker could not be physically read (or is a symlink)
     "marker_invalid",          # marker read but structurally wrong
     "id_mismatch",             # local record, marker, and/or expected_anchor_id disagree
+    "no_root_configured",      # strict mode, but the call site had no root to check at
+                                # all (never produced by check_write_allowed/
+                                # assert_write_allowed themselves — those always require
+                                # a root argument; this reason exists for a call site,
+                                # e.g. Downloader._publish_staged, that fails closed when
+                                # its own root-bearing task/config is missing a root
+                                # while running in strict mode. Implementation-audit
+                                # finding, P1 #2: previously such a call site skipped
+                                # the guard entirely instead of refusing).
 ]
 
 

--- a/tiddl/core/utils/m3u.py
+++ b/tiddl/core/utils/m3u.py
@@ -1,19 +1,33 @@
 from __future__ import annotations
 from logging import getLogger
 from pathlib import Path
+from typing import Literal, Optional
 
 from tiddl.core.api.models import Track
+from tiddl.core.utils import destination_anchor as anchor
 
 log = getLogger(__name__)
 
 
 def save_tracks_to_m3u(
-    tracks_with_path: list[tuple[Path, Track]], path: Path
+    tracks_with_path: list[tuple[Path, Track]],
+    path: Path,
+    root: Optional[Path] = None,
+    mode: Literal["off", "strict"] = "off",
+    tracker: Optional["anchor.IdentityFailureTracker"] = None,
 ):
     """
     tracks_with_path: [track_path, Track]
     path: m3u file location
     filename: name of the m3u file
+    root/mode/tracker: destination-volume identity guard (operation 7, see
+        tiddl.core.utils.destination_anchor). Called synchronously — this
+        function is always invoked directly on the event loop, never inside
+        asyncio.to_thread, so touching `tracker` here is safe (v2.4 mandatory
+        safeguard #2 is a non-issue for this call site by construction, not
+        by a caught-after-to_thread pattern). `root` may be omitted (mode
+        stays "off") for callers that predate this feature, e.g. direct
+        unit tests of this function.
     """
 
     file = path.with_suffix(".m3u")
@@ -22,6 +36,21 @@ def save_tracks_to_m3u(
     if not tracks_with_path:
         log.warning(f"can't save '{file}', no tracks")
         return
+
+    if root is not None:
+        try:
+            anchor.assert_write_allowed(root, file, mode)
+        except anchor.DestinationNotTrusted as e:
+            # Class C (v2.3 §3): every track in this M3U already has its own
+            # truthful _db_insert record by the time this runs (the M3U is
+            # written after all per-track processing completes) — nothing to
+            # withhold here, just a distinguishable warning + tracker trip.
+            if tracker is not None:
+                tracker.mark_refused(e.check)
+            log.warning(
+                f"[destination-identity] refused m3u write for {file}: {e.check.reason}"
+            )
+            return
 
     try:
         file.parent.mkdir(parents=True, exist_ok=True)

--- a/tiddl/core/utils/retained_registry.py
+++ b/tiddl/core/utils/retained_registry.py
@@ -75,7 +75,42 @@ from .fsio import _fsync_dir, _fsync_path, _safe_unlink_warn, _same_volume, atom
 
 log = getLogger(__name__)
 
-REGISTRY_VERSION = 1
+#: Bumped from 1 to 2 by the destination-volume-identity feature (see
+#: PROPOSAL_destination_volume_identity_v2_2.md/v2_3.md §4, kept
+#: local/untracked, not part of this diff) when it added the
+#: `destination_root`/`destination_anchor_id` fields to `RetainedEntry`.
+#: `RetainedEntry.from_json_dict` ends with `RetainedEntry(**d)` against the
+#: FULL unfiltered parsed dict — an OLDER build's dataclass (without those
+#: two fields) would raise `TypeError` on those extra keys the moment it
+#: tried to read a file this build wrote, which `_parse_registry_text`
+#: catches and reports as "the whole registry corrupt". Bumping the version
+#: makes that same older build see `version != REGISTRY_VERSION` first and
+#: report the correct, non-alarming `"unsupported_version"` instead — it
+#: backs the file up before ever risking a write, exactly like every other
+#: unsupported-version case already does, and never touches it on a
+#: read-only listing. A version-1 file (written before this feature
+#: existed) is still read as before — see `_parse_registry_text` — and is
+#: upgraded to version 2 in place the first time anything mutates it
+#: (`_write_entries` always stamps the CURRENT `REGISTRY_VERSION`). Rollback
+#: to a pre-v2 build is unsupported while any version-2-only entries exist:
+#: that older build's OWN mutation would back up the version-2 content and
+#: then write back a version-1 file containing only its own change — the
+#: pre-existing version-2 entries are not lost outright (preserved
+#: byte-for-byte in the timestamped backup, same guarantee
+#: `_preserve_unreadable` already gives for a `"corrupt"` file) but do drop
+#: out of the ACTIVE registry the older build keeps operating on. Finish
+#: outstanding recoveries (drain the registry to empty) before downgrading,
+#: or restore from the backup after re-upgrading if a downgrade already
+#: happened with entries still pending.
+REGISTRY_VERSION = 2
+#: Older registry versions this build still reads (in addition to the
+#: current `REGISTRY_VERSION`) without treating them as unsupported. Every
+#: entry in a version-1 file parses as legacy — `destination_root`/
+#: `destination_anchor_id` simply aren't present in the dict, so both
+#: default to `None`, which trivially satisfies the both-or-neither
+#: invariant `RetainedEntry.from_json_dict` enforces. Any OTHER version
+#: (neither this nor `REGISTRY_VERSION`) is `"unsupported_version"`.
+_LEGACY_READABLE_VERSIONS = frozenset({1})
 DEFAULT_LOCK_TIMEOUT = 10.0
 HASH_ALGORITHM = "sha256"
 #: [P2, third audit finding #5] Schema validation previously accepted ANY
@@ -161,6 +196,18 @@ class RetainedEntry:
     #: `staging_path` is still wherever the caller originally staged it (a
     #: degraded-but-not-lost outcome — see `quarantine_file`).
     quarantined: bool = True
+    #: Destination-volume identity (see tiddl.core.utils.destination_anchor
+    #: and PROPOSAL_destination_volume_identity_v2_1.md §5, kept
+    #: local/untracked). Both-or-neither: `destination_root` is the
+    #: normalized `root_key` (NOT the display path) the live download
+    #: resolved and verified as currently trusted at staging time;
+    #: `destination_anchor_id` is that root's anchor id at that same
+    #: moment. `None`/`None` ("legacy") means either `destination_identity`
+    #: was `"off"` at staging time, or this entry predates the feature
+    #: entirely — see `tiddl recover --bind-root` for how a legacy entry
+    #: becomes recoverable under `"strict"`.
+    destination_root: Optional[str] = None
+    destination_anchor_id: Optional[str] = None
 
     def to_json_dict(self) -> dict:
         d = asdict(self)
@@ -235,8 +282,25 @@ class RetainedEntry:
         if not isinstance(quarantined, bool):
             raise ValueError(f"invalid 'quarantined': {quarantined!r}")
 
+        # Both-or-neither (PROPOSAL v2.1 §5). A version-1 file simply never
+        # has these keys, so both default to None here and this check
+        # passes trivially — legacy entries need no special-casing.
+        dest_root = d.get("destination_root")
+        dest_anchor_id = d.get("destination_anchor_id")
+        if (dest_root is None) != (dest_anchor_id is None):
+            raise ValueError(
+                "'destination_root'/'destination_anchor_id' must be both set or both "
+                f"None: {dest_root!r}, {dest_anchor_id!r}"
+            )
+        if dest_root is not None and not isinstance(dest_root, str):
+            raise ValueError(f"invalid 'destination_root': {dest_root!r}")
+        if dest_anchor_id is not None and not isinstance(dest_anchor_id, str):
+            raise ValueError(f"invalid 'destination_anchor_id': {dest_anchor_id!r}")
+
         d["reason"] = reason
         d["hash_algorithm"] = algorithm
+        d["destination_root"] = dest_root
+        d["destination_anchor_id"] = dest_anchor_id
         return RetainedEntry(**d)
 
 
@@ -296,10 +360,11 @@ def _parse_registry_text(text: str, raw_bytes: bytes) -> ReadResult:
         log.warning(f"Retained-staging registry at {registry_path()} has an unexpected shape: {e}")
         return ReadResult(status="corrupt", entries=[], raw_bytes=raw_bytes)
 
-    if version != REGISTRY_VERSION:
+    if version != REGISTRY_VERSION and version not in _LEGACY_READABLE_VERSIONS:
         log.warning(
             f"Retained-staging registry at {registry_path()} is version {version!r}, "
-            f"this build understands version {REGISTRY_VERSION}. Leaving it untouched."
+            f"this build understands version {REGISTRY_VERSION} (and legacy "
+            f"{sorted(_LEGACY_READABLE_VERSIONS)}). Leaving it untouched."
         )
         return ReadResult(status="unsupported_version", entries=[], raw_bytes=raw_bytes)
 
@@ -762,6 +827,8 @@ async def register_retained_file(
     output_path: Path,
     reason: RetainReason,
     track_title: Optional[str] = None,
+    destination_root: Optional[str] = None,
+    destination_anchor_id: Optional[str] = None,
 ) -> RegisterResult:
     """Quarantine `retained` and record it in the registry. Best-effort end
     to end: a registry-persistence failure is logged and leaves `entry=None`
@@ -770,7 +837,15 @@ async def register_retained_file(
     failure) into an exception for the CURRENT run. `actual_path` on the
     returned result is ALWAYS the file's real current location — even when
     persistence fails after the file has already been (possibly)
-    quarantined — so the caller's own in-process pointer never goes stale."""
+    quarantined — so the caller's own in-process pointer never goes stale.
+
+    `destination_root`/`destination_anchor_id` (both or neither — see
+    `RetainedEntry`): the caller's job to capture from a live
+    `destination_anchor.check_write_allowed(...)` result at the moment this
+    file was staged, per PROPOSAL_destination_volume_identity_v2_1.md §5
+    (kept local/untracked) — this function does not itself know anything
+    about destination-volume identity, matching `publish_verified_file`'s
+    own "stay root-agnostic" design."""
     entry_id = uuid4().hex
     suffix = output_path.suffix or Path(retained).suffix
     retained = Path(retained)
@@ -797,6 +872,8 @@ async def register_retained_file(
             observed_hash=digest,
             track_title=track_title,
             quarantined=quarantined,
+            destination_root=destination_root,
+            destination_anchor_id=destination_anchor_id,
         )
         persisted_entry = await asyncio.to_thread(add_entry, entry)
         return RegisterResult(actual_path=final_path, entry=persisted_entry)


### PR DESCRIPTION
# English

## What changed

This PR adds an opt-in destination-volume identity safeguard for downloads and recovery:

- introduces `tiddl destination trust`, `status`, and `forget`;
- validates the configured destination immediately before all nine destination write sites;
- fails closed in `strict` mode when the root is missing, unknown, replaced, unreadable, or no longer carries the trusted marker;
- stores destination root + anchor identity on retained staging entries and enforces the triple-identity contract during recovery;
- adds controlled `--bind-root` handling for legacy retained entries;
- preserves verified staging data when publication is refused and exits the download command non-zero;
- closes check-to-write gaps around metadata and cover writes;
- keeps cover writes network-free after the final identity check;
- preserves truthful SQLite records across Class C cover/M3U refusals while withholding Class B inserts for incomplete per-item writes.

The feature remains disabled by default with:

```toml
[download]
destination_identity = "off"
```

Users opt in by trusting the intended root and selecting `strict`.

## Why

NAS shares, USB drives, network mappings, cloud-mounted folders, and other removable destinations can disappear while the same path remains writable locally. Without a volume identity check, a download may silently publish into the wrong filesystem. This change binds writes and recovery to a locally trusted marker so path equality alone is no longer treated as proof of destination identity.

## Validation

- independent reconstructed Windows audit: `294 passed, 3 skipped` (297 collected);
- six focused SQLite/CLI outcome tests pass;
- `python -m compileall -q tiddl tests` is clean;
- Ruff delta versus `a876407`: `606 -> 602`, with no new findings;
- published `tiddl/` and `tests/` trees match the audited diff byte-for-byte;
- 15 commits preserved in the original order; published HEAD: `2d73bd9` (including the Windows Rich-wrapping CI follow-up).

# Español

## Qué cambia

Este PR añade una protección opt-in basada en la identidad real del volumen de destino:

- incorpora `tiddl destination trust`, `status` y `forget`;
- valida el destino configurado inmediatamente antes de los nueve puntos de escritura;
- funciona en modo fail-closed cuando `strict` detecta un root ausente, desconocido, sustituido, ilegible o sin el marker confiable;
- guarda root + identidad del anchor en las entradas de staging retenido y aplica triple identidad durante la recuperación;
- añade `--bind-root` controlado para entradas legacy;
- conserva el staging verificado si la publicación es rechazada y devuelve salida distinta de cero;
- cierra condiciones check-to-write en metadata y portadas;
- impide nuevas peticiones de red después del guard final de una portada;
- conserva registros SQLite válidos ante rechazos Class C y evita insertar registros Class B de elementos incompletos.

La función permanece desactivada por defecto mediante `destination_identity = "off"`. Para activarla, el usuario debe confiar explícitamente el root correcto y seleccionar `strict`.

## Motivo

Un NAS, disco USB, mapeo de red o volumen montado puede desaparecer mientras la misma ruta sigue siendo escribible localmente. Sin verificar la identidad del volumen, la descarga podría publicarse silenciosamente en el filesystem equivocado. Esta implementación vincula cada escritura y recuperación a un marker confiable, por lo que compartir la misma ruta ya no basta para autorizar la operación.

## Validación

- auditoría independiente reconstruida en Windows: `294 passed, 3 skipped` (297 casos);
- seis pruebas dirigidas de resultados SQLite/CLI en verde;
- `compileall` limpio;
- Ruff mejora de `606` a `602`, sin hallazgos nuevos;
- los árboles publicados `tiddl/` y `tests/` coinciden byte a byte con el diff auditado;
- 15 commits preservados en su orden; HEAD publicado: `2d73bd9` (incluye el ajuste de wrapping de Rich detectado por CI en Windows).

## Merge gate / Puerta de merge

Do not merge until the full GitHub Actions matrix and automated review are green.  
No hacer merge hasta que toda la matriz de GitHub Actions y la revisión automática estén en verde.

## Summary by Sourcery

Protect download and recovery writes against destination-volume changes through an opt-in, fail-closed identity trust mechanism.

New Features:
- Add opt-in destination-volume identity protection with trust, status, and forget commands for downloads and recovery.
- Add controlled binding of legacy retained entries to trusted destination roots.

Bug Fixes:
- Prevent downloads and recovery from writing to an unintended local filesystem when a configured destination mount is missing, replaced, unreadable, or no longer trusted.
- Close check-to-write gaps for metadata, cover, playlist, lyric, timestamp, and publication writes, while retaining verified staging data after refused publication.
- Preserve accurate SQLite records by withholding incomplete per-item inserts and leaving completed records unchanged when later cover or playlist writes are refused.

Enhancements:
- Enforce triple identity matching during recovery and return a non-zero download status when any destination identity check refuses a write.
- Version retained-staging records to persist destination identity while remaining compatible with legacy registries.

Documentation:
- Document the destination-volume identity configuration and user-facing trust workflow in the changelog, example configuration, and README.

Tests:
- Add comprehensive coverage for destination anchor lifecycle, guarded writes, recovery binding, retained registry migration, and SQLite outcome semantics.

## CI follow-up / Seguimiento de CI

The first matrix found one Windows-only test assertion affected by Rich line wrapping. Commit `2d73bd9` normalizes that existing CLI output through `_flat()`. The focused test and local suite passed, and the second GitHub Actions matrix completed **13/13 green** on Windows and Ubuntu.

La primera matriz detectó una aserción de test exclusiva de Windows afectada por el salto de línea de Rich. El commit `2d73bd9` normaliza esa salida mediante `_flat()`. El test dirigido y la suite local pasaron, y la segunda matriz de GitHub Actions terminó **13/13 en verde** en Windows y Ubuntu.
