### PR TITLE
chore(release): prepare v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ---
 
-## [Unreleased] — 2026-07-19
+## [Unreleased]
+
+---
+
+## [1.2.0] - 2026-08-19
 
 ### ✨ Added
 
@@ -64,12 +68,6 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
   the actual error message, burying it. The downloader teardown now exits early when
   no resources were queued.
 
----
-
-## [Unreleased] — 2026-05-16
-
-### 🐛 Fixed
-
 - **Video ARTIST tag: multi-value list** (`tiddl/core/metadata/video.py`)
   — Video metadata now writes ARTIST as a list of individual names (sorted MAIN then
   FEATURED) instead of a single joined string. Consistent with music track behavior.
@@ -79,12 +77,6 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
   — Date tag now stores only the year (e.g. `2025`) instead of the full datetime string
   (`2025-05-15 00:00:00`). Consistent with music track behavior and iTunes/Apple Music
   expectations.
-
----
-
-## [Unreleased] — 2026-05-15
-
-### 🐛 Fixed
 
 - **Skip-existing now checks destination folder** (`cli/commands/download/__init__.py`,
   `cli/commands/download/downloader.py`)

--- a/README.md
+++ b/README.md
@@ -356,6 +356,6 @@ This tool respects TIDAL's ToS and copyright laws. Users are responsible for ens
 
 ---
 
-**Version:** 1.1.7
+**Version:** 1.2.0
 **Status:** Production Ready ✅
-**Last Updated:** August 16, 2026
+**Last Updated:** August 19, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.1.7"
+version = "1.2.0"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## English

Prepares the v1.2.0 release.

### Changes
- Bumps package and README version from 1.1.7 to 1.2.0.
- Consolidates the pending changelog entries into the 1.2.0 release dated 2026-08-19.
- Keeps a fresh empty Unreleased section for future work.

### Local validation
- 294 passed, 3 skipped.
- compileall clean for tiddl and tests.
- wheel and sdist built successfully.
- clean-venv wheel install, pip check, version metadata, and CLI smoke test passed.

No production behavior is changed by this PR; it packages the already-merged and audited work.

## Español

Prepara el release v1.2.0.

### Cambios
- Actualiza la versión del paquete y README de 1.1.7 a 1.2.0.
- Consolida las entradas pendientes del changelog en el release 1.2.0 con fecha 2026-08-19.
- Conserva una sección Unreleased nueva y vacía para trabajo futuro.

### Validación local
- 294 aprobados, 3 omitidos.
- compileall limpio para tiddl y tests.
- wheel y sdist construidos correctamente.
- Instalación del wheel en venv limpio, pip check, metadata de versión y smoke del CLI correctos.

Este PR no cambia el comportamiento de producción; empaqueta el trabajo ya mergeado y auditado.

## Summary by Sourcery

Prepare the v1.2.0 release without changing production behavior.

Enhancements:
- Prepare the project metadata and documentation for the v1.2.0 release.

Documentation:
- Consolidate pending changelog entries into the dated v1.2.0 release and reset the Unreleased section.