### PR TITLE
docs: add bilingual destination safety guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+### Documentation
+
+- Added a bilingual destination-safety guide and linked user-facing setup,
+  configuration, second-machine adoption and recovery instructions from the
+  README, configuration reference, usage guide and Spanish tutorial.
+
 ---
 
 ## [1.2.1] - 2026-08-19

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -33,6 +33,7 @@ skip_existing = true
 threads_count = 4
 requests_per_minute = 50
 download_path = "~/Music/tiddl"
+destination_identity = "off"
 
 [metadata]
 enable = true
@@ -113,6 +114,33 @@ artist_separator = " / "
 - **Type**: path
 - **Default**: ~/Music/tiddl
 - Base directory for downloads
+
+### `destination_identity`
+- **Type**: `off` / `strict`
+- **Default**: `off`
+- **Description**: Protects NAS, USB and network destinations from accidental
+  writes when the expected volume is missing or has been replaced.
+- `off`: preserves the traditional behavior and performs no identity checks.
+- `strict`: allows writes only when the configured destination root has a
+  matching local trust record and `.tiddl-anchor` marker.
+
+Trust the exact root used by `download_path` before enabling strict mode:
+
+```powershell
+tiddl destination trust "Z:\"
+tiddl destination status "Z:\"
+```
+
+Then configure:
+
+```toml
+[download]
+download_path = "Z:\\"
+destination_identity = "strict"
+```
+
+See **[DESTINATION_SAFETY.md](DESTINATION_SAFETY.md)** for Windows, Linux,
+macOS, second-machine adoption, recovery and troubleshooting instructions.
 
 ### `scan_path`
 - **Type**: path

