### PR TITLE
feat: stereo edition resolver + quality policies

### DIFF
--- a/STEREO_EDITION_AUDIT_KAROL_G.md
+++ b/STEREO_EDITION_AUDIT_KAROL_G.md
@@ -1,0 +1,48 @@
+# TIDAL-only Stereo Edition Audit — Artist 5237820
+
+Date: 2026-08-19
+
+This is a read-only integration-test record. No media was downloaded. Source:
+TIDAL artist/album/item endpoints through the project's authenticated API.
+
+## Catalog distribution
+
+| Category | Count |
+|---|---:|
+| Atmos-only albums | 4 |
+| Stereo MAX albums (`HIRES_LOSSLESS`) | 6 |
+| Stereo High-only albums (`LOSSLESS`) | 7 |
+| Total | 17 |
+
+## Atmos resolution matrix
+
+| Input Atmos album | Selected stereo album | Track overlap | Confirmation |
+|---:|---:|---:|---|
+| 549984784 | 549980023 | 13/14 (92.9%) | Yes: adds `Still` |
+| 443072650 | 442927546 | 20/20 (100%) | No listing difference |
+| 310041848 | 309985062 | 10/10 (100%) | No listing difference |
+| 278210628 | 277248246 | 17/17 (100%) | No listing difference |
+
+All four resolved for both `requested_quality=high` and
+`requested_quality=max`. Selected candidates advertise both `LOSSLESS` and
+`HIRES_LOSSLESS`; the later playback request determines whether High or MAX is
+actually delivered.
+
+## Reproduction
+
+Use the source checkout (until packaged/installed):
+
+```powershell
+python -c "import sys; from tiddl.cli.app import main; sys.argv=['tiddl','download','--track-quality','max','--audio-mode','stereo','--dry-run','url','https://tidal.com/album/443072650']; main()"
+```
+
+Expected: stereo replacement `443072650 -> 442927546`, 100% score and overlap,
+then a statement that no files or settings were changed.
+
+## Controlled playback attempt
+
+The replacement was accepted in a one-track isolated test and correctly
+requested `HI_RES_LOSSLESS` from stereo track `442927549`. Playback could not
+complete because the TIDAL token had expired and automatic refresh was refused.
+No files were written. Manual reauthentication is required before ffprobe can
+validate the delivered stream.

--- a/STEREO_EDITION_RESOLVER_MEMORY.md
+++ b/STEREO_EDITION_RESOLVER_MEMORY.md
@@ -1,0 +1,207 @@
+# Stereo Edition Resolver — Continuation Memory
+
+Last updated: 2026-08-19
+
+## Objective
+
+Allow a user who supplies a TIDAL Atmos-only album URL to find and optionally
+use a separately published TIDAL stereo edition at High (Lossless) or MAX
+(HiRes Lossless), without MusicBrainz, ISRC dependence, or any non-TIDAL data.
+
+## Confirmed catalog case
+
+- Atmos: album `549984784`, 13 tracks, `audioModes=[DOLBY_ATMOS]`.
+- Stereo/MAX: album `549980023`, 14 tracks,
+  `audioModes=[STEREO]`, tags `LOSSLESS, HIRES_LOSSLESS`.
+- Same artist/title/date; stereo adds `Still`.
+- Resolver score: 97.4%; track overlap: 92.9%; confirmation required.
+- Corresponding Atmos/stereo tracks have different IDs and ISRCs. ISRC is not
+  a reliable bridge for this feature.
+
+## Implemented
+
+1. `tiddl/core/edition_resolver.py`
+   - TIDAL-only catalog matching.
+   - Normalized title matching, artist/date/explicit/duration/track overlap.
+   - High accepts `LOSSLESS` or `HIRES_LOSSLESS` stereo.
+   - MAX requires advertised `HIRES_LOSSLESS` stereo.
+   - Compatible source albums are retained without catalog search.
+2. `tiddl info editions -q high|max ALBUM_URL`
+   - Read-only diagnostic; tested against both confirmed album IDs.
+3. `tiddl download --audio-mode stereo --edition-match ask|best --dry-run ...`
+   - Direct album URLs only in this phase.
+   - `auto` remains the default and preserves all legacy behavior.
+   - Missing stereo candidate is skipped, never silently downloaded as Atmos.
+   - Changed track lists require confirmation under `ask`.
+   - `--dry-run` never prompts, downloads, or changes settings.
+
+## Tests and evidence
+
+- `tests/test_edition_resolver.py`: 7 focused tests currently pass.
+- Ruff and `git diff --check` pass for resolver-related files.
+- Real TIDAL diagnostic succeeds in about 3.6 seconds after title-prefiltering.
+- Full suite observation before download integration: 298 passed, 3 skipped,
+  6 failures in existing recover/publish tests under the local destination
+  identity configuration. These failures are unrelated to resolver files.
+
+## Safety boundaries
+
+- Do not add MusicBrainz or another metadata source.
+- Do not treat catalog Atmos tags as proof of the delivered stream mode.
+- Do not alter playlist, artist, mix, or individual-track IDs yet.
+- Do not enable automatic replacement by default.
+- Before accepting a downloaded file as stereo/MAX, later phases must validate
+  the playback response (`audioMode`, `audioQuality`, bit depth/sample rate)
+  and ideally the parsed codec/channel layout.
+
+## Next steps
+
+1. Add focused CLI tests for dry-run, accept, decline, no-candidate, and
+   already-compatible source using mocked TIDAL APIs.
+2. Add post-playback stream validation before enabling this in the GUI.
+3. Decide non-interactive behavior and non-zero exit status for skipped albums.
+4. Test one accepted replacement against a controlled temporary destination.
+5. Only then persist `audio_mode` in config and expose it in tiddl-gui.
+
+## Latest live integration checks
+
+- Real MAX dry-run for Atmos album `549984784` selected stereo album
+  `549980023`, reported `Still`, stated that confirmation would be required,
+  and performed no download.
+- Real `ask` run was answered `No`; it skipped the Atmos album and printed
+  `No resources remain to download.` No download began.
+- An accepted real download has intentionally not been run during development;
+  test acceptance with a controlled destination before release.
+
+### Controlled accepted-run attempt
+
+Attempted on 2026-08-19 with:
+
+- Atmos input `443072650` (Tropicoqueta).
+- Expected stereo replacement `442927546`.
+- MAX, `edition-match=best`, one-track session limit, one thread, zero delays.
+- Isolated temporary destination outside the music library.
+
+Observed:
+
+- Resolver correctly replaced `443072650 -> 442927546` at 100% score/overlap.
+- Playback request targeted stereo track `442927549` with
+  `audioquality=HI_RES_LOSSLESS`.
+- TIDAL returned 401 token-expired and rejected automatic refresh because the
+  account/token is flagged; manual `tiddl auth login` is required.
+- Total downloads: 0. Temporary destination contained no files.
+- Therefore codec/channel/bit-depth verification with ffprobe remains pending.
+
+Unrelated defects exposed by this attempt:
+
+- A playback 401 was eventually displayed as `(Rate Limit)`.
+- With `max_tracks_per_session=1`, remaining album items each printed the
+  session-limit message.
+
+Both defects were corrected offline on 2026-08-19:
+
+- HTTP failures are now classified using the actual response status (with a
+  conservative exact-number fallback). A 401 reports `Authentication expired`;
+  only a real 429 reports `Rate Limit`. Generic words such as `Limit` or `Rate`
+  no longer cause false classification.
+- A 401 now also raises the shared cooperative stop signal. Queued tracks,
+  remaining resources, quality fallbacks, and responses from concurrent stream
+  requests already in flight stop before any further processing or writes.
+- `SessionTrackLimit` admits tracks synchronously and marks its warning as
+  announced, so already-scheduled remaining items are skipped quietly.
+- `tests/test_download_policy.py` covers 401/429 separation, false-positive
+  prevention, unlimited mode, and one-time session-limit notification.
+- Focused offline result after run-wide 401 stopping: 15 passed
+  (download-policy + edition-resolver tests). The broader downloader-policy
+  group also passes: 35 tests.
+- Full offline result: 307 passed, 3 skipped, and the same 6 pre-existing
+  recover/publish failures caused by local destination-identity configuration.
+- No TIDAL endpoint, login, token refresh, playback, or download was contacted
+  while the account was temporarily blocked.
+
+## Real artist-catalog audit: KAROL G (artist 5237820)
+
+Read-only TIDAL audit on 2026-08-19:
+
+- 17 album entries returned.
+- 4 Atmos-only editions.
+- 6 stereo editions advertising MAX (`HIRES_LOSSLESS`).
+- 7 stereo editions advertising High (`LOSSLESS` only).
+
+Resolver results for every Atmos album:
+
+| Atmos ID | Title | Stereo ID | High | MAX | Score | Difference |
+|---|---|---:|---|---|---:|---|
+| 549984784 | NO ME ARREPIENTO DE SENTIR TANTO | 549980023 | found | found | 97.4% | stereo adds `Still` |
+| 443072650 | Tropicoqueta | 442927546 | found | found | 100% | identical listing |
+| 310041848 | MAÑANA SERÁ BONITO (BICHOTA SEASON) | 309985062 | found | found | 100% | identical listing |
+| 278210628 | MAÑANA SERÁ BONITO | 277248246 | found | found | 100% | identical listing |
+
+Both High and MAX can select a stereo edition advertising
+`LOSSLESS, HIRES_LOSSLESS`: High later requests `LOSSLESS`; MAX later requests
+`HI_RES_LOSSLESS`. Catalog selection and playback quality remain separate.
+
+## Offline playback-policy phase (2026-08-19)
+
+- Added `tiddl/core/stream_policy.py` to inspect playback metadata before any
+  media URL is transferred.
+- `--audio-mode stereo` is passed into `Downloader`; a returned mode other than
+  `STEREO` (including `DOLBY_ATMOS`) triggers the run-wide cooperative stop.
+- The inspection records actual `audioQuality`, bit depth and sample rate, and
+  reports whether the delivered quality meets High (`LOSSLESS`) or MAX
+  (`HI_RES_LOSSLESS`). A lower-quality track is not discarded solely for being
+  below MAX because mixed-quality albums may legitimately contain tracks whose
+  highest available stereo asset is standard lossless; existing fallback and
+  degradation reporting remain responsible for that case.
+- Focused stream-policy, resolver, failure-policy and downloader regression
+  group: 47 tests passed. No TIDAL calls were made.
+- Latest full offline suite after this phase: 314 passed, 3 skipped, with the
+  same 6 pre-existing `recover/publish` failures under the machine's local
+  destination-identity state. No new resolver/downloader failures appeared.
+
+### Complete preference matrix
+
+- Audio edition: `auto` or `stereo`.
+- Requested quality: `low`, `normal`, `high`, or `max`.
+- Quality policy: `flexible` (legacy fallback) or `strict` (exact delivery).
+- These controls are independent, so every combination is available.
+- `stereo` always rejects a non-`STEREO` playback manifest.
+- `strict high` requires exactly `LOSSLESS`; `strict max` requires exactly
+  `HI_RES_LOSSLESS`. Neither silently falls back.
+- Low/Normal stereo catalog discovery is supported: any catalog edition that
+  advertises `STEREO` can be requested at those delivery tiers.
+- Focused regression after completing the matrix: 50 tests passed offline.
+- Flexible catalog selection now treats the user's quality as a ceiling:
+  MAX searches MAX -> High -> Normal -> Low; High searches High -> Normal ->
+  Low. The playback request uses the original ceiling and follows the same
+  downward order.
+- The resolver scans the artist catalog only once, groups matching stereo
+  editions by their highest usable tier, then selects from the first available
+  tier. It does not repeat the complete catalog query for each fallback level.
+- Focused regression after catalog fallback optimization: 53 tests passed.
+- The GUI now exposes the existing engine `--dry-run` through a `Verify
+  versions` action for direct album links. This exercises catalog resolution
+  and reports the selected tier/differences without constructing `Downloader`
+  or transferring media.
+
+## Clean offline regression baseline
+
+- The six historical `recover/publish` failures were test-environment leakage,
+  not product failures: `tests/test_recover_cli.py` inherited the developer's
+  real `destination_identity = strict` setting while its default-path tests
+  assumed `off`.
+- Its autouse fixture now explicitly isolates that setting to `off`; tests that
+  exercise strict mode still opt into it themselves.
+- Recovery group: 34 passed.
+- Complete engine suite after all resolver/stream-policy changes: **326 passed,
+  3 skipped, 0 failed** in the offline environment.
+- No TIDAL catalog, playback, authentication, or download request was made.
+- Packaging check succeeded: generated
+  `.codex-build/tiddl_elvigilante-1.2.1-py3-none-any.whl`, containing the new
+  resolver, stream policy and download policy modules.
+
+## Working tree caution
+
+This repository contains many user-owned untracked audit/proposal files.
+Preserve them. Resolver work is limited to the files listed above plus focused
+tests and documentation.

