### PR TITLE
perf(download): cache catalog reads across an artist stereo run

### DIFF
--- a/tests/test_stereo_plan.py
+++ b/tests/test_stereo_plan.py
@@ -10,7 +10,7 @@ run never silently drops an album.
 
 from types import SimpleNamespace
 
-from tiddl.cli.commands.download import plan_stereo_resolution
+from tiddl.cli.commands.download import CatalogReadCache, plan_stereo_resolution
 
 
 def ns(**values):
@@ -64,3 +64,54 @@ def test_candidate_replace_propagates_confirmation_flag():
 def test_candidate_replace_without_confirmation():
     r = result(candidate=candidate(1000, needs_confirmation=False))
     assert plan_stereo_resolution(r, keep_original=False) == ("replace", 1000, False)
+
+
+class _CountingApi:
+    """Fake api counting real calls to the cached catalog reads."""
+
+    def __init__(self):
+        self.calls = {"get_album": 0, "get_artist_albums": 0, "get_uncached": 0}
+
+    def get_album(self, album_id):
+        self.calls["get_album"] += 1
+        return ("album", album_id)
+
+    def get_artist_albums(self, artist_id, limit=100, offset=0, filter=None):
+        self.calls["get_artist_albums"] += 1
+        return ("artist_albums", artist_id, limit, offset, filter)
+
+    def get_uncached(self, x):
+        self.calls["get_uncached"] += 1
+        return x
+
+
+def test_cache_memoises_repeated_reads_by_args():
+    api = _CountingApi()
+    cache = CatalogReadCache(api)
+    # same album id repeated -> underlying called once
+    assert cache.get_album(album_id=549984784) == ("album", 549984784)
+    assert cache.get_album(album_id=549984784) == ("album", 549984784)
+    assert api.calls["get_album"] == 1
+    # same artist page repeated (the hot path when resolving a whole artist)
+    for _ in range(5):
+        cache.get_artist_albums(artist_id=5237820, limit=100, offset=0)
+    assert api.calls["get_artist_albums"] == 1
+
+
+def test_cache_distinguishes_different_args():
+    api = _CountingApi()
+    cache = CatalogReadCache(api)
+    cache.get_album(album_id=1)
+    cache.get_album(album_id=2)
+    assert api.calls["get_album"] == 2
+    cache.get_artist_albums(artist_id=9, offset=0, filter="ALBUMS")
+    cache.get_artist_albums(artist_id=9, offset=0, filter="EPSANDSINGLES")
+    assert api.calls["get_artist_albums"] == 2
+
+
+def test_cache_passes_through_uncached_methods():
+    api = _CountingApi()
+    cache = CatalogReadCache(api)
+    assert cache.get_uncached(7) == 7
+    assert cache.get_uncached(7) == 7
+    assert api.calls["get_uncached"] == 2  # not memoised

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -358,6 +358,37 @@ def plan_stereo_resolution(result, keep_original: bool) -> tuple:
     return ("replace", candidate.album.id, candidate.requires_confirmation)
 
 
+class CatalogReadCache:
+    """Per-run memoiser for the read-only catalog endpoints the stereo
+    resolver hits repeatedly. Resolving a whole artist calls
+    ``find_stereo_editions`` once per album, and each of those re-fetches the
+    same ``get_artist_albums`` page (and re-reads album items), which is slow
+    on large discographies. Wrapping the api in this proxy for one artist run
+    fetches each ``get_album`` / ``get_artist_albums`` / ``get_album_items``
+    result at most once; every other attribute passes straight through so
+    behaviour is identical. Catalog data is stable within a single run, so
+    caching these reads is safe."""
+
+    _CACHED = ("get_album", "get_artist_albums", "get_album_items")
+
+    def __init__(self, api):
+        self._api = api
+        self._cache: dict = {}
+
+    def __getattr__(self, name):
+        attr = getattr(self._api, name)
+        if name not in self._CACHED or not callable(attr):
+            return attr
+
+        def cached(*args, **kwargs):
+            key = (name, args, tuple(sorted(kwargs.items())))
+            if key not in self._cache:
+                self._cache[key] = attr(*args, **kwargs)
+            return self._cache[key]
+
+        return cached
+
+
 @download_command.callback(no_args_is_help=True)
 def download_callback(
     ctx: Context,
@@ -841,16 +872,18 @@ def download_callback(
 
         if AUDIO_MODE == "stereo":
 
-            async def _resolve_stereo_album(album_id, keep_original: bool):
+            async def _resolve_stereo_album(album_id, keep_original: bool, api=None):
                 """Resolve one album id to the album id that should actually be
                 downloaded. Returns ``(album_id, download_it)``. When
                 ``keep_original`` is True (artist expansion) an unresolved or
                 declined album keeps its original id; when False (direct album
                 URL) it is skipped, preserving the original single-album
-                behaviour."""
+                behaviour. ``api`` lets the artist path pass a
+                ``CatalogReadCache`` so the shared artist catalog is fetched
+                once per run instead of once per album."""
                 result = await asyncio.to_thread(
                     find_stereo_editions,
-                    ctx.obj.api,
+                    api if api is not None else ctx.obj.api,
                     int(album_id),
                     TRACK_QUALITY,
                     0.75,
@@ -986,11 +1019,15 @@ def download_callback(
                         f"artist/{resource.id} (videos are not included in stereo mode)."
                     )
                     seen_stereo_ids: set = set()
+                    # One shared cache for the whole artist run so the artist
+                    # catalog (and repeated album reads) are fetched once, not
+                    # once per album.
+                    artist_api = CatalogReadCache(ctx.obj.api)
                     for aid in await _collect_artist_album_ids(resource.id):
                         if is_cancelled():
                             break
                         album_id, download_it = await _resolve_stereo_album(
-                            aid, keep_original=True
+                            aid, keep_original=True, api=artist_api
                         )
                         if download_it and album_id not in seen_stereo_ids:
                             seen_stereo_ids.add(album_id)


### PR DESCRIPTION
Resolving a whole artist in stereo mode called `find_stereo_editions` once per album, each re-fetching the same `get_artist_albums` page — minutes of redundant, rate-limited requests on a large discography. Adds a per-run `CatalogReadCache` memoising `get_album` / `get_artist_albums` / `get_album_items`; all other attributes pass through, so behaviour is identical.

**Live re-test** (KAROL G, ~131 albums, `--dry-run`): **~7+ min → 2.9 s**, bit-identical results (4 replacements, 109 already-stereo, 18 kept originals). Full suite: 337 passed, 3 skipped. Module-level class with unit tests (memoise / arg-keying / pass-through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Speed up artist-wide stereo downloads by reusing catalog data throughout each resolution run.

Enhancements:
- Cache repeated catalog reads during artist-wide stereo resolution to substantially reduce redundant API requests while preserving existing behavior.

Tests:
- Add unit tests covering catalog read memoization, argument-specific cache keys, and pass-through behavior for uncached API methods.