### PR TITLE
feat(download): --exclude-compilations / --exclude-live-albums CLI flags

### DIFF
--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -679,6 +679,20 @@ def download_callback(
             help="Set file modified-time to the release date (overrides config).",
         ),
     ] = None,
+    EXCLUDE_COMPILATIONS: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--exclude-compilations/--no-exclude-compilations",
+            help="On artist downloads, skip the artist's compilations (overrides config).",
+        ),
+    ] = None,
+    EXCLUDE_LIVE_ALBUMS: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--exclude-live-albums/--no-exclude-live-albums",
+            help="On artist downloads, skip the artist's live albums (overrides config).",
+        ),
+    ] = None,
     MAX_TRACKS: Annotated[
         Optional[int],
         typer.Option(
@@ -769,6 +783,10 @@ def download_callback(
         CONFIG.download.requests_per_minute = REQUESTS_PER_MINUTE
     if UPDATE_MTIME is not None:
         CONFIG.download.update_mtime = UPDATE_MTIME
+    if EXCLUDE_COMPILATIONS is not None:
+        CONFIG.download.exclude_compilations = EXCLUDE_COMPILATIONS
+    if EXCLUDE_LIVE_ALBUMS is not None:
+        CONFIG.download.exclude_live_albums = EXCLUDE_LIVE_ALBUMS
     if MAX_TRACKS is not None:
         CONFIG.download.max_tracks_per_session = MAX_TRACKS
     if SAVE_M3U is not None:


### PR DESCRIPTION
CLI-flag equivalents of the `exclude_compilations` / `exclude_live_albums` config options (#29). Tri-state (`--flag/--no-flag`, default = use config), applied to CONFIG at the callback top like the other download overrides.

Live-validated: a stereo artist `--dry-run --exclude-compilations --exclude-live-albums` drops the same 7 compilation/live releases (46 → 39) as the config path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Add tri-state CLI flags to include or exclude artist compilations and live albums during downloads, with configuration fallback by default.