--- a/STEREO_EDITION_RESOLVER_MEMORY.md
+++ b/STEREO_EDITION_RESOLVER_MEMORY.md
@@ -205,3 +205,55 @@ Both High and MAX can select a stereo edition advertising
 This repository contains many user-owned untracked audit/proposal files.
 Preserve them. Resolver work is limited to the files listed above plus focused
 tests and documentation.
+
+## Successful controlled live downloads (2026-08-19)
+
+The TIDAL account became available again and the accepted replacement was
+validated using isolated roots outside the music library.
+
+- Source: Atmos album `549984784`.
+- Selected replacement: stereo album `549980023` at 97.4% score and 92.9%
+  track overlap; the additional track `Still` was reported before transfer.
+- Each run used `--edition-match best`, `--quality-policy strict`, one thread,
+  zero delays and `--max-tracks 1`.
+- MAX delivered `Te llevas To` as FLAC, 24-bit, 48 kHz, 2-channel stereo.
+- High delivered the same track as FLAC, 16-bit, 44.1 kHz, 2-channel stereo.
+- Both runs exited successfully with exactly one download. `ffprobe` confirmed
+  the codec, bit depth, sample rate and stereo channel layout.
+- Strict destination-identity protection correctly rejected the first
+  untrusted test root. Each root was then explicitly trusted for its run and
+  removed from local trust state afterward; global security was not weakened.
+- Test files remain under `C:\tiddl-live-test` and
+  `C:\tiddl-live-test-high` for manual inspection or later cleanup.
+
+### Flexible degradation validated with Kinito Mendez
+
+- Artist `3941799` returned 23 album entries: no album advertised
+  `HIRES_LOSSLESS`, 13 advertised `LOSSLESS`, and 10 advertised only `STEREO`.
+- Album `14824487` (`El Decreto`) with MAX + flexible resolved to catalog tier
+  High and downloaded one track successfully as FLAC, 16-bit, 44.1 kHz,
+  2-channel stereo. SHA-256:
+  `68216CD006791C957E810244501855B99F39CAC77BA9CCAA4C4D52487C3B148F`.
+- MAX + strict correctly rejected the same album without downloading because
+  no exact MAX stereo edition exists.
+- That strict dry run exposed misleading wording claiming an Atmos avoidance
+  even though the source was already stereo. The message was corrected to say
+  that the requested stereo/quality policy cannot be satisfied.
+
+Album `8455110` (`El Hombre Merengue`) validated the complete lossy fallback:
+
+- MAX + flexible selected catalog tier Normal; live playback ultimately
+  returned LOW and the engine downloaded one HE-AAC `.m4a`, 96 kbps class,
+  44.1 kHz, 2-channel stereo. It emitted the quality-degradation warning.
+- SHA-256: `096E02D1715F8CF0A6DEBAC0D7D63CC35A1FD8EDF900A86FF4F4F746BFDC68A7`.
+- Normal + strict received LOW, stopped before media transfer, downloaded zero
+  files and now exits with status 1.
+- This test exposed two defects that were fixed: cooperative safety stops now
+  produce a non-zero CLI exit status, and Downloader preserves the original
+  user quality slug so Normal maps to TIDAL `HIGH` rather than being
+  reinterpreted as user High/`LOSSLESS` during strict validation.
+- Focused regression: 65 passed. Complete offline suite after the fixes:
+  **328 passed, 3 skipped, 0 failed**.
+
+Still not intentionally tested live: forcing an authentication failure to
+exercise the 401 stop. That path remains covered by offline tests.

--- a/tests/test_download_policy.py
+++ b/tests/test_download_policy.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from tiddl.cli.commands.download.downloader import (
+    _abort_for_authentication_error,
+    _is_authentication_error,
+    _is_rate_limit_error,
+)
+from tiddl.core import cancel
+from tiddl.core.download_policy import SessionTrackLimit
+
+
+class ResponseError(Exception):
+    def __init__(self, message: str, status: int):
+        super().__init__(message)
+        self.response = SimpleNamespace(status_code=status)
+
+
+def test_session_limit_warns_only_once_for_remaining_scheduled_tracks():
+    policy = SessionTrackLimit(limit=1)
+
+    assert policy.admit() == (True, False)
+    assert policy.admit() == (False, True)
+    assert policy.admit() == (False, False)
+    assert policy.admit() == (False, False)
+
+
+def test_zero_session_limit_is_unlimited():
+    policy = SessionTrackLimit(limit=0)
+
+    assert [policy.admit() for _ in range(3)] == [(True, False)] * 3
+
+
+def test_http_401_is_authentication_not_rate_limit():
+    error = ResponseError("401 Client Error: Limit reached while refreshing", 401)
+
+    assert _is_authentication_error(error)
+    assert not _is_rate_limit_error(error)
+
+
+def test_http_429_is_rate_limit_not_authentication():
+    error = ResponseError("Too Many Requests", 429)
+
+    assert _is_rate_limit_error(error)
+    assert not _is_authentication_error(error)
+
+
+def test_unrelated_limit_or_rate_words_are_not_misclassified():
+    assert not _is_rate_limit_error(Exception("quality Limit fallback failed"))
+    assert not _is_rate_limit_error(Exception("Rate selection failed"))
+
+
+def test_status_text_fallback_requires_exact_numeric_code():
+    assert _is_authentication_error(Exception("401 Client Error"))
+    assert _is_rate_limit_error(Exception("HTTP 429"))
+    assert not _is_rate_limit_error(Exception("error 1429"))
+
+
+def test_http_401_sets_run_wide_cooperative_stop():
+    cancel.clear()
+    try:
+        assert _abort_for_authentication_error(ResponseError("Unauthorized", 401))
+        assert cancel.is_cancelled()
+    finally:
+        cancel.clear()
+
+
+def test_non_401_does_not_stop_the_run():
+    cancel.clear()
+    try:
+        assert not _abort_for_authentication_error(ResponseError("Too Many Requests", 429))
+        assert not cancel.is_cancelled()
+    finally:
+        cancel.clear()

