### PR TITLE
chore(release): prepare v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,6 @@ This tool respects TIDAL's ToS and copyright laws. Users are responsible for ens
 
 ---
 
-**Version:** 1.3.2
+**Version:** 1.4.0
 **Status:** Production Ready ✅
 **Last Updated:** August 19, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.3.2"
+version = "1.4.0"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump 1.3.2 → 1.4.0 for the artist compilation/live-album exclusion filter (#29). Bumps pyproject + README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump the project release version from 1.3.2 to 1.4.0 in package metadata and user-facing documentation.