### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,6 @@ This tool respects TIDAL's ToS and copyright laws. Users are responsible for ens
 
 ---
 
-**Version:** 1.2.1
+**Version:** 1.3.0
 **Status:** Production Ready ✅
 **Last Updated:** August 19, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.2.1"
+version = "1.3.0"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump 1.2.1 → 1.3.0 for the stereo edition resolver + quality policies feature (merged in #20) and the safety-stop / strict-Normal fixes.

Bumps `pyproject.toml` and README version. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Release version 1.3.0 with synchronized package metadata and README version information.

Build:
- Bump the project package version from 1.2.1 to 1.3.0.

Documentation:
- Update the README to reflect version 1.3.0.