--- a/tests/test_edition_resolver.py
+++ b/tests/test_edition_resolver.py
@@ -1,0 +1,210 @@
+from types import SimpleNamespace
+
+from tiddl.core.edition_resolver import (
+    find_stereo_editions,
+    normalize_catalog_text,
+    quality_fallback_order,
+    score_stereo_candidate,
+    supports_requested_quality,
+)
+
+
+def ns(**values):
+    return SimpleNamespace(**values)
+
+
+def album(album_id, mode, *, tracks=13, duration=2363, title="NO ME ARREPIENTO DE SENTIR TANTO"):
+    return ns(
+        id=album_id,
+        title=title,
+        artist=ns(id=5237820, name="KAROL G"),
+        releaseDate="2026-08-07",
+        explicit=True,
+        duration=duration,
+        numberOfTracks=tracks,
+        audioModes=[mode],
+        audioQuality="LOSSLESS" if mode == "STEREO" else "LOW",
+        mediaMetadata=ns(
+            tags=["HIRES_LOSSLESS", "LOSSLESS"] if mode == "STEREO" else ["DOLBY_ATMOS"]
+        ),
+    )
+
+
+def track(title, version=None):
+    return ns(title=title, version=version)
+
+
+def wrapped_tracks(titles):
+    return ns(items=[ns(type="track", item=track(title)) for title in titles])
+
+
+ATMOS_TITLES = [
+    "Te llevas To", "Maybe", "Bebiendo Lágrimas", "Ahí", "Final feliz",
+    "Alguien que te amaba", "MATADORA", "For u My lova", "Si lo ven", "BbY WOW",
+    "Con quién andará?", "Eclipse", "Después de ti",
+]
+STEREO_TITLES = ATMOS_TITLES[:5] + ["Still"] + ATMOS_TITLES[5:]
+
+
+def test_normalization_handles_case_accents_and_punctuation():
+    assert normalize_catalog_text("  Ahí — (Remix)! ") == "ahi remix"
+
+
+def test_flexible_quality_is_a_user_ceiling_with_downward_fallback():
+    assert quality_fallback_order("max") == ("max", "high", "normal", "low")
+    assert quality_fallback_order("high") == ("high", "normal", "low")
+    assert quality_fallback_order("normal") == ("normal", "low")
+    assert quality_fallback_order("low") == ("low",)
+
+
+def test_strict_quality_never_falls_back():
+    assert quality_fallback_order("max", "strict") == ("max",)
+    assert quality_fallback_order("high", "strict") == ("high",)
+
+
+def test_known_stereo_edition_scores_high_and_requires_confirmation():
+    source = album(549984784, "DOLBY_ATMOS")
+    candidate = album(549980023, "STEREO", tracks=14, duration=2583)
+
+    scored = score_stereo_candidate(
+        source,
+        candidate,
+        [track(title) for title in ATMOS_TITLES],
+        [track(title) for title in STEREO_TITLES],
+    )
+
+    assert scored is not None
+    assert scored.score > 0.90
+    assert scored.track_overlap == 13 / 14
+    assert scored.missing_tracks == ()
+    assert scored.extra_tracks == ("still",)
+    assert scored.requires_confirmation
+
+
+def test_rejects_atmos_and_unrelated_candidates():
+    source = album(1, "DOLBY_ATMOS")
+    tracks = [track(title) for title in ATMOS_TITLES]
+    assert score_stereo_candidate(source, album(2, "DOLBY_ATMOS"), tracks, tracks) is None
+    assert score_stereo_candidate(
+        source, album(3, "STEREO", title="Completely Different"), tracks, tracks
+    ) is None
+
+
+def test_quality_filter_uses_tidal_catalog_tags():
+    stereo_max = album(10, "STEREO")
+    stereo_high = album(11, "STEREO")
+    stereo_high.mediaMetadata.tags = ["LOSSLESS"]
+    atmos = album(12, "DOLBY_ATMOS")
+
+    assert supports_requested_quality(stereo_max, "max")
+    assert supports_requested_quality(stereo_max, "high")
+    assert not supports_requested_quality(stereo_high, "max")
+    assert supports_requested_quality(stereo_high, "high")
+    assert not supports_requested_quality(atmos, "max")
+    assert supports_requested_quality(stereo_high, "normal")
+    assert supports_requested_quality(stereo_high, "low")
+    assert not supports_requested_quality(atmos, "normal")
+
+
+def test_find_stereo_editions_is_read_only_and_returns_best_match():
+    source = album(549984784, "DOLBY_ATMOS")
+    stereo = album(549980023, "STEREO", tracks=14, duration=2583)
+    unrelated = album(9, "STEREO", title="Other Album")
+
+    class FakeApi:
+        def __init__(self):
+            self.calls = []
+
+        def get_album(self, album_id):
+            self.calls.append(("get_album", album_id))
+            return source
+
+        def get_artist_albums(self, artist_id, limit, offset):
+            self.calls.append(("get_artist_albums", artist_id, limit, offset))
+            return ns(items=[source, unrelated, stereo])
+
+        def get_album_items(self, album_id):
+            self.calls.append(("get_album_items", album_id))
+            titles = STEREO_TITLES if album_id == stereo.id else ATMOS_TITLES
+            return wrapped_tracks(titles)
+
+    api = FakeApi()
+    result = find_stereo_editions(api, source.id)
+
+    assert result.best is not None
+    assert result.best.album.id == 549980023
+    assert result.requested_quality == "max"
+    assert all(call[0].startswith("get_") for call in api.calls)
+    assert ("get_album_items", unrelated.id) not in api.calls
+
+
+def test_max_excludes_lossless_only_but_high_accepts_it():
+    source = album(20, "DOLBY_ATMOS")
+    lossless = album(21, "STEREO")
+    lossless.mediaMetadata.tags = ["LOSSLESS"]
+
+    class FakeApi:
+        def get_album(self, album_id):
+            return source
+
+        def get_artist_albums(self, artist_id, limit, offset):
+            return ns(items=[lossless])
+
+        def get_album_items(self, album_id):
+            return wrapped_tracks(ATMOS_TITLES)
+
+    api = FakeApi()
+    assert find_stereo_editions(api, source.id, requested_quality="max").best is None
+    assert find_stereo_editions(api, source.id, requested_quality="high").best is not None
+
+
+def test_flexible_max_chooses_lossless_candidate_with_one_catalog_scan():
+    source = album(40, "DOLBY_ATMOS")
+    lossless = album(41, "STEREO")
+    lossless.mediaMetadata.tags = ["LOSSLESS"]
+
+    class FakeApi:
+        def __init__(self):
+            self.catalog_calls = 0
+
+        def get_album(self, album_id):
+            return source
+
+        def get_artist_albums(self, artist_id, limit, offset):
+            self.catalog_calls += 1
+            return ns(items=[lossless])
+
+        def get_album_items(self, album_id):
+            return wrapped_tracks(ATMOS_TITLES)
+
+    api = FakeApi()
+    result = find_stereo_editions(
+        api, source.id, requested_quality="max", quality_policy="flexible"
+    )
+
+    assert result.best is not None
+    assert result.best.album.id == lossless.id
+    assert result.requested_quality == "high"
+    assert api.catalog_calls == 1
+
+
+def test_compatible_source_is_kept_without_catalog_search():
+    source = album(30, "STEREO")
+
+    class FakeApi:
+        def __init__(self):
+            self.catalog_searched = False
+
+        def get_album(self, album_id):
+            return source
+
+        def get_artist_albums(self, **kwargs):
+            self.catalog_searched = True
+            raise AssertionError("compatible source should not trigger an edition search")
+
+    api = FakeApi()
+    result = find_stereo_editions(api, source.id, requested_quality="max")
+
+    assert result.source_satisfies_request
+    assert result.best is None
+    assert not api.catalog_searched

--- a/tests/test_guarded_writes.py
+++ b/tests/test_guarded_writes.py
@@ -727,5 +727,16 @@ def test_finish_download_run_exits_normally_when_nothing_refused():
     console = types.SimpleNamespace(print=lambda *a, **k: printed.append((a, k)))
 
     _finish_download_run(console, False)
-
     assert printed == []
