### PR TITLE
chore(release): prepare v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+---
+
+## [1.2.1] - 2026-08-19
+
 ### Changed
 
 - **Accurate CLI version output** — `tiddl --version` now reads the installed

--- a/README.md
+++ b/README.md
@@ -356,6 +356,6 @@ This tool respects TIDAL's ToS and copyright laws. Users are responsible for ens
 
 ---
 
-**Version:** 1.2.0
+**Version:** 1.2.1
 **Status:** Production Ready ✅
 **Last Updated:** August 19, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.2.0"
+version = "1.2.1"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## English

Patch release for the post-v1.2.0 CLI and packaging improvements merged in PR #17.

### Included
- `tiddl --version` reports the installed SemVer and optional Git provenance.
- Version lookup remains usable with missing or malformed distribution metadata.
- PEP 639 SPDX license metadata with explicit LICENSE inclusion.
- Six focused version tests.

### Validation
- 300 passed, 3 skipped.
- requirements.lock in sync.
- Wheel and sdist built successfully without license deprecation warnings.

## Español

Patch release para las mejoras de CLI y empaquetado posteriores a v1.2.0, mergeadas en el PR #17.

### Incluye
- `tiddl --version` muestra la versión SemVer instalada y procedencia Git opcional.
- La consulta de versión sigue funcionando con metadata ausente o corrupta.
- Metadata de licencia SPDX/PEP 639 con inclusión explícita de LICENSE.
- Seis tests dirigidos de versión.

### Validación
- 300 aprobados, 3 omitidos.
- requirements.lock sincronizado.
- Wheel y sdist construidos sin advertencias deprecadas de licencia.

## Summary by Sourcery

Prepare the 1.2.1 patch release by synchronizing the package metadata and project documentation.

Enhancements:
- Update the project and documentation to the 1.2.1 patch release.

Documentation:
- Record the 1.2.1 release in the changelog and update the documented version.