### PR TITLE
feat(download): exclude compilations / live albums from artist downloads

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -115,6 +115,12 @@ singles_filter = "none"        # default: "none"
 #   "none" = ignore videos   "only" = videos only   "allow" = audio + videos
 videos_filter = "none"         # default: "none"
 
+# When downloading an ARTIST, exclude these release types. TIDAL lists them as
+# plain albums, so they are identified from the artist page (the same
+# "Compilations" / "Live albums" sections the TIDAL app shows) and skipped.
+exclude_compilations = false   # default: false — skip the artist's compilations
+exclude_live_albums = false    # default: false — skip the artist's live albums
+
 # Set the file modified time (mtime) to the release date.
 update_mtime = false           # default: false
 

--- a/tests/test_artist_sections.py
+++ b/tests/test_artist_sections.py
@@ -1,0 +1,85 @@
+"""Unit coverage for the artist-page section parser that powers the
+compilation / live / appears-on exclusion filter."""
+
+from tiddl.core.artist_sections import excluded_album_ids_from_page
+
+# Shaped like a real pages/artist response (English module titles).
+PAGE = {
+    "rows": [
+        {
+            "modules": [
+                {"title": "Featured Albums", "type": "ALBUM_LIST",
+                 "pagedList": {"items": [{"id": 1}, {"id": 2}]}},
+                {"title": "EP & Singles", "type": "ALBUM_LIST",
+                 "pagedList": {"items": [{"id": 3}]}},
+            ]
+        },
+        {
+            "modules": [
+                {"title": "Compilations", "type": "ALBUM_LIST",
+                 "pagedList": {"items": [{"id": 10}, {"id": 11}]}},
+                {"title": "Live albums", "type": "ALBUM_LIST",
+                 "pagedList": {"items": [{"id": 20}]}},
+                {"title": "Videos", "type": "VIDEO_LIST",
+                 "pagedList": {"items": [{"id": 999, "type": "Music Video"}]}},
+                {"title": "Appears On", "type": "ALBUM_LIST",
+                 "pagedList": {"items": [{"id": 30}, {"id": 31}]}},
+            ]
+        },
+    ]
+}
+
+
+def test_no_flags_excludes_nothing():
+    assert excluded_album_ids_from_page(
+        PAGE, compilations=False, live=False, appears_on=False
+    ) == set()
+
+
+def test_compilations_only():
+    assert excluded_album_ids_from_page(
+        PAGE, compilations=True, live=False, appears_on=False
+    ) == {10, 11}
+
+
+def test_live_only():
+    assert excluded_album_ids_from_page(
+        PAGE, compilations=False, live=True, appears_on=False
+    ) == {20}
+
+
+def test_appears_on_only():
+    assert excluded_album_ids_from_page(
+        PAGE, compilations=False, live=False, appears_on=True
+    ) == {30, 31}
+
+
+def test_all_three_union():
+    assert excluded_album_ids_from_page(
+        PAGE, compilations=True, live=True, appears_on=True
+    ) == {10, 11, 20, 30, 31}
+
+
+def test_featured_and_singles_never_excluded():
+    got = excluded_album_ids_from_page(
+        PAGE, compilations=True, live=True, appears_on=True
+    )
+    assert 1 not in got and 2 not in got and 3 not in got  # albums/EPs kept
+    assert 999 not in got  # videos never counted
+
+
+def test_title_matching_is_case_insensitive():
+    page = {"rows": [{"modules": [
+        {"title": "COMPILATIONS", "pagedList": {"items": [{"id": 7}]}},
+        {"title": "live albums", "pagedList": {"items": [{"id": 8}]}},
+    ]}]}
+    assert excluded_album_ids_from_page(
+        page, compilations=True, live=True, appears_on=False
+    ) == {7, 8}
+
+
+def test_misshaped_input_is_safe():
+    for bad in (None, {}, {"rows": None}, {"rows": [None]}, "nope", 42):
+        assert excluded_album_ids_from_page(
+            bad, compilations=True, live=True, appears_on=True
+        ) == set()

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -23,6 +23,7 @@ from tiddl.core.utils.format import format_template
 from tiddl.core.utils.m3u import save_tracks_to_m3u
 from tiddl.core.utils import destination_anchor as anchor
 from tiddl.core.edition_resolver import find_stereo_editions