+
+
+def test_finish_download_run_exits_nonzero_on_cooperative_safety_stop():
+    printed = []
+    console = types.SimpleNamespace(print=lambda *a, **k: printed.append((a, k)))
+
+    with pytest.raises(SystemExit) as exc:
+        _finish_download_run(console, False, cooperative_stop=True)
+
+    assert exc.value.code == 1
+    assert len(printed) == 1
+    assert "stopped the run for safety" in printed[0][0][0]

--- a/tests/test_recover_cli.py
+++ b/tests/test_recover_cli.py
@@ -38,7 +38,13 @@ def _strip_ansi(text: str) -> str:
 
 @pytest.fixture(autouse=True)
 def _isolated_app_path(tmp_path, monkeypatch):
+    from tiddl.cli.config import CONFIG
+
     monkeypatch.setattr(reg, "APP_PATH", tmp_path / "_app")
+    # Never inherit the developer machine's real config.toml. These tests
+    # exercise the legacy/default recovery path unless an individual test
+    # explicitly opts into strict destination identity below.
+    monkeypatch.setattr(CONFIG.download, "destination_identity", "off")
     # cli/const.py's APP_PATH is resolved at import time (module-level
     # create_app_path()) and consumed by name in a couple of other modules;
     # recover.py only ever reaches the registry through `reg.*`, so

--- a/tests/test_stream_policy.py
+++ b/tests/test_stream_policy.py
@@ -96,3 +96,22 @@ def test_strict_max_accepts_stereo_hires_only():
 
     assert result.accepted
     assert result.is_stereo
+
+
+def test_strict_normal_maps_to_tidal_high_not_lossless():
+    accepted = inspect_track_stream(
+        stream(quality="HIGH"),
+        audio_mode="stereo",
+        requested_quality="normal",
+        quality_policy="strict",
+    )
+    rejected = inspect_track_stream(
+        stream(quality="LOW"),
+        audio_mode="stereo",
+        requested_quality="normal",
+        quality_policy="strict",
+    )
+
+    assert accepted.accepted
+    assert not rejected.accepted
+    assert "requested exact quality HIGH" in rejected.reason

