### PR TITLE
feat(download): resolve stereo editions for artist URLs

### DIFF
--- a/tests/test_stereo_plan.py
+++ b/tests/test_stereo_plan.py
@@ -1,0 +1,58 @@
+"""Unit coverage for `plan_stereo_resolution`, the pure decision that drives
+both the direct-album and the artist-expansion stereo paths in
+`tiddl.cli.commands.download`.
+
+The only behavioural difference between the two call sites is `keep_original`:
+a direct album URL is skipped when no stereo edition qualifies, while an album
+reached by expanding an artist keeps its original id so a whole-artist stereo
+run never silently drops an album.
+"""
+
+from types import SimpleNamespace
+
+from tiddl.cli.commands.download import plan_stereo_resolution
+
+
+def ns(**values):
+    return SimpleNamespace(**values)
+
+
+def result(*, source_ok=False, candidate=None, source_id=100):
+    return ns(
+        source=ns(id=source_id, title="Some Album"),
+        source_satisfies_request=source_ok,
+        best=candidate,
+    )
+
+
+def candidate(album_id, *, needs_confirmation):
+    return ns(album=ns(id=album_id), requires_confirmation=needs_confirmation)
+
+
+def test_source_already_stereo_keeps_source_for_both_modes():
+    r = result(source_ok=True, source_id=7)
+    assert plan_stereo_resolution(r, False) == ("keep-source", 7, False)
+    assert plan_stereo_resolution(r, True) == ("keep-source", 7, False)
+
+
+def test_no_candidate_direct_album_is_skipped():
+    r = result(source_ok=False, candidate=None, source_id=11)
+    assert plan_stereo_resolution(r, keep_original=False) == ("skip", 11, False)
+
+
+def test_no_candidate_artist_expansion_keeps_original():
+    # The whole point of keep_original: an artist album with no stereo edition
+    # is downloaded as-is instead of being dropped.
+    r = result(source_ok=False, candidate=None, source_id=11)
+    assert plan_stereo_resolution(r, keep_original=True) == ("keep-source", 11, False)
+
+
+def test_candidate_replace_propagates_confirmation_flag():
+    r = result(candidate=candidate(999, needs_confirmation=True))
+    assert plan_stereo_resolution(r, False) == ("replace", 999, True)
+    assert plan_stereo_resolution(r, True) == ("replace", 999, True)
+
+
+def test_candidate_replace_without_confirmation():
+    r = result(candidate=candidate(1000, needs_confirmation=False))
+    assert plan_stereo_resolution(r, keep_original=False) == ("replace", 1000, False)

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -338,6 +338,26 @@ def _finish_download_run(
         sys.exit(exit_code)
 
 
+def plan_stereo_resolution(result, keep_original: bool) -> tuple:
+    """Pure pre-confirmation decision for the stereo resolution of one album.
+
+    Returns ``(action, album_id, needs_confirmation)`` where ``action`` is one
+    of ``"keep-source"``, ``"replace"`` or ``"skip"``. ``keep_original`` is the
+    only behavioural difference between the two call sites: a direct album URL
+    (``keep_original=False``) is skipped when no stereo edition qualifies,
+    while an album reached by expanding an artist (``keep_original=True``)
+    keeps its original id instead — so a whole-artist stereo run never silently
+    drops an album. Kept a standalone pure function for direct unit coverage,
+    same as ``_download_exit_code`` above."""
+    source = result.source
+    if result.source_satisfies_request:
+        return ("keep-source", source.id, False)
+    candidate = result.best
+    if candidate is None:
+        return ("keep-source" if keep_original else "skip", source.id, False)
+    return ("replace", candidate.album.id, candidate.requires_confirmation)
+
+
 @download_command.callback(no_args_is_help=True)
 def download_callback(
     ctx: Context,
@@ -354,7 +374,9 @@ def download_callback(
             "--audio-mode",
             help=(
                 "Audio edition policy: auto keeps supplied IDs; stereo resolves "
-                "album URLs to stereo editions."
+                "album URLs to stereo editions, and expands artist URLs into "
+                "their albums resolved to stereo (keeping an album's original "
+                "when it has no stereo edition)."
             ),
         ),
     ] = "auto",
@@ -818,36 +840,35 @@ def download_callback(
         await auto_refresh_if_needed(threshold_minutes=30)
 
         if AUDIO_MODE == "stereo":
-            resolved_resources: list[TidalResource] = []
-            for resource in ctx.obj.resources:
-                if resource.type != "album":
-                    ctx.obj.console.print(
-                        f"[yellow]Stereo edition resolution currently applies only to direct "
-                        f"album URLs; keeping {resource.type}/{resource.id} unchanged.[/]"
-                    )
-                    resolved_resources.append(resource)
-                    continue
 
+            async def _resolve_stereo_album(album_id, keep_original: bool):
+                """Resolve one album id to the album id that should actually be
+                downloaded. Returns ``(album_id, download_it)``. When
+                ``keep_original`` is True (artist expansion) an unresolved or
+                declined album keeps its original id; when False (direct album
+                URL) it is skipped, preserving the original single-album
+                behaviour."""
                 result = await asyncio.to_thread(
                     find_stereo_editions,
                     ctx.obj.api,
-                    int(resource.id),
+                    int(album_id),
                     TRACK_QUALITY,
                     0.75,
                     QUALITY_POLICY,
                 )
                 resolved_quality = result.requested_quality
                 source = result.source
-                if result.source_satisfies_request:
+                action, target_id, needs_confirmation = plan_stereo_resolution(
+                    result, keep_original
+                )
+
+                if action == "keep-source" and result.source_satisfies_request:
                     ctx.obj.console.print(
                         f"[green]Stereo {resolved_quality.upper()} already available:[/] "
                         f"{source.title} (album/{source.id})"
                     )
-                    resolved_resources.append(resource)
-                    continue
-
-                candidate = result.best
-                if candidate is None:
+                    return source.id, True
+                if action == "skip":
                     quality_requirement = (
                         f"at or below {TRACK_QUALITY.upper()}"
                         if QUALITY_POLICY == "flexible"
@@ -858,8 +879,16 @@ def download_callback(
                         f"{source.title} (album/{source.id}); skipped because the requested "
                         "stereo/quality policy cannot be satisfied.[/]"
                     )
-                    continue
+                    return source.id, False
+                if action == "keep-source":
+                    # keep_original and no qualifying stereo edition was found.
+                    ctx.obj.console.print(
+                        f"[yellow]No stereo edition found for {source.title} "
+                        f"(album/{source.id}); keeping the original.[/]"
+                    )
+                    return source.id, True
 
+                candidate = result.best
                 alternate = candidate.album
                 ctx.obj.console.print(
                     f"[bold cyan]Stereo replacement:[/] album/{source.id} → "
@@ -879,7 +908,7 @@ def download_callback(
                     )
 
                 accept = True
-                if candidate.requires_confirmation and EDITION_MATCH == "ask":
+                if needs_confirmation and EDITION_MATCH == "ask":
                     if DRY_RUN:
                         ctx.obj.console.print(
                             "[yellow]A real run would request confirmation before substitution.[/]"
@@ -891,13 +920,84 @@ def download_callback(
                             default=False,
                         )
                 if accept:
-                    resolved_resources.append(
-                        TidalResource(type="album", id=str(alternate.id))
+                    return alternate.id, True
+                if keep_original:
+                    ctx.obj.console.print(
+                        f"[yellow]Replacement declined; keeping original album/{source.id}.[/]"
                     )
+                    return source.id, True
+                ctx.obj.console.print(
+                    f"[yellow]Replacement declined; album/{source.id} was skipped.[/]"
+                )
+                return source.id, False
+
+            async def _collect_artist_album_ids(artist_id):
+                """Enumerate an artist's releases as album ids, honouring the
+                same ``--singles`` filter as a normal artist download."""
+                ids: list = []
+
+                async def _page(singles: bool):
+                    offset = 0
+                    filter_type = "EPSANDSINGLES" if singles else "ALBUMS"
+                    while True:
+                        if is_cancelled():
+                            break
+                        page = await asyncio.to_thread(
+                            ctx.obj.api.get_artist_albums,
+                            artist_id=artist_id,
+                            offset=offset,
+                            filter=filter_type,
+                        )
+                        if not page or not getattr(page, "items", None):
+                            break
+                        for album in page.items:
+                            ids.append(album.id)
+                        offset += page.limit
+                        if offset >= page.totalNumberOfItems:
+                            break
+
+                if SINGLES_FILTER == "include":
+                    await _page(False)
+                    await _page(True)
+                else:
+                    await _page(SINGLES_FILTER == "only")
+                return ids
+
+            resolved_resources: list[TidalResource] = []
+            for resource in ctx.obj.resources:
+                if is_cancelled():
+                    break
+                if resource.type == "album":
+                    album_id, download_it = await _resolve_stereo_album(
+                        resource.id, keep_original=False
+                    )
+                    if download_it:
+                        resolved_resources.append(
+                            TidalResource(type="album", id=str(album_id))
+                        )
+                elif resource.type == "artist":
+                    ctx.obj.console.print(
+                        f"[bold cyan]Stereo mode:[/] resolving stereo editions across "
+                        f"artist/{resource.id} (videos are not included in stereo mode)."
+                    )
+                    seen_stereo_ids: set = set()
+                    for aid in await _collect_artist_album_ids(resource.id):
+                        if is_cancelled():
+                            break
+                        album_id, download_it = await _resolve_stereo_album(
+                            aid, keep_original=True
+                        )
+                        if download_it and album_id not in seen_stereo_ids:
+                            seen_stereo_ids.add(album_id)
+                            resolved_resources.append(
+                                TidalResource(type="album", id=str(album_id))
+                            )
                 else:
                     ctx.obj.console.print(
-                        f"[yellow]Replacement declined; album/{source.id} was skipped.[/]"
+                        f"[yellow]Stereo edition resolution applies only to album and artist "
+                        f"URLs; keeping {resource.type}/{resource.id} unchanged.[/]"
                     )
+                    resolved_resources.append(resource)
 
             if DRY_RUN:
                 ctx.obj.console.print(


### PR DESCRIPTION
## What's new
`--audio-mode stereo` now works on **artist** URLs, not just direct album URLs. It expands the artist into its releases (honouring the `--singles` filter) and resolves each album to its stereo edition, de-duplicating by resolved album id.

- An album with **no** qualifying stereo edition **keeps its original** and is still downloaded, so a whole-artist stereo run never silently drops an album (direct album URLs keep their existing skip behaviour).
- Videos are not included in stereo mode.
- The pre-confirmation decision is extracted into a pure, unit-tested `plan_stereo_resolution()`; album and artist share one `_resolve_stereo_album()` helper, so **album behaviour is unchanged**.
- Playlists/mixes/single tracks still stay unchanged (no reliable per-track Atmos↔stereo bridge).

Full suite: **333 passed, 3 skipped, 0 failed**; 3.10 compile OK.

## Novedades
`--audio-mode stereo` ahora funciona con URLs de **artista**, no solo de álbum directo. Expande el artista en sus lanzamientos (respetando el filtro `--singles`) y resuelve cada álbum a su edición estéreo, deduplicando por id resuelto.

- Un álbum **sin** edición estéreo válida **mantiene el original** y se descarga igual, para que una descarga de artista en estéreo nunca omita álbumes en silencio (los álbumes directos conservan su comportamiento de omitir).
- Los videos no se incluyen en modo estéreo.
- La decisión previa a confirmación se extrae en una función pura y testeada `plan_stereo_resolution()`; álbum y artista comparten `_resolve_stereo_album()`, así el **comportamiento de álbum no cambia**.
- Playlists/mixes/tracks sueltos siguen sin tocarse (no hay puente fiable Atmos↔estéreo por pista).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend stereo audio-mode resolution to artist downloads without changing existing album, playlist, mix, or track behavior.

New Features:
- Resolve stereo editions for albums expanded from artist URLs while honoring the singles filter and deduplicating resolved albums.

Bug Fixes:
- Preserve artist albums without qualifying stereo editions instead of silently dropping them, while retaining existing direct-album behavior.

Enhancements:
- Exclude videos from stereo-mode artist expansion and keep unsupported resource types unchanged.
- Share stereo album resolution behavior between direct album and artist downloads through a pure planning function.

Documentation:
- Update the audio-mode help text to describe stereo resolution for artist URLs.

Tests:
- Add unit coverage for stereo resolution planning across direct-album and artist-expansion scenarios.