+from tiddl.core.artist_sections import get_excluded_artist_album_ids
 from tiddl.core.download_policy import SessionTrackLimit
 from tiddl.cli.config import (
     CONFIG,
@@ -1005,6 +1006,16 @@ def download_callback(
                     await _page(True)
                 else:
                     await _page(SINGLES_FILTER == "only")
+                excluded = await asyncio.to_thread(
+                    get_excluded_artist_album_ids,
+                    ctx.obj.api,
+                    artist_id,
+                    compilations=CONFIG.download.exclude_compilations,
+                    live=CONFIG.download.exclude_live_albums,
+                    appears_on=False,  # third-party albums are never in an artist download
+                )
+                if excluded:
+                    ids = [i for i in ids if i not in excluded]
                 return ids
 
             resolved_resources: list[TidalResource] = []
@@ -2008,7 +2019,30 @@ def download_callback(
                         await collect_albums(True)
                     else:
                         await collect_albums(SINGLES_FILTER == "only")
-                
+
+                # Optionally drop compilations / live albums / "appears on"
+                # releases, resolved from the artist page (get_artist_albums
+                # cannot tell them apart). Config-driven; default keeps all.
+                _excluded_ids = await asyncio.to_thread(
+                    get_excluded_artist_album_ids,
+                    ctx.obj.api,
+                    resource.id,
+                    compilations=CONFIG.download.exclude_compilations,
+                    live=CONFIG.download.exclude_live_albums,
+                    appears_on=False,  # third-party albums are never in an artist download
+                )
+                if _excluded_ids:
+                    _before = len(collected_albums)
+                    collected_albums = [
+                        a for a in collected_albums if a.id not in _excluded_ids
+                    ]
+                    _dropped = _before - len(collected_albums)
+                    if _dropped:
+                        ctx.obj.console.print(
+                            f"[dim]Excluded {_dropped} compilation/live/appears-on "
+                            f"release(s) from the artist download.[/]"
+                        )
+
                 # SMART DEDUPLICATION & QUALITY SELECTION
                 # Group albums by Title + Type + Version to find duplicates (e.g. same album in HiRes vs Lossless)
                 # Keep the highest quality version.

--- a/tiddl/cli/config.py
+++ b/tiddl/cli/config.py
@@ -72,6 +72,15 @@ class Config(BaseModel):
         video_download_path: Optional[Path] = None
         singles_filter: ARTIST_SINGLES_FILTER_LITERAL = "none"
         videos_filter: VIDEOS_FILTER_LITERAL = "none"
+        # Artist-download release-type filters. TIDAL's get_artist_albums returns
+        # compilations and live albums typed as plain ALBUM, so these are resolved
+        # from the artist *page* endpoint (the "Compilations" / "Live albums"
+        # sections the web UI shows) and excluded by album id. Both default off
+        # (unchanged behavior). ("Appears On" releases are third-party albums the
+        # artist endpoint never returns, so no toggle is needed for them.)
+        # See core.artist_sections.
+        exclude_compilations: bool = False
+        exclude_live_albums: bool = False
         update_mtime: bool = False
         rewrite_metadata: bool = False
         # Destination-volume identity (see tiddl.core.utils.destination_anchor).

--- a/tiddl/core/artist_sections.py
+++ b/tiddl/core/artist_sections.py
@@ -1,0 +1,109 @@
+"""Resolve an artist's compilation / live / "appears on" releases.
+
+TIDAL's flat ``get_artist_albums`` endpoint returns compilations and live albums
+typed as plain ``ALBUM`` (verified against several artists), so they cannot be
+told apart there. The artist *page* endpoint (``pages/artist``) — the one the web
+UI renders — instead groups releases into titled sections ("Featured Albums",
+"EP & Singles", "Compilations", "Live albums", "Appears On"). This module reads
+those sections so an artist download can optionally exclude a release type by
+album id.
+
+The only field that distinguishes a section is its (English) ``title``; the
+module ``id`` / ``dataApiPath`` are opaque per-artist UUIDs. The page returns
+English titles even for non-English accounts, and we additionally request
+``locale=en_US`` to bias toward them, then match case-insensitively.
+"""
+
+from typing import Any
+
+# Case-insensitive title fragments identifying each excludable section.
+_SECTION_FRAGMENTS = {
+    "compilations": ("compilation",),
+    "live": ("live album",),
+    "appears_on": ("appears on",),
+}
+
+
+def excluded_album_ids_from_page(
+    page: Any,
+    *,
+    compilations: bool,
+    live: bool,
+    appears_on: bool,
+) -> set:
+    """Pure: given the ``pages/artist`` JSON (a dict), return the set of album
+    ids in the requested sections. Unknown/misshaped input yields an empty set
+    so this never blocks a download."""
+    wanted = set()
+    if compilations:
+        wanted.add("compilations")
+    if live:
+        wanted.add("live")
+    if appears_on:
+        wanted.add("appears_on")
+    if not wanted or not isinstance(page, dict):
+        return set()
+
+    excluded: set = set()
+    for row in page.get("rows", []) or []:
+        if not isinstance(row, dict):
+            continue
+        for module in row.get("modules", []) or []:
+            if not isinstance(module, dict):
+                continue
+            title = str(module.get("title", "")).strip().lower()
+            section = next(
+                (
+                    key
+                    for key in wanted
+                    if any(frag in title for frag in _SECTION_FRAGMENTS[key])
+                ),
+                None,
+            )
+            if section is None:
+                continue
+            paged = module.get("pagedList") or {}
+            items = paged.get("items", []) if isinstance(paged, dict) else []
+            for item in items or []:
+                if isinstance(item, dict) and item.get("id") is not None:
+                    excluded.add(item["id"])
+    return excluded
+
+
+def get_excluded_artist_album_ids(
+    api: Any,
+    artist_id: Any,
+    *,
+    compilations: bool,
+    live: bool,
+    appears_on: bool,
+) -> set:
+    """Fetch ``pages/artist`` and return the album ids to exclude for the
+    requested release types. Any failure (network, parsing, missing endpoint)
+    returns an empty set — a page hiccup must never block or crash a download."""
+    if not (compilations or live or appears_on):
+        return set()
+    try:
+        from pydantic import BaseModel
+
+        class _RawPage(BaseModel):
+            class Config:
+                extra = "allow"
+
+        page = api.client.fetch(
+            _RawPage,
+            "pages/artist",
+            {
+                "artistId": artist_id,
+                "countryCode": getattr(api, "country_code", None),
+                "deviceType": "BROWSER",
+                "locale": "en_US",
+            },
+            expire_after=3600,
+        )
+        data = page.dict() if hasattr(page, "dict") else page
+        return excluded_album_ids_from_page(
+            data, compilations=compilations, live=live, appears_on=appears_on
+        )
+    except Exception:
+        return set()


### PR DESCRIPTION
## What's new
Two new `[download]` options — `exclude_compilations` and `exclude_live_albums` (default off) — drop those release types from an artist download (normal **and** stereo).

TIDAL's `get_artist_albums` returns compilations/live as plain `ALBUM`, so they're identified from the **artist page** endpoint (the same "Compilations"/"Live albums" sections the web UI shows) and excluded by album id. New module `core/artist_sections`; fetch failures fail open (never blocks a download); titles matched case-insensitively with `locale=en_US`.

"Appears On" is intentionally not offered — those third-party albums are never returned by the artist-albums endpoint, so they're already never downloaded.

## Validation
Live (Cradle of Filth, 26125): the 4 compilations + 3 live albums are dropped from the 46-release enumeration, matching the TIDAL web UI exactly. Pure section parser unit-tested (8 tests). Full suite: **347 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add configurable exclusion of compilation and live-album releases from artist downloads while preserving existing default behavior.

New Features:
- Add optional artist-download filters for excluding compilation and live-album releases, disabled by default.

Enhancements:
- Resolve artist release categories from TIDAL artist-page sections and fail open when the page cannot be fetched or parsed.

Documentation:
- Document the new download configuration options and their default behavior.

Tests:
- Add unit coverage for section parsing, case-insensitive matching, unions, and malformed input handling.