--- a/tests/test_stream_policy.py
+++ b/tests/test_stream_policy.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+from tiddl.core.stream_policy import inspect_track_stream
+
+
+def stream(mode="STEREO", quality="LOSSLESS", bit_depth=16, sample_rate=44100):
+    return SimpleNamespace(
+        audioMode=mode,
+        audioQuality=quality,
+        bitDepth=bit_depth,
+        sampleRate=sample_rate,
+    )
+
+
+def test_stereo_high_is_verified_from_playback_metadata():
+    result = inspect_track_stream(stream(), audio_mode="stereo", requested_quality="high")
+
+    assert result.accepted
+    assert result.is_stereo
+    assert result.meets_requested_quality
+    assert result.bit_depth == 16
+    assert result.sample_rate == 44100
+
+
+def test_stereo_max_is_verified_from_playback_metadata():
+    result = inspect_track_stream(
+        stream(quality="HI_RES_LOSSLESS", bit_depth=24, sample_rate=96000),
+        audio_mode="stereo",
+        requested_quality="max",
+    )
+
+    assert result.accepted
+    assert result.meets_requested_quality
+
+
+def test_atmos_is_rejected_when_stereo_was_requested():
+    result = inspect_track_stream(
+        stream(mode="DOLBY_ATMOS", quality="HI_RES_LOSSLESS"),
+        audio_mode="stereo",
+        requested_quality="max",
+    )
+
+    assert not result.accepted
+    assert not result.is_stereo
+    assert "DOLBY_ATMOS" in result.reason
+
+
+def test_auto_preserves_legacy_atmos_behavior():
+    result = inspect_track_stream(
+        stream(mode="DOLBY_ATMOS"), audio_mode="auto", requested_quality="high"
+    )
+
+    assert result.accepted
+
+
+def test_max_reports_lossless_delivery_as_below_request_without_rejecting_it():
+    result = inspect_track_stream(
+        stream(quality="LOSSLESS"), audio_mode="stereo", requested_quality="max"
+    )
+
+    assert result.accepted
+    assert not result.meets_requested_quality
+
+
+def test_strict_high_rejects_lossy_fallback():
+    result = inspect_track_stream(
+        stream(quality="HIGH"),
+        audio_mode="stereo",
+        requested_quality="high",
+        quality_policy="strict",
+    )
+
+    assert not result.accepted
+    assert "LOSSLESS" in result.reason
+
+
+def test_strict_max_rejects_standard_lossless_fallback():
+    result = inspect_track_stream(
+        stream(quality="LOSSLESS"),
+        audio_mode="stereo",
+        requested_quality="max",
+        quality_policy="strict",
+    )
+
+    assert not result.accepted
+    assert "HI_RES_LOSSLESS" in result.reason
+
+
+def test_strict_max_accepts_stereo_hires_only():
+    result = inspect_track_stream(
+        stream(quality="HI_RES_LOSSLESS", bit_depth=24, sample_rate=192000),
+        audio_mode="stereo",
+        requested_quality="max",
+        quality_policy="strict",
+    )
+
+    assert result.accepted
+    assert result.is_stereo

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -292,7 +292,9 @@ def _finalize_db_record(downloader, item, download_path, was_downloaded, identit
         downloader._db_insert(item.id, download_path, "VIDEO")
 
 
-def _download_exit_code(any_identity_refused: bool) -> Optional[int]:
+def _download_exit_code(
+    any_identity_refused: bool, cooperative_stop: bool = False
+) -> Optional[int]:
     """v2.4 §2: the final `tiddl download` exit-code decision, evaluated
     once after every per-item and per-resource task in the run has
     completed (`identity_tracker.any_refused`, which is monotonic across
@@ -304,10 +306,12 @@ def _download_exit_code(any_identity_refused: bool) -> Optional[int]:
     `None` to fall through to Typer's normal 0. Standalone pure function
     for direct unit coverage of this decision, same audit finding as
     `_should_insert_db_record` above."""
-    return 1 if any_identity_refused else None
+    return 1 if any_identity_refused or cooperative_stop else None
 
 
-def _finish_download_run(console, any_identity_refused: bool) -> None:
+def _finish_download_run(
+    console, any_identity_refused: bool, cooperative_stop: bool = False
+) -> None:
     """v2.4 §2: the COMPLETE final-outcome effect for `tiddl download` —
     the warning message AND the actual `sys.exit()` — not just the
     decision. `run()` calls this, not `_download_exit_code()` +
@@ -318,13 +322,19 @@ def _finish_download_run(console, any_identity_refused: bool) -> None:
     `download_callback` below), so a test calling it directly (asserting
     `SystemExit` via `pytest.raises`) exercises the real call site, not a
     parallel copy of its logic."""
-    exit_code = _download_exit_code(any_identity_refused)
+    exit_code = _download_exit_code(any_identity_refused, cooperative_stop)
     if exit_code is not None:
-        console.print(
-            "[red]One or more destination-identity checks refused a write "
-            "this run — see the warnings above. Nothing was lost (retryable "
-            "copies were retained where applicable); exiting non-zero.[/]"
-        )
+        if any_identity_refused:
+            console.print(
+                "[red]One or more destination-identity checks refused a write "
+                "this run — see the warnings above. Nothing was lost (retryable "
+                "copies were retained where applicable); exiting non-zero.[/]"
+            )
+        else:
+            console.print(
+                "[red]The download engine stopped the run for safety; "
+                "exiting non-zero.[/]"
+            )
         sys.exit(exit_code)
 
 
@@ -838,11 +848,15 @@ def download_callback(
 
                 candidate = result.best
                 if candidate is None:
+                    quality_requirement = (
+                        f"at or below {TRACK_QUALITY.upper()}"
+                        if QUALITY_POLICY == "flexible"
+                        else f"at exactly {TRACK_QUALITY.upper()}"
+                    )
                     ctx.obj.console.print(
-                        f"[red]No matching stereo edition at or below "
-                        f"{TRACK_QUALITY.upper()} found for "
-                        f"{source.title} (album/{source.id}); skipped to avoid downloading "
-                        "the Atmos edition.[/]"
+                        f"[red]No matching stereo edition {quality_requirement} found for "
+                        f"{source.title} (album/{source.id}); skipped because the requested "
+                        "stereo/quality policy cannot be satisfied.[/]"
                     )
                     continue
 
@@ -2279,6 +2293,10 @@ def download_callback(
             import traceback
             log.error(traceback.format_exc())
         else:
-            _finish_download_run(ctx.obj.console, any_identity_refused)
+            _finish_download_run(
+                ctx.obj.console,
+                any_identity_refused,
+                cooperative_stop=is_cancelled(),
+            )
 
     ctx.call_on_close(run)

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -22,6 +22,8 @@ from tiddl.core.api.models import Album, Track, Video, AlbumItemsCredits
 from tiddl.core.utils.format import format_template
 from tiddl.core.utils.m3u import save_tracks_to_m3u
 from tiddl.core.utils import destination_anchor as anchor
+from tiddl.core.edition_resolver import find_stereo_editions
+from tiddl.core.download_policy import SessionTrackLimit
 from tiddl.cli.config import (
     CONFIG,
     TRACK_QUALITY_LITERAL,
@@ -336,6 +338,43 @@ def download_callback(
             "-q",
         ),
     ] = CONFIG.download.track_quality,
+    AUDIO_MODE: Annotated[
+        str,
+        typer.Option(
+            "--audio-mode",
+            help=(
+                "Audio edition policy: auto keeps supplied IDs; stereo resolves "
+                "album URLs to stereo editions."
+            ),
+        ),
+    ] = "auto",
+    EDITION_MATCH: Annotated[
+        str,
+        typer.Option(
+            "--edition-match",
+            help=(
+                "Stereo replacement policy: ask before changed track lists, "
+                "or best to accept the best match."
+            ),
+        ),
+    ] = "ask",
+    QUALITY_POLICY: Annotated[
+        str,
+        typer.Option(
+            "--quality-policy",
+            help=(
+                "Quality delivery policy: flexible permits normal fallback; "
+                "strict requires the exact requested quality."
+            ),
+        ),
+    ] = "flexible",
+    DRY_RUN: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Resolve stereo editions and show the plan without downloading or changing files.",
+        ),
+    ] = False,
     VIDEO_QUALITY: Annotated[
         VIDEO_QUALITY_LITERAL,
         typer.Option(
@@ -608,6 +647,21 @@ def download_callback(
         ),
     ] = None,
 ):
+    AUDIO_MODE = AUDIO_MODE.casefold()
+    EDITION_MATCH = EDITION_MATCH.casefold()
+    QUALITY_POLICY = QUALITY_POLICY.casefold()
+    if AUDIO_MODE not in ("auto", "stereo"):
+        raise typer.BadParameter("audio mode must be auto or stereo", param_hint="--audio-mode")
+    if EDITION_MATCH not in ("ask", "best"):
+        raise typer.BadParameter("edition match must be ask or best", param_hint="--edition-match")
+    if QUALITY_POLICY not in ("flexible", "strict"):
+        raise typer.BadParameter(
+            "quality policy must be flexible or strict", param_hint="--quality-policy"
+        )
+    if DRY_RUN and AUDIO_MODE != "stereo":
+        raise typer.BadParameter(
+            "dry-run currently requires --audio-mode stereo", param_hint="--dry-run"
+        )
     """
     Download Tidal resources.
     """
@@ -753,9 +807,98 @@ def download_callback(
         from tiddl.cli.commands.web_login import auto_refresh_if_needed
         await auto_refresh_if_needed(threshold_minutes=30)
 
+        if AUDIO_MODE == "stereo":
+            resolved_resources: list[TidalResource] = []
+            for resource in ctx.obj.resources:
+                if resource.type != "album":
+                    ctx.obj.console.print(
+                        f"[yellow]Stereo edition resolution currently applies only to direct "
+                        f"album URLs; keeping {resource.type}/{resource.id} unchanged.[/]"
+                    )
+                    resolved_resources.append(resource)
+                    continue
+
+                result = await asyncio.to_thread(
+                    find_stereo_editions,
+                    ctx.obj.api,
+                    int(resource.id),
+                    TRACK_QUALITY,
+                    0.75,
+                    QUALITY_POLICY,
+                )
+                resolved_quality = result.requested_quality
+                source = result.source
+                if result.source_satisfies_request:
+                    ctx.obj.console.print(
+                        f"[green]Stereo {resolved_quality.upper()} already available:[/] "
+                        f"{source.title} (album/{source.id})"
+                    )
+                    resolved_resources.append(resource)
+                    continue
+
+                candidate = result.best
+                if candidate is None:
+                    ctx.obj.console.print(
+                        f"[red]No matching stereo edition at or below "
+                        f"{TRACK_QUALITY.upper()} found for "
+                        f"{source.title} (album/{source.id}); skipped to avoid downloading "
+                        "the Atmos edition.[/]"
+                    )
+                    continue
+
+                alternate = candidate.album
+                ctx.obj.console.print(
+                    f"[bold cyan]Stereo replacement:[/] album/{source.id} → "
+                    f"album/{alternate.id} ({candidate.score:.1%}, "
+                    f"{candidate.track_overlap:.1%} track overlap, "
+                    f"catalog tier {resolved_quality.upper()})"
+                )
+                if candidate.missing_tracks:
+                    ctx.obj.console.print(
+                        "[yellow]Missing from replacement:[/] "
+                        + ", ".join(candidate.missing_tracks)
+                    )
+                if candidate.extra_tracks:
+                    ctx.obj.console.print(
+                        "[yellow]Additional in replacement:[/] "
+                        + ", ".join(candidate.extra_tracks)
+                    )
+
+                accept = True
+                if candidate.requires_confirmation and EDITION_MATCH == "ask":
+                    if DRY_RUN:
+                        ctx.obj.console.print(
+                            "[yellow]A real run would request confirmation before substitution.[/]"
+                        )
+                    else:
+                        accept = await asyncio.to_thread(
+                            typer.confirm,
+                            f"Use stereo album {alternate.id} instead of {source.id}?",
+                            default=False,
+                        )
+                if accept:
+                    resolved_resources.append(
+                        TidalResource(type="album", id=str(alternate.id))
+                    )
+                else:
+                    ctx.obj.console.print(
+                        f"[yellow]Replacement declined; album/{source.id} was skipped.[/]"
+                    )
+
+            if DRY_RUN:
+                ctx.obj.console.print(
+                    "[dim]Dry run complete: no files were downloaded and no settings "
+                    "were changed.[/]"
+                )
+                return False
+            ctx.obj.resources = resolved_resources
+            if not ctx.obj.resources:
+                ctx.obj.console.print("[yellow]No resources remain to download.[/]")
+                return False
+
         rich_output = RichOutput(ctx.obj.console)
-        _session_track_count = [0]
         _session_limit = CONFIG.download.max_tracks_per_session
+        _session_track_limit = SessionTrackLimit(_session_limit)
 
         # identity_tracker: created once in download_callback() above (not
         # here) — this closure just reuses it, same object save_m3u() and
@@ -775,6 +918,8 @@ def download_callback(
             fallback_api=ctx.obj.fallback_api,
             destination_identity=CONFIG.download.destination_identity,
             identity_tracker=identity_tracker,
+            audio_mode=AUDIO_MODE,
+            quality_policy=QUALITY_POLICY,
         )
 
         # Fast-skip shortcuts (whole-album fast exit, up-front present detection,
@@ -837,13 +982,14 @@ def download_callback(
                 rich_output.total_increment()
 
                 # Límite de tracks por sesión
-                if _session_limit > 0 and _session_track_count[0] >= _session_limit:
-                    ctx.obj.console.print(
-                        f"[yellow]Límite de sesión alcanzado ({_session_limit} tracks). "
-                        f"Reinicia para continuar.[/]"
-                    )
+                admitted, announce_limit = _session_track_limit.admit()
+                if not admitted:
+                    if announce_limit:
+                        ctx.obj.console.print(
+                            f"[yellow]Límite de sesión alcanzado ({_session_limit} tracks). "
+                            f"Reinicia para continuar.[/]"
+                        )
                     return Path(""), item
-                _session_track_count[0] += 1
 
                 if not track_metadata:
                     track_metadata = Metadata()

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -400,6 +400,10 @@ class Downloader:
         self.fallback_api = fallback_api
         self.rich_output = rich_output
         self.semaphore = asyncio.Semaphore(threads_count)
+        # Keep the user tier separate from TIDAL's playback enum. User
+        # `normal` maps to TIDAL `HIGH`; remapping that enum would otherwise
+        # reinterpret it as user `high` (LOSSLESS) during strict inspection.
+        self.requested_quality = track_quality
         self.track_quality = track_qualities[track_quality]
         self.video_quality = video_qualities[video_quality]
         self.videos_filter = videos_filter
@@ -1328,7 +1332,7 @@ class Downloader:
                     inspection = inspect_track_stream(
                         stream,
                         audio_mode=self.audio_mode,
-                        requested_quality=self.track_quality,
+                        requested_quality=self.requested_quality,
                         quality_policy=self.quality_policy,
                     )
                     if not inspection.accepted:

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -34,6 +34,7 @@ from tiddl.core.utils.fsio import _safe_unlink
 from tiddl.core.utils.publish import publish_verified_file
 from tiddl.core.utils import retained_registry
 from tiddl.core.utils import destination_anchor as anchor
+from tiddl.core.stream_policy import inspect_track_stream
 
 from .output import RichOutput
 
@@ -41,6 +42,48 @@ log = getLogger(__name__)
 
 CHUNK_SIZE = 1024**2
 MAX_RETRIES = 3  # Maximum number of retries for corrupt files
+
+
+def _http_status_code(error: Exception) -> Optional[int]:
+    """Extract an HTTP status without guessing from unrelated message words."""
+    response = getattr(error, "response", None)
+    status = getattr(response, "status_code", None)
+    if status is None:
+        status = getattr(error, "status_code", None)
+    if status is None:
+        status = getattr(error, "status", None)
+    try:
+        return int(status) if status is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _message_has_status(error: Exception, status: int) -> bool:
+    """Conservative fallback for exceptions that do not expose a response."""
+    import re
+
+    return re.search(rf"(?<!\d){status}(?!\d)", str(error)) is not None
+
+
+def _is_rate_limit_error(error: Exception) -> bool:
+    status = _http_status_code(error)
+    return status == 429 or (status is None and _message_has_status(error, 429))
+
+
+def _is_authentication_error(error: Exception) -> bool:
+    status = _http_status_code(error)
+    return status == 401 or (status is None and _message_has_status(error, 401))
+
+
+def _abort_for_authentication_error(error: Exception) -> bool:
+    """Stop the complete cooperative download run when TIDAL returns 401."""
+    if not _is_authentication_error(error):
+        return False
+
+    from tiddl.core.cancel import request_cancel
+
+    request_cancel()
+    return True
 
 
 def _guarded_mkdir(root: Path, path: Path, mode: str) -> "anchor.AnchorCheck":
@@ -348,6 +391,8 @@ class Downloader:
         fallback_api: Optional[TidalAPI] = None,
         destination_identity: Literal["off", "strict"] = "off",
         identity_tracker: Optional["anchor.IdentityFailureTracker"] = None,
+        audio_mode: Literal["auto", "stereo"] = "auto",
+        quality_policy: Literal["flexible", "strict"] = "flexible",
     ) -> None:
         self.api = tidal_api
         # Modo hibrido: cliente TV (lossless) para cuando el primario (HiRes)
@@ -370,6 +415,8 @@ class Downloader:
         # this feature) never hits an AttributeError — its any_refused is
         # simply never observed by anything outside this instance.
         self.identity_tracker = identity_tracker or anchor.IdentityFailureTracker()
+        self.audio_mode = audio_mode
+        self.quality_policy = quality_policy
         self.dir_cache: dict[Path, set[str]] = {}
         # Flat index: stem → set of extensions, para lookup de alternativas sin re-escanear
         self._stem_index: dict[str, set[str]] = {}
@@ -1223,12 +1270,25 @@ class Downloader:
                         log.warning(f"Quality '{q}' failed for {item.id}: {e}")
                         self.rich_output.console.print(f"[yellow]⚠ Quality {q} failed: {e}[/]")
 
-                        # FIX: Fail fast on Rate Limit to avoid "Error Could not download..." spam
-                        if "429" in str(e) or "Limit" in str(e):
+                        if _abort_for_authentication_error(e):
+                            self.rich_output.console.print(
+                                f"[red]Download stopped: authentication expired (401) while "
+                                f"requesting '{display_title}'.[/]"
+                            )
+                            return None, False
+
+                        # Fail fast on a real HTTP 429 to avoid retry spam.
+                        if _is_rate_limit_error(e):
                             self.rich_output.console.print(f"[yellow]Skipped '{display_title}' (Rate Limit)[/]")
                             return None, False
 
                         continue
+
+                    # Another concurrent track may have received a fatal 401 while
+                    # this blocking request was in flight. Do not process or write
+                    # its response after the run-wide stop signal.
+                    if is_cancelled():
+                        return None, False
 
                     # Hibrido de 2 tokens: si el primario (HiRes) degrado por debajo
                     # de LOSSLESS (ej. HI_RES_LOSSLESS -> HIGH 320 en un track solo
@@ -1261,6 +1321,25 @@ class Downloader:
                         if quality_score.get(stream.audioQuality, 0) < quality_score.get(_next_q, 0):
                             log.debug(f"{item.id}: {q}->{stream.audioQuality} degradado, reintento en {_next_q}")
                             continue
+
+                    # Inspect the FINAL selected manifest (including a possible
+                    # fallback-client replacement), before parsing media URLs or
+                    # creating any destination/staging file.
+                    inspection = inspect_track_stream(
+                        stream,
+                        audio_mode=self.audio_mode,
+                        requested_quality=self.track_quality,
+                        quality_policy=self.quality_policy,
+                    )
+                    if not inspection.accepted:
+                        from tiddl.core.cancel import request_cancel
+
+                        request_cancel()
+                        self.rich_output.console.print(
+                            f"[red]Download stopped before media transfer: {inspection.reason} "
+                            f"for '{display_title}'.[/]"
+                        )
+                        return None, False
                     urls, _ = parse_track_stream(stream)
                     # Use stream.audioQuality (actual delivery) not q (requested quality).
                     # TIDAL can downgrade silently; using q would save M4A content as .flac.
@@ -1388,13 +1467,22 @@ class Downloader:
                         stream = await asyncio.to_thread(self.api.get_video_stream, video_id=item.id, quality=q)
                     except (ApiError, HTTPError) as e:
                         log.warning(f"video quality '{q}' failed for {item.id}: {e}")
-                        if "429" in str(e) or "Rate" in str(e):
+                        if _abort_for_authentication_error(e):
+                            self.rich_output.console.print(
+                                f"[red]Download stopped: authentication expired (401) while "
+                                f"requesting '{display_title}'.[/]"
+                            )
+                            return None, False
+                        if _is_rate_limit_error(e):
                             self.rich_output.console.print(f"[yellow]Skipped '{display_title}' (Rate Limit)[/]")
                             return None, False
                         continue
                     except Exception as e:
                         log.error(f"Unexpected error for video {item.id} q={q}: {e}")
                         continue
+
+                    if is_cancelled():
+                        return None, False
 
                     quality = video_qualities_color[stream.videoQuality]
 

--- a/tiddl/cli/commands/info.py
+++ b/tiddl/cli/commands/info.py
@@ -1,12 +1,103 @@
 from __future__ import annotations
+
 import typer
 from rich.syntax import Syntax
 from typing_extensions import Annotated
 
 from tiddl.cli.ctx import Context
 from tiddl.cli.utils.resource import TidalResource
+from tiddl.core.edition_resolver import SUPPORTED_QUALITIES, find_stereo_editions
 
 info_command = typer.Typer(name="info", help="Show metadata for a resource.")
+
+
+@info_command.command(
+    name="editions",
+    help="Find likely stereo editions of a TIDAL album without downloading anything.",
+)
+def info_editions(
+    ctx: Context,
+    album: Annotated[TidalResource, typer.Argument(parser=TidalResource.from_string)],
+    quality: Annotated[
+        str,
+        typer.Option(
+            "--quality",
+            "-q",
+            help="Required stereo quality: low, normal, high (Lossless), or max (HiRes Lossless).",
+        ),
+    ] = "max",
+):
+    """Read-only diagnostic for separately published Atmos/stereo editions."""
+    if album.type != "album":
+        raise typer.BadParameter("editions requires a TIDAL album URL")
+    quality = quality.casefold()
+    if quality not in SUPPORTED_QUALITIES:
+        raise typer.BadParameter(
+            "quality must be low, normal, high, or max", param_hint="--quality"
+        )
+
+    ctx.obj.console.print(
+        f"[bold cyan]Dry run: checking {quality.upper()} stereo editions "
+        f"for album {album.id}...[/]"
+    )
+    try:
+        result = find_stereo_editions(
+            ctx.obj.api, int(album.id), requested_quality=quality
+        )
+    except Exception as exc:
+        ctx.obj.console.print(f"[red]Error checking editions:[/] {exc}")
+        raise typer.Exit(1)
+
+    source = result.source
+    modes = ", ".join(getattr(source, "audioModes", []) or []) or "unknown"
+    ctx.obj.console.print(
+        f"Requested: [bold]{source.title}[/] (ID {source.id}) — {modes}, "
+        f"{source.numberOfTracks} tracks"
+    )
+    if result.source_satisfies_request:
+        ctx.obj.console.print(
+            f"[green]The requested album already provides {quality.upper()} stereo; "
+            "no replacement is needed.[/]"
+        )
+        ctx.obj.console.print(
+            "[dim]Dry run only: no files were downloaded and no settings were changed.[/]"
+        )
+        return
+    if not result.candidates:
+        ctx.obj.console.print(
+            f"[yellow]No sufficiently similar {quality.upper()} stereo edition was found.[/]"
+        )
+        ctx.obj.console.print("[dim]No files were downloaded and no settings were changed.[/]")
+        return
+
+    for index, candidate in enumerate(result.candidates, start=1):
+        alternate = candidate.album
+        quality_tags = getattr(getattr(alternate, "mediaMetadata", None), "tags", []) or []
+        ctx.obj.console.print(
+            f"\n[bold green]#{index} Stereo candidate:[/] {alternate.title} "
+            f"(ID {alternate.id})"
+        )
+        ctx.obj.console.print(
+            f"Score: {candidate.score:.1%} · track overlap: {candidate.track_overlap:.1%} · "
+            f"quality: {', '.join(quality_tags) or alternate.audioQuality}"
+        )
+        if candidate.missing_tracks:
+            ctx.obj.console.print(
+                "[yellow]Missing from candidate:[/] " + ", ".join(candidate.missing_tracks)
+            )
+        if candidate.extra_tracks:
+            ctx.obj.console.print(
+                "[yellow]Additional in candidate:[/] " + ", ".join(candidate.extra_tracks)
+            )
+        if candidate.requires_confirmation:
+            ctx.obj.console.print("[yellow]Confirmation would be required before substitution.[/]")
+        else:
+            ctx.obj.console.print(
+                "[green]Track listing matches; safe for a future confirmed substitution.[/]"
+            )
+    ctx.obj.console.print(
+        "\n[dim]Dry run only: no files were downloaded and no settings were changed.[/]"
+    )
 
 
 @info_command.command(name="url", help="Get metadata for Tidal URLs.")
@@ -20,7 +111,9 @@ def info_url(
     Get metadata for Tidal URLs.
     """
     for resource in urls:
-        ctx.obj.console.print(f"\n[bold cyan]Fetching metadata for {resource.type} {resource.id}...[/]")
+        ctx.obj.console.print(
+            f"\n[bold cyan]Fetching metadata for {resource.type} {resource.id}...[/]"
+        )
 
         try:
             data = None
@@ -46,7 +139,7 @@ def info_url(
                     json_str = data.model_dump_json(indent=4)
                 else:
                     json_str = data.json(indent=4)
-                    
+
                 syntax = Syntax(json_str, "json", theme="monokai", word_wrap=True)
                 ctx.obj.console.print(syntax)
 

--- a/tiddl/core/download_policy.py
+++ b/tiddl/core/download_policy.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class SessionTrackLimit:
+    """Small, synchronous gate for a per-process track limit.
+
+    ``admit`` returns whether the item may continue and whether the caller
+    should display the limit warning.  The warning is deliberately emitted
+    only once even when many already-scheduled items reach the gate.
+    """
+
+    limit: int
+    count: int = 0
+    announced: bool = False
+
+    def admit(self) -> tuple[bool, bool]:
+        if self.limit > 0 and self.count >= self.limit:
+            should_announce = not self.announced
+            self.announced = True
+            return False, should_announce
+
+        self.count += 1
+        return True, False

--- a/tiddl/core/edition_resolver.py
+++ b/tiddl/core/edition_resolver.py
@@ -1,0 +1,256 @@
+"""Read-only discovery of alternate stereo editions.
+
+TIDAL commonly publishes stereo and Dolby Atmos mixes as separate album and
+track IDs.  This module deliberately does not affect downloads: it only finds
+and scores possible stereo counterparts so the behaviour can be evaluated
+before automatic substitution is introduced.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any, Iterable
+
+SUPPORTED_QUALITIES = ("low", "normal", "high", "max")
+
+
+def quality_fallback_order(requested_quality: str, policy: str = "flexible") -> tuple[str, ...]:
+    """Catalog tiers to try, from the user's ceiling down to LOW."""
+    quality = requested_quality.casefold()
+    if quality not in SUPPORTED_QUALITIES:
+        raise ValueError(f"unsupported quality: {requested_quality}")
+    if policy.casefold() == "strict":
+        return (quality,)
+    if policy.casefold() != "flexible":
+        raise ValueError(f"unsupported quality policy: {policy}")
+    index = SUPPORTED_QUALITIES.index(quality)
+    return tuple(reversed(SUPPORTED_QUALITIES[: index + 1]))
+
+
+def normalize_catalog_text(value: str | None) -> str:
+    """Normalize catalog text for comparison, preserving meaningful words."""
+    text = unicodedata.normalize("NFKD", value or "")
+    text = "".join(char for char in text if not unicodedata.combining(char))
+    return " ".join(re.sub(r"[^a-z0-9]+", " ", text.casefold()).split())
+
+
+def album_modes(album: Any) -> tuple[str, ...]:
+    return tuple(str(mode).upper() for mode in (getattr(album, "audioModes", None) or []))
+
+
+def is_stereo_album(album: Any) -> bool:
+    return "STEREO" in album_modes(album)
+
+
+def is_atmos_album(album: Any) -> bool:
+    return "DOLBY_ATMOS" in album_modes(album)
+
+
+def album_quality_tags(album: Any) -> tuple[str, ...]:
+    metadata = getattr(album, "mediaMetadata", None)
+    return tuple(str(tag).upper() for tag in (getattr(metadata, "tags", None) or []))
+
+
+def supports_requested_quality(album: Any, requested_quality: str) -> bool:
+    """Whether the TIDAL catalog advertises the requested stereo tier."""
+    quality = requested_quality.casefold()
+    if quality not in SUPPORTED_QUALITIES:
+        raise ValueError(f"unsupported quality: {requested_quality}")
+    if not is_stereo_album(album):
+        return False
+    # Every stereo album can be requested from TIDAL at its lossy LOW/HIGH
+    # delivery tiers; catalog lossless tags only matter for High and MAX.
+    if quality in ("low", "normal"):
+        return True
+    tags = set(album_quality_tags(album))
+    if quality == "max":
+        return "HIRES_LOSSLESS" in tags
+    # A HiRes edition can also be requested at LOSSLESS by the playback API.
+    return bool(tags.intersection({"LOSSLESS", "HIRES_LOSSLESS"}))
+
+
+def _title_similarity(source: Any, candidate: Any) -> float:
+    source_title = normalize_catalog_text(getattr(source, "title", ""))
+    candidate_title = normalize_catalog_text(getattr(candidate, "title", ""))
+    return SequenceMatcher(None, source_title, candidate_title).ratio()
+
+
+def _track_title(track: Any) -> str:
+    title = getattr(track, "title", "")
+    version = getattr(track, "version", None)
+    return f"{title} {version}" if version else str(title)
+
+
+def _tracks(items: Any) -> list[Any]:
+    result = []
+    for wrapped in getattr(items, "items", []) or []:
+        item = getattr(wrapped, "item", wrapped)
+        # Album item endpoints can include videos; edition matching is audio-only.
+        if getattr(wrapped, "type", "track") == "track":
+            result.append(item)
+    return result
+
+
+def _title_multiset(tracks: Iterable[Any]) -> list[str]:
+    return [normalize_catalog_text(_track_title(track)) for track in tracks]
+
+
+def _match_titles(source: list[str], candidate: list[str]) -> tuple[int, list[str], list[str]]:
+    """Return exact normalized matches and unmatched titles, preserving duplicates."""
+    remaining = list(candidate)
+    missing: list[str] = []
+    matches = 0
+    for title in source:
+        try:
+            remaining.remove(title)
+            matches += 1
+        except ValueError:
+            missing.append(title)
+    return matches, missing, remaining
+
+
+@dataclass(frozen=True)
+class EditionCandidate:
+    album: Any
+    score: float
+    title_similarity: float
+    track_overlap: float
+    missing_tracks: tuple[str, ...]
+    extra_tracks: tuple[str, ...]
+
+    @property
+    def requires_confirmation(self) -> bool:
+        return bool(self.missing_tracks or self.extra_tracks)
+
+
+@dataclass(frozen=True)
+class EditionSearchResult:
+    source: Any
+    requested_quality: str
+    candidates: tuple[EditionCandidate, ...]
+
+    @property
+    def best(self) -> EditionCandidate | None:
+        return self.candidates[0] if self.candidates else None
+
+    @property
+    def source_satisfies_request(self) -> bool:
+        return supports_requested_quality(self.source, self.requested_quality)
+
+
+def score_stereo_candidate(
+    source: Any,
+    candidate: Any,
+    source_tracks: Iterable[Any],
+    candidate_tracks: Iterable[Any],
+) -> EditionCandidate | None:
+    """Score a stereo candidate; unrelated titles are rejected early."""
+    if getattr(source, "id", None) == getattr(candidate, "id", None):
+        return None
+    if not is_stereo_album(candidate):
+        return None
+
+    title_similarity = _title_similarity(source, candidate)
+    if title_similarity < 0.85:
+        return None
+
+    source_names = _title_multiset(source_tracks)
+    candidate_names = _title_multiset(candidate_tracks)
+    matches, missing, extra = _match_titles(source_names, candidate_names)
+    denominator = max(len(source_names), len(candidate_names), 1)
+    track_overlap = matches / denominator
+
+    source_artist = getattr(getattr(source, "artist", None), "id", None)
+    candidate_artist = getattr(getattr(candidate, "artist", None), "id", None)
+    artist_match = bool(source_artist and source_artist == candidate_artist)
+    date_match = bool(
+        getattr(source, "releaseDate", None)
+        and getattr(source, "releaseDate", None) == getattr(candidate, "releaseDate", None)
+    )
+    explicit_match = getattr(source, "explicit", None) == getattr(candidate, "explicit", None)
+    source_duration = max(int(getattr(source, "duration", 0) or 0), 1)
+    candidate_duration = max(int(getattr(candidate, "duration", 0) or 0), 1)
+    duration_similarity = min(source_duration, candidate_duration) / max(
+        source_duration, candidate_duration
+    )
+
+    score = (
+        0.35 * title_similarity
+        + 0.15 * float(artist_match)
+        + 0.10 * float(date_match)
+        + 0.30 * track_overlap
+        + 0.05 * duration_similarity
+        + 0.05 * float(explicit_match)
+    )
+    return EditionCandidate(
+        album=candidate,
+        score=score,
+        title_similarity=title_similarity,
+        track_overlap=track_overlap,
+        missing_tracks=tuple(missing),
+        extra_tracks=tuple(extra),
+    )
+
+
+def find_stereo_editions(
+    api: Any,
+    album_id: int,
+    requested_quality: str = "max",
+    minimum_score: float = 0.75,
+    quality_policy: str = "strict",
+) -> EditionSearchResult:
+    """Find likely stereo counterparts using only read-only catalog endpoints."""
+    requested_quality = requested_quality.casefold()
+    if requested_quality not in SUPPORTED_QUALITIES:
+        raise ValueError(f"unsupported quality: {requested_quality}")
+    tiers = quality_fallback_order(requested_quality, quality_policy)
+    source = api.get_album(album_id=album_id)
+    for tier in tiers:
+        if supports_requested_quality(source, tier):
+            return EditionSearchResult(source=source, requested_quality=tier, candidates=())
+    artist = getattr(source, "artist", None)
+    artist_id = getattr(artist, "id", None)
+    if not artist_id:
+        return EditionSearchResult(
+            source=source, requested_quality=requested_quality, candidates=()
+        )
+
+    source_tracks = _tracks(api.get_album_items(album_id=album_id))
+    albums_page = api.get_artist_albums(artist_id=artist_id, limit=100, offset=0)
+    candidates_by_tier: dict[str, list[EditionCandidate]] = {tier: [] for tier in tiers}
+    for album in getattr(albums_page, "items", []) or []:
+        if getattr(album, "id", None) == album_id:
+            continue
+        candidate_tier = next(
+            (tier for tier in tiers if supports_requested_quality(album, tier)), None
+        )
+        if candidate_tier is None:
+            continue
+        # Avoid one network request per album in a large discography. Track
+        # lists are only fetched after the cheap catalog-title filter passes.
+        if _title_similarity(source, album) < 0.85:
+            continue
+        candidate_tracks = _tracks(api.get_album_items(album_id=album.id))
+        scored = score_stereo_candidate(source, album, source_tracks, candidate_tracks)
+        if scored is not None and scored.score >= minimum_score:
+            candidates_by_tier[candidate_tier].append(scored)
+
+    for tier in tiers:
+        candidates = candidates_by_tier[tier]
+        if not candidates:
+            continue
+        candidates.sort(key=lambda value: (value.score, value.track_overlap), reverse=True)
+        return EditionSearchResult(
+            source=source,
+            requested_quality=tier,
+            candidates=tuple(candidates),
+        )
+
+    return EditionSearchResult(
+        source=source,
+        requested_quality=tiers[-1],
+        candidates=(),
+    )

--- a/tiddl/core/stream_policy.py
+++ b/tiddl/core/stream_policy.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+from typing import Any
+
+
+QUALITY_RANK = {
+    "LOW": 0,
+    "HIGH": 1,
+    "LOSSLESS": 2,
+    "HI_RES_LOSSLESS": 3,
+}
+
+REQUESTED_QUALITY = {
+    "low": "LOW",
+    "normal": "HIGH",
+    "high": "LOSSLESS",
+    "max": "HI_RES_LOSSLESS",
+}
+
+
+@dataclass(frozen=True)
+class StreamInspection:
+    audio_mode: str
+    audio_quality: str
+    bit_depth: int | None
+    sample_rate: int | None
+    is_stereo: bool
+    meets_requested_quality: bool
+    accepted: bool
+    reason: str = ""
+
+
+def inspect_track_stream(
+    stream: Any,
+    *,
+    audio_mode: str = "auto",
+    requested_quality: str = "high",
+    quality_policy: str = "flexible",
+) -> StreamInspection:
+    """Inspect playback metadata before any media URL is downloaded."""
+    mode = str(getattr(stream, "audioMode", "") or "UNKNOWN").upper()
+    quality = str(getattr(stream, "audioQuality", "") or "UNKNOWN").upper()
+    wanted = REQUESTED_QUALITY.get(requested_quality.casefold(), requested_quality.upper())
+    is_stereo = mode == "STEREO"
+    meets_quality = QUALITY_RANK.get(quality, -1) >= QUALITY_RANK.get(wanted, 99)
+
+    if audio_mode.casefold() == "stereo" and not is_stereo:
+        return StreamInspection(
+            mode,
+            quality,
+            getattr(stream, "bitDepth", None),
+            getattr(stream, "sampleRate", None),
+            is_stereo,
+            meets_quality,
+            False,
+            f"requested stereo but TIDAL returned {mode}",
+        )
+
+    if quality_policy.casefold() == "strict" and quality != wanted:
+        return StreamInspection(
+            mode,
+            quality,
+            getattr(stream, "bitDepth", None),
+            getattr(stream, "sampleRate", None),
+            is_stereo,
+            meets_quality,
+            False,
+            f"requested exact quality {wanted} but TIDAL returned {quality}",
+        )
+
+    return StreamInspection(
+        mode,
+        quality,
+        getattr(stream, "bitDepth", None),
+        getattr(stream, "sampleRate", None),
+        is_stereo,
+        meets_quality,
+        True,
+    )


### PR DESCRIPTION
## What's new

Adds the **Stereo Edition Resolver + Quality Policies** feature (TIDAL-only, no MusicBrainz/ISRC).

- Given an Atmos-only album URL, resolve and optionally use a separately published **stereo** edition at High (LOSSLESS) or MAX (HIRES_LOSSLESS).
- New controls: `--audio-mode auto|stereo`, `--edition-match ask|best`, `--quality-policy flexible|strict`.
- New read-only diagnostic: `tiddl info editions -q high|max ALBUM_URL`.
- New core modules: `edition_resolver.py`, `stream_policy.py`, `download_policy.py`.
- `auto` remains the default and preserves all legacy behavior; a missing stereo candidate is skipped, never silently downloaded as Atmos.
- Playback metadata is inspected before any media transfer; a non-`STEREO` manifest triggers a run-wide cooperative stop.
- Safety stops now exit the CLI non-zero; strict `normal` correctly maps to TIDAL `HIGH` (not `LOSSLESS`); the no-candidate message reflects the active quality policy.

Validated live (KAROL G, Kinito Méndez): MAX → 24-bit/48 kHz stereo FLAC, High → 16-bit/44.1 kHz stereo FLAC, flexible degradation down to LOW HE-AAC, all verified with ffprobe. Offline suite: 328 passed, 3 skipped, 0 failed. Design and evidence in `STEREO_EDITION_RESOLVER_MEMORY.md`.

## Novedades

Añade la función **Resolutor de edición estéreo + políticas de calidad** (solo TIDAL, sin MusicBrainz/ISRC).

- A partir de una URL de álbum solo-Atmos, localiza y opcionalmente usa una edición **estéreo** publicada por separado en High (LOSSLESS) o MAX (HIRES_LOSSLESS).
- Nuevos controles: `--audio-mode auto|stereo`, `--edition-match ask|best`, `--quality-policy flexible|strict`.
- Nuevo diagnóstico de solo lectura: `tiddl info editions -q high|max URL_ÁLBUM`.
- Nuevos módulos del core: `edition_resolver.py`, `stream_policy.py`, `download_policy.py`.
- `auto` sigue siendo el valor por defecto y conserva todo el comportamiento previo; si no hay candidata estéreo se omite, nunca se descarga Atmos en silencio.
- Se inspecciona el manifiesto de reproducción antes de transferir; un manifiesto no `STEREO` detiene toda la corrida de forma cooperativa.
- Las paradas de seguridad ahora salen con código ≠ 0; `strict normal` mapea correctamente a `HIGH` de TIDAL (no `LOSSLESS`); el mensaje de "sin candidata" refleja la política de calidad activa.

Validado en vivo (KAROL G, Kinito Méndez): MAX → FLAC estéreo 24-bit/48 kHz, High → FLAC estéreo 16-bit/44.1 kHz, degradación flexible hasta LOW HE-AAC, todo verificado con ffprobe. Suite offline: 328 pasan, 3 omitidos, 0 fallos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add TIDAL stereo edition resolution and enforce configurable audio and quality policies throughout downloads.

New Features:
- Add TIDAL stereo-edition resolution for album downloads with configurable matching, quality, and dry-run controls.
- Add a read-only editions diagnostic command for inspecting likely stereo album replacements.

Bug Fixes:
- Prevent Atmos streams from being downloaded when stereo playback was requested.
- Correctly distinguish authentication failures from rate limits and stop affected runs safely.
- Ensure strict quality validation maps user-facing quality levels correctly and reports safety stops with a non-zero exit status.

Enhancements:
- Add playback stream validation before media transfer and support flexible versus strict quality delivery policies.
- Improve session track-limit handling so its warning is emitted only once.

Documentation:
- Document the stereo edition resolver design, catalog audit results, and live validation evidence.

Tests:
- Add coverage for edition matching, quality fallback, stream validation, authentication/rate-limit classification, session limits, and cooperative safety stops.