--- a/DESTINATION_SAFETY.md
+++ b/DESTINATION_SAFETY.md
@@ -1,0 +1,275 @@
+# Destination Safety / Seguridad del destino
+
+Destination-volume identity is an opt-in safety feature for NAS shares, USB
+drives, mapped network drives and other removable or remote destinations. It
+prevents tiddl from publishing files when the mounted destination is not the
+same volume the user explicitly trusted.
+
+La identidad del volumen de destino es una protección opcional para NAS,
+unidades USB, discos de red y otros destinos remotos o extraíbles. Evita que
+tiddl publique archivos cuando el destino montado no sea el mismo volumen que
+el usuario autorizó expresamente.
+
+---
+
+## English
+
+### Why enable it?
+
+An unavailable NAS or USB drive can leave behind a valid-looking path. Without
+an identity check, an application may write to that local fallback path instead
+of the intended volume. Strict mode requires two matching pieces of evidence:
+
+1. A local trust record on the current machine.
+2. A `.tiddl-anchor` marker stored at the real destination root.
+
+If either is missing, unreadable or different, tiddl refuses the destination
+write. Verified staging data is retained for recovery instead of being lost.
+
+### One-time setup
+
+First confirm that the real destination is mounted. Always trust the **exact
+same root** configured as `download_path`.
+
+Windows drive-letter example:
+
+```powershell
+Get-PSDrive Z
+tiddl destination trust "Z:\"
+tiddl destination status "Z:\"
+```
+
+UNC path example:
+
+```powershell
+tiddl destination trust "\\server\Music"
+tiddl destination status "\\server\Music"
+```
+
+Linux/macOS example:
+
+```bash
+mountpoint /mnt/music
+tiddl destination trust /mnt/music
+tiddl destination status /mnt/music
+```
+
+The status command should report `trusted`. Then edit
+`~/.tiddl/config.toml` (`C:\Users\YourName\.tiddl\config.toml` on Windows):
+
+```toml
+[download]
+download_path = "Z:\\"
+scan_path = "Z:\\"
+destination_identity = "strict"
+```
+
+Normal download commands do not change. Strict mode checks the destination
+immediately before protected writes.
+
+### A second computer or fresh installation
+
+The destination marker may already exist while the second machine has no local
+record. With the real volume mounted, adopt the existing marker:
+
+```powershell
+tiddl destination trust "Z:\" --adopt-existing
+```
+
+Do not use `--adopt-existing` if you cannot independently confirm that the path
+is the intended physical or network destination.
+
+For unattended automation only, `--confirm-mounted` skips the interactive
+question. Use it only after the script has independently verified the mount.
+
+### Status and troubleshooting
+
+```powershell
+tiddl destination status "Z:\"
+```
+
+| Result | Meaning | Action |
+|---|---|---|
+| `trusted` | Local record and destination marker agree. | Downloads may publish normally. |
+| `local_state_unreadable` | The local trust database cannot be read safely. | Check its permissions or corruption before retrying; do not recreate trust blindly. |
+| `unknown_root` | This machine has no trust record for the root. | Trust it, or adopt an independently verified existing marker. |
+| `marker_absent` | The trusted root is present without its marker. | Confirm the correct volume is mounted; do not blindly retrust it. |
+| `marker_invalid` / `marker_unreadable` | The marker cannot be validated. | Check permissions and storage health. |
+| `id_mismatch` | Local record and mounted marker identify different destinations. | Stop and verify the mount; never overwrite the marker to bypass the warning. |
+
+`destination status` is read-only. A non-`trusted` result is status information
+and may still return process exit code 0; scripts should inspect the reported
+reason instead of relying only on the exit code.
+
+### Retained-file recovery
+
+List retained files without contacting TIDAL or modifying them:
+
+```bash
+tiddl recover
+```
+
+After restoring and trusting the correct destination, publish one retained
+entry or all eligible entries:
+
+```bash
+tiddl recover --publish ENTRY_ID
+tiddl recover --all --yes
+```
+
+For a legacy retained entry that has no destination identity, first bind it to
+an already-trusted root:
+
+```powershell
+tiddl recover --bind-root ENTRY_ID --root "Z:\" --confirm
+```
+
+### Disable or forget
+
+To disable enforcement while keeping trust records, set:
+
+```toml
+[download]
+destination_identity = "off"
+```
+
+To remove only this machine's local trust record:
+
+```powershell
+tiddl destination forget "Z:\"
+```
+
+`forget` intentionally does **not** delete `.tiddl-anchor` from the shared
+destination because another installation may still depend on it.
+
+---
+
+## Español
+
+### ¿Por qué activarlo?
+
+Cuando un NAS o USB no está disponible, puede quedar una ruta aparentemente
+válida en el equipo. Sin comprobar su identidad, una aplicación podría escribir
+en esa carpeta local en vez del volumen esperado. El modo estricto exige dos
+evidencias coincidentes:
+
+1. Un registro de confianza local en la computadora actual.
+2. Un marcador `.tiddl-anchor` guardado en la raíz del destino real.
+
+Si falta alguno, no se puede leer o no coincide, tiddl rechaza la escritura. Los
+archivos verificados de staging se conservan para recuperación.
+
+### Configuración inicial — una sola vez
+
+Primero confirmá que el destino real esté conectado. Autorizá siempre la
+**misma raíz exacta** configurada como `download_path`.
+
+Ejemplo con unidad de Windows:
+
+```powershell
+Get-PSDrive Z
+tiddl destination trust "Z:\"
+tiddl destination status "Z:\"
+```
+
+Ejemplo con ruta UNC:
+
+```powershell
+tiddl destination trust "\\servidor\Musica"
+tiddl destination status "\\servidor\Musica"
+```
+
+Ejemplo Linux/macOS:
+
+```bash
+mountpoint /mnt/musica
+tiddl destination trust /mnt/musica
+tiddl destination status /mnt/musica
+```
+
+El estado debe mostrar `trusted`. Después editá `~/.tiddl/config.toml`
+(`C:\Users\TuNombre\.tiddl\config.toml` en Windows):
+
+```toml
+[download]
+download_path = "Z:\\"
+scan_path = "Z:\\"
+destination_identity = "strict"
+```
+
+Los comandos de descarga no cambian. El modo estricto verifica el destino justo
+antes de cada escritura protegida.
+
+### Segunda computadora o instalación nueva
+
+El marcador puede existir en el NAS aunque la computadora nueva todavía no
+tenga un registro local. Con el volumen real conectado, adoptalo así:
+
+```powershell
+tiddl destination trust "Z:\" --adopt-existing
+```
+
+No uses `--adopt-existing` si no podés confirmar por otro medio que la ruta
+pertenece al destino físico o de red correcto.
+
+Solo para automatización sin supervisión, `--confirm-mounted` omite la pregunta
+interactiva. Usalo únicamente si el script ya verificó el montaje por otro medio.
+
+### Estado y diagnóstico
+
+```powershell
+tiddl destination status "Z:\"
+```
+
+| Resultado | Significado | Acción |
+|---|---|---|
+| `trusted` | El registro local y el marcador coinciden. | Las descargas pueden publicar normalmente. |
+| `local_state_unreadable` | No se puede leer con seguridad la base local de confianza. | Revisar sus permisos o corrupción antes de reintentar; no recrear la confianza a ciegas. |
+| `unknown_root` | Esta computadora no confía todavía en esa raíz. | Autorizarla o adoptar un marcador existente verificado. |
+| `marker_absent` | La raíz confiable aparece sin marcador. | Confirmar que está montado el volumen correcto; no autorizarlo a ciegas. |
+| `marker_invalid` / `marker_unreadable` | No se puede validar el marcador. | Revisar permisos y salud del almacenamiento. |
+| `id_mismatch` | El registro y el marcador identifican destinos diferentes. | Detenerse y revisar el montaje; no sobrescribir el marcador para evitar el aviso. |
+
+`destination status` es de solo lectura. Un resultado distinto de `trusted` es
+información de estado y puede devolver código de proceso 0; los scripts deben
+leer la razón mostrada y no depender solamente del código de salida.
+
+### Recuperar archivos retenidos
+
+Listá los archivos sin contactar TIDAL ni modificarlos:
+
+```bash
+tiddl recover
+```
+
+Después de restaurar y confiar en el destino correcto:
+
+```bash
+tiddl recover --publish ID_DE_ENTRADA
+tiddl recover --all --yes
+```
+
+Para una entrada antigua sin identidad de destino, vinculala primero a una raíz
+que ya esté autorizada:
+
+```powershell
+tiddl recover --bind-root ID_DE_ENTRADA --root "Z:\" --confirm
+```
+
+### Desactivar u olvidar
+
+Para desactivar la protección conservando los registros:
+
+```toml
+[download]
+destination_identity = "off"
+```
+
+Para retirar solo la confianza local de esta computadora:
+
+```powershell
+tiddl destination forget "Z:\"
+```
+
+`forget` no borra `.tiddl-anchor` del destino compartido porque otra
+instalación puede seguir utilizándolo.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ At scale — tens of thousands of albums — this means your library reflects th
 - 📝 **Complete Metadata** - Artist, album, cover, lyrics, credits
 - 🌍 **Unicode Support** - CJK, Arabic, Vietnamese, Devanagari
 - 💾 **File Integrity** - Hash verification & corruption detection
