### PR TITLE
chore(release): prepare v1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,6 @@ This tool respects TIDAL's ToS and copyright laws. Users are responsible for ens
 
 ---
 
-**Version:** 1.3.1
+**Version:** 1.3.2
 **Status:** Production Ready ✅
 **Last Updated:** August 19, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.3.1"
+version = "1.3.2"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump 1.3.1 → 1.3.2 for the artist-catalog cache (#26): a whole-artist stereo resolution went from minutes to ~3s with identical results. Bumps pyproject + README. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the 1.3.2 release by updating the project and documentation version references.

Build:
- Bump the project version from 1.3.1 to 1.3.2 in the package metadata.

Documentation:
- Update the README to reflect version 1.3.2.