### PR TITLE
chore(release): prepare v1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,6 @@ This tool respects TIDAL's ToS and copyright laws. Users are responsible for ens
 
 ---
 
-**Version:** 1.4.0
+**Version:** 1.4.1
 **Status:** Production Ready ✅
 **Last Updated:** August 19, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.4.0"
+version = "1.4.1"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump 1.4.0 → 1.4.1 for the `--exclude-compilations` / `--exclude-live-albums` CLI flags (#31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the 1.4.1 release across project metadata and user-facing documentation.

Documentation:
- Update the README to reflect the 1.4.1 release.

Chores:
- Bump the project version from 1.4.0 to 1.4.1.