-- 🔒 **Destination-Volume Identity** (opt-in) - Refuse to write if a configured NAS/USB destination is unmounted and silently falls back to a same-named local folder — `tiddl destination trust <path>`, then `[download] destination_identity = "strict"`
+- 🔒 **Destination-Volume Identity** (opt-in) - Refuse to write if a configured NAS/USB destination is unmounted and silently falls back to a same-named local folder — see the **[Destination Safety Guide (EN/ES)](DESTINATION_SAFETY.md)**
 - ⚡ **Async Downloads** - Concurrent multi-threaded downloads
 - 🔍 **Smart Quality** - Automatic fallback for unavailable qualities
 - 📦 **M3U8 Export** - Create playlists for media players
@@ -254,6 +254,7 @@ artist_separator = " / "
 ### 📋 Detailed Guides
 - **[USAGE.md](USAGE.md)** - Practical command examples and scenarios
 - **[CONFIG.md](CONFIG.md)** - Configuration reference with all options
+- **[DESTINATION_SAFETY.md](DESTINATION_SAFETY.md)** 🔒 - Protect NAS, USB and network destinations (English/Español)
 - **[FORK.md](FORK.md)** - About this fork and improvements over original
 
 ### 🤝 Community

--- a/TUTORIAL_ES.md
+++ b/TUTORIAL_ES.md
@@ -115,6 +115,29 @@ save_lyrics = true
 cover = true
 ```
 
+### 6.1 Proteger un NAS, USB o unidad de red (recomendado)
+
+Si `download_path` apunta a un NAS, USB o unidad mapeada como `Z:\`, podés
+evitar que tiddl escriba en una carpeta local equivocada cuando el volumen no
+esté conectado. Con el destino real montado, ejecutá una sola vez:
+
+```powershell
+tiddl destination trust "Z:\"
+tiddl destination status "Z:\"
+```
+
+El segundo comando debe mostrar `Z:\: trusted`. Después añadí a la sección
+`[download]` de `config.toml`:
+
+```toml
+destination_identity = "strict"
+```
+
+Desde ese momento, si el NAS o disco desaparece o cambia, tiddl rechaza la
+escritura y conserva el archivo verificado para recuperación. No hace falta
+repetir el proceso en cada descarga. Consultá la guía bilingüe completa:
+**[DESTINATION_SAFETY.md](DESTINATION_SAFETY.md)**.
+
 ---
 
 ## 7. Comandos básicos para descargar

--- a/USAGE.md
+++ b/USAGE.md
@@ -76,6 +76,39 @@ Supports all options of `download url`.
 
 ---
 
+## 🔒 Protecting NAS, USB and Network Destinations
+
+Destination-volume identity prevents tiddl from publishing files to a
+same-named local directory when the intended NAS, USB drive or network mount is
+missing. The feature is opt-in and remains disabled until the user explicitly
+trusts the mounted root and enables strict mode.
+
+```powershell
+# Run only while the real destination is mounted.
+tiddl destination trust "Z:\"
+
+# Confirm the live marker and local record agree.
+tiddl destination status "Z:\"
+```
+
+Add this to `~/.tiddl/config.toml`, using the same root as `download_path`:
+
+```toml
+[download]
+download_path = "Z:\\"
+destination_identity = "strict"
+```
+
+After activation, downloads work normally while the destination is trusted. If
+the volume disappears or its identity changes, tiddl refuses destination writes
+and retains verified staging files for `tiddl recover` instead of risking the
+wrong path.
+
+For full setup, second-machine adoption, status reasons and recovery, see
+**[DESTINATION_SAFETY.md](DESTINATION_SAFETY.md)**.
+
+---
+
 ## 📝 Advanced Options
 
 ### Quality


### PR DESCRIPTION
## English

### What changed

- Added a complete bilingual `DESTINATION_SAFETY.md` guide for destination-volume identity.
- Documented one-time setup on Windows, UNC paths, Linux and macOS.
- Documented second-machine adoption, status reasons, retained-file recovery, disabling and forgetting trust.
- Linked the guide from README, configuration reference, usage guide and Spanish tutorial.
- Added the documentation entry to the Unreleased changelog.

### Why

Version 1.2.1 introduced destination-volume identity and retained-staging recovery. Users need a safe, practical path to activate and operate those protections without understanding the implementation internals.

### User impact

No runtime behavior changes. Users now have copyable commands and bilingual explanations for safely protecting NAS, USB and network destinations.

### Validation

- CLI help compared against every documented `destination` and `recover` option.
- All documented identity status reasons compared against production code.
- Local Markdown links verified.
- `git diff --check` clean.

## Español

### Qué cambió

- Se añadió la guía bilingüe completa `DESTINATION_SAFETY.md` para la identidad del volumen de destino.
- Se documentó la configuración inicial en Windows, rutas UNC, Linux y macOS.
- Se documentaron la adopción desde una segunda computadora, los estados, la recuperación de archivos retenidos, la desactivación y el olvido de confianza.
- Se enlazó la guía desde README, configuración, uso y tutorial en español.
- Se añadió la entrada documental al changelog de Unreleased.

### Motivo e impacto

La versión 1.2.1 incorporó la identidad del destino y la recuperación de staging retenido. Este PR ofrece instrucciones prácticas y copiables para que un usuario pueda activar esas protecciones de forma segura. No cambia el comportamiento del programa.

## Summary by Sourcery

Document safe setup and operation of destination-volume identity and retained-file recovery for English- and Spanish-speaking users.

Enhancements:
- Add a bilingual guide explaining how to protect NAS, USB, and network destinations with destination-volume identity, including setup, adoption, status troubleshooting, recovery, and trust management.

Documentation:
- Link the destination safety guidance from the README, configuration reference, usage guide, and Spanish tutorial, and record it in the Unreleased changelog.