### PR TITLE
docs: stereo resolver, quality policies, artist release-type filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,58 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 - Added a bilingual destination-safety guide and linked user-facing setup,
   configuration, second-machine adoption and recovery instructions from the
   README, configuration reference, usage guide and Spanish tutorial.
+- Documented the stereo edition resolver, quality policies, `tiddl info
+  editions` and the artist compilation/live-album filter across the README,
+  configuration reference and command reference.
+
+---
+
+## [1.4.1] - 2026-08-20
+
+### Added
+
+- `--exclude-compilations` / `--exclude-live-albums` CLI flags (tri-state,
+  override the config equivalents per run).
+
+## [1.4.0] - 2026-08-20
+
+### Added
+
+- Exclude **compilations** and **live albums** from artist downloads.
+  TIDAL types both as plain albums, so they are identified from the artist page
+  (the same "Compilations" / "Live albums" sections the app shows) via the new
+  `core/artist_sections` module and skipped by album id. Config:
+  `[download] exclude_compilations` / `exclude_live_albums` (default off).
+
+## [1.3.2] - 2026-08-19
+
+### Performance
+
+- Cache catalog reads across an artist stereo run: resolving a whole artist went
+  from minutes to seconds with identical results (per-run `CatalogReadCache`).
+
+## [1.3.1] - 2026-08-19
+
+### Added
+
+- `--audio-mode stereo` now works on **artist** URLs — expands the artist into
+  its releases (honouring `--singles`) and resolves each album to its stereo
+  edition; an album with no stereo edition keeps its original.
+
+## [1.3.0] - 2026-08-19
+
+### Added
+
+- **Stereo Edition Resolver + Quality Policies.** Given an Atmos-only album URL,
+  find and use a separately-published stereo edition at High/MAX, TIDAL-catalog
+  only. New `--audio-mode auto|stereo`, `--edition-match ask|best`,
+  `--quality-policy flexible|strict`, and the read-only `tiddl info editions`
+  diagnostic. New modules `edition_resolver`, `stream_policy`, `download_policy`.
+
+### Fixed
+
+- A cooperative safety stop (e.g. run-wide 401) now exits the CLI non-zero.
+- Strict `normal` correctly maps to TIDAL `HIGH` (not `LOSSLESS`).
 
 ---
 

--- a/COMPLETE_COMMAND_REFERENCE.md
+++ b/COMPLETE_COMMAND_REFERENCE.md
@@ -126,9 +126,28 @@ tiddl download --albums url https://tidal.com/playlist/...   # full album of eve
 tiddl download --artists url https://tidal.com/playlist/...  # full discography of every credited artist
 tiddl download --tracks url https://tidal.com/playlist/...   # each track standalone
 
