### PR TITLE
test(download): cover get_album_items caching; harden cache key

### DIFF
--- a/tests/test_stereo_plan.py
+++ b/tests/test_stereo_plan.py
@@ -70,11 +70,20 @@ class _CountingApi:
     """Fake api counting real calls to the cached catalog reads."""
 
     def __init__(self):
-        self.calls = {"get_album": 0, "get_artist_albums": 0, "get_uncached": 0}
+        self.calls = {
+            "get_album": 0,
+            "get_artist_albums": 0,
+            "get_album_items": 0,
+            "get_uncached": 0,
+        }
 
     def get_album(self, album_id):
         self.calls["get_album"] += 1
         return ("album", album_id)
+
+    def get_album_items(self, album_id):
+        self.calls["get_album_items"] += 1
+        return ("album_items", album_id)
 
     def get_artist_albums(self, artist_id, limit=100, offset=0, filter=None):
         self.calls["get_artist_albums"] += 1
@@ -96,6 +105,23 @@ def test_cache_memoises_repeated_reads_by_args():
     for _ in range(5):
         cache.get_artist_albums(artist_id=5237820, limit=100, offset=0)
     assert api.calls["get_artist_albums"] == 1
+
+
+def test_cache_memoises_album_items():
+    api = _CountingApi()
+    cache = CatalogReadCache(api)
+    assert cache.get_album_items(album_id=549984784) == ("album_items", 549984784)
+    assert cache.get_album_items(album_id=549984784) == ("album_items", 549984784)
+    assert api.calls["get_album_items"] == 1
+
+
+def test_cache_passes_through_unhashable_args_without_crashing():
+    # Defensive: an unhashable arg must not crash the cache; it just isn't cached.
+    api = _CountingApi()
+    cache = CatalogReadCache(api)
+    assert cache.get_album(album_id=[1, 2]) == ("album", [1, 2])
+    assert cache.get_album(album_id=[1, 2]) == ("album", [1, 2])
+    assert api.calls["get_album"] == 2  # not memoised (unhashable)
 
 
 def test_cache_distinguishes_different_args():

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -382,6 +382,12 @@ class CatalogReadCache:
 
         def cached(*args, **kwargs):
             key = (name, args, tuple(sorted(kwargs.items())))
+            try:
+                hash(key)
+            except TypeError:
+                # Unhashable argument (the catalog reads only take scalars, so
+                # this is defensive): skip the cache and call straight through.
+                return attr(*args, **kwargs)
             if key not in self._cache:
                 self._cache[key] = attr(*args, **kwargs)
             return self._cache[key]


### PR DESCRIPTION
Sourcery follow-up on #26 (no behaviour change):
- Test `get_album_items` caching (was untested).
- Defensive: skip the cache (call through) if a cached method ever gets an unhashable arg, instead of raising. Never triggers today (scalar args only); covered by a test.

Declined with reason: thread-safe locking (artist resolution is sequential — one `to_thread` at a time); explicit methods vs `__getattr__` (pass-through for non-cached attrs needs the dynamic form; mypy is informational).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden catalog read caching and expand its test coverage.

Bug Fixes:
- Make catalog caching safely bypass the cache for unhashable arguments instead of raising an error.

Tests:
- Add coverage for get_album_items memoization and unhashable-argument pass-through behavior.