### PR TITLE
perf(download): de-dup artist album ids before stereo resolution

### DIFF
--- a/tests/test_stereo_plan.py
+++ b/tests/test_stereo_plan.py
@@ -35,6 +35,14 @@ def test_source_already_stereo_keeps_source_for_both_modes():
     assert plan_stereo_resolution(r, True) == ("keep-source", 7, False)
 
 
+def test_source_satisfies_request_ignores_candidate():
+    # The decision short-circuits on source_satisfies_request and must never
+    # inspect result.best in that case, even when a candidate exists.
+    r = result(source_ok=True, source_id=7, candidate=candidate(9, needs_confirmation=True))
+    assert plan_stereo_resolution(r, False) == ("keep-source", 7, False)
+    assert plan_stereo_resolution(r, True) == ("keep-source", 7, False)
+
+
 def test_no_candidate_direct_album_is_skipped():
     r = result(source_ok=False, candidate=None, source_id=11)
     assert plan_stereo_resolution(r, keep_original=False) == ("skip", 11, False)

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -933,8 +933,11 @@ def download_callback(
 
             async def _collect_artist_album_ids(artist_id):
                 """Enumerate an artist's releases as album ids, honouring the
-                same ``--singles`` filter as a normal artist download."""
+                same ``--singles`` filter as a normal artist download. Album
+                ids are de-duplicated across pages and the ALBUMS/EPSANDSINGLES
+                passes (order preserved) so no album is resolved twice."""
                 ids: list = []
+                seen: set = set()
 
                 async def _page(singles: bool):
                     offset = 0
@@ -951,7 +954,9 @@ def download_callback(
                         if not page or not getattr(page, "items", None):
                             break
                         for album in page.items:
-                            ids.append(album.id)
+                            if album.id not in seen:
+                                seen.add(album.id)
+                                ids.append(album.id)
                         offset += page.limit
                         if offset >= page.totalNumberOfItems:
                             break


### PR DESCRIPTION
Addresses the Sourcery review on #23:
- De-duplicate album ids in `_collect_artist_album_ids` (order preserved) so an artist's release is never resolved twice (resolution is API-heavy). Downloads were already de-duped downstream; this removes redundant resolution work.
- Adds a regression test: `plan_stereo_resolution` ignores a present candidate when the source already satisfies the request.

Declined (with reason): Enum for the 3-value action (consistent with existing string-literal patterns); parallelizing per-album resolution (would burst API calls and risk 429 — the client already paces via requests_per_minute).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Avoid redundant artist album resolution and make stereo planning consistently retain sources that already satisfy the requested mode.

Bug Fixes:
- Prevent stereo resolution from considering an alternate candidate when the existing source already satisfies the request.

Enhancements:
- De-duplicate artist album IDs across paginated release results and release-type passes while preserving their order, avoiding redundant album resolution.

Tests:
- Add regression coverage for source-satisfies-request behavior when a candidate is also present.