+# Stereo edition resolver: use the separately-published stereo edition of an
+# Atmos-only album (or, for an artist URL, every album). Playlists/mixes/single
+# tracks are left unchanged.
+tiddl download --audio-mode stereo --edition-match best url https://tidal.com/album/549984784
+tiddl download --audio-mode stereo --edition-match ask  url https://tidal.com/artist/5237820
+tiddl download --audio-mode stereo --dry-run url https://tidal.com/album/...   # preview, no download
+#   --audio-mode  auto (default) | stereo
+#   --edition-match  best (auto-accept) | ask (prompt on a changed tracklist)
+
+# Quality policy: flexible (ceiling, default) vs strict (exact tier only)
+tiddl download -q high --quality-policy strict url https://...
+
+# Artist release-type filter (artist downloads): skip compilations / live albums
+tiddl download --exclude-compilations --exclude-live-albums url https://tidal.com/artist/5237820
+#   also --no-exclude-compilations / --no-exclude-live-albums to override config
+
 # Debug (global flag, goes before the subcommand)
 tiddl --debug download url https://...
 ```
+
+> **Stereo editions** are matched against the TIDAL catalog only (no MusicBrainz/ISRC).
+> `tiddl info editions -q high|max <ALBUM_URL>` lists an album's stereo editions without downloading.
 
 ---
 
@@ -206,6 +225,17 @@ tiddl info url https://tidal.com/album/497662013
 - Available bitrate
 - Release date
 - Availability
+
+### `tiddl info editions` — list an album's stereo editions
+
+Read-only diagnostic for the stereo edition resolver: given an Atmos-capable
+album, it searches the artist catalog for matching **stereo** editions and shows
+the candidates (score, track overlap, tier) without downloading anything.
+
+```bash
+tiddl info editions -q max  https://tidal.com/album/549984784
+tiddl info editions -q high https://tidal.com/album/549984784
+```
 
 ---
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -162,6 +162,17 @@ macOS, second-machine adoption, recovery and troubleshooting instructions.
 - **Default**: none
 - How to handle music videos
 
+### `exclude_compilations`
+- **Type**: boolean
+- **Default**: false
+- When downloading a whole **artist**, skip the artist's compilations. TIDAL lists them as ordinary albums, so they are identified from the artist page (the same "Compilations" section the TIDAL app shows) and skipped by album id. CLI override: `--exclude-compilations` / `--no-exclude-compilations`.
+
+### `exclude_live_albums`
+- **Type**: boolean
+- **Default**: false
+- Same as above for the artist's **live albums** ("Live albums" section). CLI override: `--exclude-live-albums` / `--no-exclude-live-albums`.
+- (Note: "Appears On" third-party albums are never part of an artist download, so no option is needed for them.)
+
 ### `max_tracks_per_session`
 - **Type**: integer
 - **Default**: 0 (no limit)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ At scale — tens of thousands of albums — this means your library reflects th
 - 🎬 **Music Videos** - Download with full metadata
 - 📝 **Complete Metadata** - Artist, album, cover, lyrics, credits
 - 🌍 **Unicode Support** - CJK, Arabic, Vietnamese, Devanagari
+- 🎚️ **Stereo Edition Resolver** - Give an Atmos-only album (or artist) URL and get the separately-published **stereo** edition at High/MAX instead — TIDAL-catalog-only, no MusicBrainz/ISRC
+- 🎯 **Quality Policies** - `flexible` (ceiling) vs `strict` (exact tier) delivery, independent of the audio edition
+- 🚫 **Artist release-type filter** - Skip **compilations** and **live albums** when downloading a whole artist
 - 💾 **File Integrity** - Hash verification & corruption detection
 - 🔒 **Destination-Volume Identity** (opt-in) - Refuse to write if a configured NAS/USB destination is unmounted and silently falls back to a same-named local folder — see the **[Destination Safety Guide (EN/ES)](DESTINATION_SAFETY.md)**
 - ⚡ **Async Downloads** - Concurrent multi-threaded downloads
@@ -209,6 +212,50 @@ tiddl download url --template "{album.artist}/{album.title}/{item.title}" https:
 # Debug mode (global flag — goes before the subcommand)
 tiddl --debug download url https://...
 ```
