### PR TITLE
chore(release): prepare v1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,6 @@ This tool respects TIDAL's ToS and copyright laws. Users are responsible for ens
 
 ---
 
-**Version:** 1.4.1
+**Version:** 1.4.2
 **Status:** Production Ready ✅
 **Last Updated:** August 19, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.4.1"
+version = "1.4.2"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump 1.4.1 → 1.4.2 for the per-album resilience fix (#34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the project for the 1.4.2 release.

Build:
- Bump the package version to 1.4.2.

Documentation:
- Update the documented project version to 1.4.2.