### PR TITLE
fix(cli): report SemVer and modernize license metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+### Changed
+
+- **Accurate CLI version output** — `tiddl --version` now reads the installed
+  distribution metadata and reports the actual SemVer version instead of the
+  fixed `elvigilante-julio-2026` label. Git-installed builds still append their
+  commit and date when that provenance is available.
+- **Modern package license metadata** — Packaging now uses the PEP 639 SPDX
+  expression (`MIT`) and explicitly includes `LICENSE`, eliminating deprecated
+  setuptools metadata before its 2027 removal deadline.
+
 ---
 
 ## [1.2.0] - 2026-08-19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=65.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,8 @@ name = "tiddl-elvigilante"
 version = "1.2.0"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     {name = "np3ir"},
     {name = "tiddl-elvigilante contributors"},
@@ -20,7 +21,6 @@ keywords = ["tidal", "downloader", "music", "streaming", "python3.10", "tidal-do
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: End Users/Desktop",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -23,13 +23,23 @@ def test_installed_version_has_controlled_fallback(monkeypatch):
     assert app_module._installed_version() == "unknown"
 
 
+def test_installed_version_survives_malformed_metadata(monkeypatch):
+    def malformed(_name: str) -> str:
+        raise ValueError("invalid distribution metadata")
+
+    monkeypatch.setattr(importlib.metadata, "version", malformed)
+
+    assert app_module._installed_version() == "unknown"
+
+
 def test_version_callback_reports_semver_without_network(monkeypatch, capsys):
     monkeypatch.setattr(app_module, "_installed_version", lambda: "1.2.3")
     monkeypatch.setattr(app_module, "_installed_commit", lambda: "")
 
-    with pytest.raises(typer.Exit):
+    with pytest.raises(typer.Exit) as exc_info:
         app_module.version_callback(True)
 
+    assert exc_info.value.exit_code == 0
     assert capsys.readouterr().out == "tiddl-elvigilante 1.2.3\n"
 
 
@@ -40,9 +50,10 @@ def test_version_callback_keeps_git_provenance(monkeypatch, capsys):
         app_module, "_commit_datetime", lambda _commit: "2026-08-19 09:30"
     )
 
-    with pytest.raises(typer.Exit):
+    with pytest.raises(typer.Exit) as exc_info:
         app_module.version_callback(True)
 