+
+### Stereo editions & quality control
+
+Some releases exist on TIDAL only in Dolby Atmos. `--audio-mode stereo` finds a
+separately-published **stereo** edition of that album (or, for an artist URL, of
+every album in the discography) and uses it instead — matched against the TIDAL
+catalog only (no MusicBrainz/ISRC). Playlists, mixes and single tracks are left
+unchanged. Combine it with a quality policy:
+
+```bash
+# Resolve an Atmos-only album to its stereo edition (auto-accept the best match)
+tiddl download -q max --audio-mode stereo --edition-match best url https://tidal.com/album/549984784
+
+# Preview the plan without downloading (also the GUI's "Check available versions")
+tiddl download -q max --audio-mode stereo --dry-run url https://tidal.com/album/549984784
+
+# Whole artist, stereo editions, ask before substituting a changed tracklist
+tiddl download -q max --audio-mode stereo --edition-match ask url https://tidal.com/artist/5237820
+
+# Quality policy: flexible = use the selected quality as a ceiling (default);
+#                 strict   = deliver only the exact selected tier
+tiddl download -q high --quality-policy strict url https://tidal.com/album/...
+
+# List the stereo editions of an album without downloading
+tiddl info editions -q max https://tidal.com/album/549984784
+```
+
+`--edition-match best` auto-accepts the top match; `ask` prompts when the stereo
+tracklist differs. See the config equivalents (`audio_mode` is CLI-only; the rest
+have config keys) in [CONFIG.md](CONFIG.md).
+
+### Skip compilations / live albums (artist downloads)
+
+TIDAL lists compilations and live albums as ordinary albums, so tiddl reads the
+artist **page** (the same "Compilations" / "Live albums" sections the TIDAL app
+shows) to identify and skip them:
+
+```bash
+tiddl download --audio-mode auto --exclude-compilations --exclude-live-albums url https://tidal.com/artist/5237820
+```
+
+Or set them once in `config.toml` (`[download] exclude_compilations` /
+`exclude_live_albums`). Both default off. ("Appears On" third-party albums are
+never part of an artist download to begin with.)
 
 See [USAGE.md](USAGE.md) for complete examples.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -76,6 +76,50 @@ Supports all options of `download url`.
 
 ---
 
+## 🎚️ Stereo Editions & Quality Control
+
+Some albums are on TIDAL only in Dolby Atmos. `--audio-mode stereo` finds the
+separately-published **stereo** edition and uses it instead — matched against the
+TIDAL catalog only (no MusicBrainz/ISRC). For an artist URL it resolves every
+album; playlists, mixes and single tracks are left unchanged.
+
+```bash
+# Album → its stereo edition (auto-accept the best match)
+tiddl download -q max --audio-mode stereo --edition-match best url https://tidal.com/album/549984784
+
+# Preview only (no download) — this is the GUI's "Check available versions"
+tiddl download -q max --audio-mode stereo --dry-run url https://tidal.com/album/549984784
+
+# Whole artist in stereo; ask before substituting a changed tracklist
+tiddl download -q max --audio-mode stereo --edition-match ask url https://tidal.com/artist/5237820
+
+# List an album's stereo editions without downloading
+tiddl info editions -q max https://tidal.com/album/549984784
+```
+
+**Quality policy** is independent of the audio edition:
+
+```bash
+tiddl download -q high --quality-policy flexible url https://...   # ceiling (default)
+tiddl download -q high --quality-policy strict   url https://...   # exact tier only
+```
+
+## 🚫 Skip Compilations / Live Albums (Artist)
+
+When downloading a whole artist, skip its compilations and/or live albums.
+TIDAL lists them as ordinary albums, so tiddl reads the artist page (the same
+"Compilations" / "Live albums" sections the app shows) to identify them:
+
+```bash
+tiddl download --exclude-compilations --exclude-live-albums url https://tidal.com/artist/5237820
+```
+
+Or set `[download] exclude_compilations` / `exclude_live_albums` in `config.toml`
+(both default off). "Appears On" third-party albums are never part of an artist
+download to begin with.
+
+---
+
 ## 🔒 Protecting NAS, USB and Network Destinations
 
 Destination-volume identity prevents tiddl from publishing files to a


### PR DESCRIPTION
Documents the features shipped in v1.3.0–v1.4.1 across README, CONFIG.md, COMPLETE_COMMAND_REFERENCE.md, USAGE.md and CHANGELOG.md. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document stereo edition selection, quality controls, and artist compilation and live-album filtering across the user-facing guides and changelog.

Enhancements:
- Document stereo edition resolution, quality policies, and artist release-type filtering for downloads.
- Document the `tiddl info editions` diagnostic command and related download options across the user guides.

Documentation:
- Update the README, configuration reference, command reference, usage guide, and changelog with features released in versions 1.3.0 through 1.4.1.