+    assert exc_info.value.exit_code == 0
     assert (
         capsys.readouterr().out
         == "tiddl-elvigilante 1.2.3 (abcdef12, 2026-08-19 09:30)\n"

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.metadata
+
+import pytest
+import typer
+
+from tiddl.cli import app as app_module
+
+
+def test_installed_version_reads_distribution_metadata(monkeypatch):
+    monkeypatch.setattr(importlib.metadata, "version", lambda name: "1.2.3")
+
+    assert app_module._installed_version() == "1.2.3"
+
+
+def test_installed_version_has_controlled_fallback(monkeypatch):
+    def missing(_name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError
+
+    monkeypatch.setattr(importlib.metadata, "version", missing)
+
+    assert app_module._installed_version() == "unknown"
+
+
+def test_version_callback_reports_semver_without_network(monkeypatch, capsys):
+    monkeypatch.setattr(app_module, "_installed_version", lambda: "1.2.3")
+    monkeypatch.setattr(app_module, "_installed_commit", lambda: "")
+
+    with pytest.raises(typer.Exit):
+        app_module.version_callback(True)
+
+    assert capsys.readouterr().out == "tiddl-elvigilante 1.2.3\n"
+
+
+def test_version_callback_keeps_git_provenance(monkeypatch, capsys):
+    monkeypatch.setattr(app_module, "_installed_version", lambda: "1.2.3")
+    monkeypatch.setattr(app_module, "_installed_commit", lambda: "abcdef12")
+    monkeypatch.setattr(
+        app_module, "_commit_datetime", lambda _commit: "2026-08-19 09:30"
+    )
+
+    with pytest.raises(typer.Exit):
+        app_module.version_callback(True)
+
+    assert (
+        capsys.readouterr().out
+        == "tiddl-elvigilante 1.2.3 (abcdef12, 2026-08-19 09:30)\n"
+    )
+
+
+def test_version_callback_ignores_false_value(capsys):
+    assert app_module.version_callback(False) is None
+    assert capsys.readouterr().out == ""

--- a/tiddl/cli/app.py
+++ b/tiddl/cli/app.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import importlib.metadata
 import sys
 import typer
 import logging
@@ -36,10 +37,10 @@ def _installed_version() -> str:
     and bundled applications, so the CLI cannot drift from ``pyproject.toml``.
     """
     try:
-        import importlib.metadata as _md
-
-        return _md.version("tiddl-elvigilante")
-    except _md.PackageNotFoundError:
+        return importlib.metadata.version("tiddl-elvigilante")
+    except Exception:
+        # --version must remain available even if installed metadata is missing
+        # or malformed; it is also a primary troubleshooting command.
         return "unknown"
 
 

--- a/tiddl/cli/app.py
+++ b/tiddl/cli/app.py
@@ -29,6 +29,20 @@ app = typer.Typer(name="tiddl", no_args_is_help=True, rich_markup_mode="rich")
 register_commands(app)
 
 
+def _installed_version() -> str:
+    """Return the installed distribution version, or a stable fallback.
+
+    ``importlib.metadata`` reads the same package metadata used by pip, wheels,
+    and bundled applications, so the CLI cannot drift from ``pyproject.toml``.
+    """
+    try:
+        import importlib.metadata as _md
+
+        return _md.version("tiddl-elvigilante")
+    except _md.PackageNotFoundError:
+        return "unknown"
+
+
 def _installed_commit() -> str:
     """Short git commit of the installed tiddl-elvigilante (empty if unknown).
     Read from the pip direct_url.json written for git installs; works both for
@@ -68,8 +82,9 @@ def _commit_datetime(commit: str) -> str:
 
 def version_callback(value: bool):
     if value:
+        version = _installed_version()
         commit = _installed_commit()
-        out = "elvigilante-julio-2026"
+        out = f"tiddl-elvigilante {version}"
         if commit:
             when = _commit_datetime(commit)
             out += f" ({commit}" + (f", {when}" if when else "") + ")"


### PR DESCRIPTION
## English

Applies two follow-up recommendations from the v1.2.0 release audit.

### Changes
- `tiddl --version` now reports the installed `tiddl-elvigilante` SemVer from distribution metadata instead of a fixed edition label.
- Git-installed builds preserve the optional commit/date provenance suffix.
- Missing distribution metadata degrades to the stable `unknown` value without crashing.
- Package license metadata now uses the PEP 639 SPDX expression `MIT` and explicitly includes `LICENSE`.
- The build backend floor is raised to setuptools 77 and the deprecated license classifier is removed.
- Five focused version-output tests and Unreleased changelog entries are included.

### Validation
- 299 passed, 3 skipped.
- New test file Ruff-clean.
- `tiddl --version` -> `tiddl-elvigilante 1.2.0`.
- Wheel and sdist build without the previous license deprecation warnings.
- requirements.lock remains in sync.

## Español

Aplica dos recomendaciones posteriores a la auditoría del release v1.2.0.

### Cambios
- `tiddl --version` ahora muestra la versión SemVer instalada desde la metadata de distribución, en lugar de una etiqueta fija.
- Las instalaciones desde Git conservan el sufijo opcional con commit y fecha.
- Si no existe metadata de distribución, degrada de forma controlada a `unknown` sin cerrar el CLI.
- La licencia usa ahora la expresión SPDX `MIT` de PEP 639 e incluye `LICENSE` explícitamente.
- El backend de build requiere setuptools 77 y se elimina el clasificador de licencia obsoleto.
- Se añaden cinco tests dirigidos y entradas en Unreleased.

### Validación
- 299 aprobados, 3 omitidos.
- Archivo de tests nuevo limpio en Ruff.
- `tiddl --version` -> `tiddl-elvigilante 1.2.0`.
- Wheel y sdist sin las advertencias anteriores de licencia.
- requirements.lock permanece sincronizado.

## Summary by Sourcery

Make CLI version reporting distribution-aware and update package licensing metadata for modern setuptools compatibility.

New Features:
- Report the installed package SemVer in `tiddl --version`, including available Git commit and date provenance.

Bug Fixes:
- Keep version reporting operational with an `unknown` fallback when distribution metadata is unavailable or malformed.

Enhancements:
- Modernize package license metadata to the PEP 639 SPDX format and explicitly include the LICENSE file.
- Raise the minimum setuptools build requirement and remove the deprecated license classifier.

Documentation:
- Document the updated CLI version reporting and package license metadata in the Unreleased changelog.

Tests:
- Add focused coverage for metadata lookup, fallback behavior, version output, Git provenance, and disabled version callbacks.