### PR TITLE
v1.5.0 — giant-run hardening + quality cascade

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,20 +6,12 @@ Fork de tiddl — descargador de música TIDAL production-ready.
 - Python 3.10+, Pydantic v1
 - Config path: controlado por `TIDDL_PATH` (env var)
 
-## Deploy en NAS
-- Contenedor: `tiddl` en 192.168.68.55
-- Ruta: `/volume1/docker/tiddl/`
-- Config: `/volume1/docker/tiddl/config/`
-- Descarga a: `/volume1/SERVER/Music`
-- Scripts: `run_artists.sh` con `artist.txt` y `artist2.txt`
-- Logs: `artist_run.log`, `artist2_run.log`
-
-## Dockerfile en NAS
-```
-FROM python:3.12-slim + ffmpeg
-TIDDL_PATH=/config
-CMD tail -f /dev/null  (se controla con run_artists.sh externamente)
-```
+## Consumidores del motor
+El motor ya **no** se despliega en el NAS. Vive en dos sitios y toda mejora de
+resiliencia debe pensarse para ambos:
+- **CLI**: `tiddl-elvigilante` instalado (system `tiddl.exe`), uso directo por terminal.
+- **GUI**: `tiddl-elvigilante-gui` lo **bundlea** (single-binary, in-process) vía el
+  pin de `requirements.txt`.
 
 ## Notas de desarrollo
 - Fork de tiddl con optimizaciones de Pydantic v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-08-23
+
 ### Added
 
 - **Fidelity quality cascade with Dolby Atmos as a rung.** `-q` now names the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ### Added
 
+- **Fidelity quality cascade with Dolby Atmos as a rung.** `-q` now names the
+  STARTING rung of a fixed ladder `max > high > atmos > normal > low`; each track
+  is taken at the first rung from there DOWN that it actually offers. This fixes
+  a real trap: TIDAL serves an AAC (`.m4a`) stream for an Atmos-flagged track at
+  the LOSSLESS tier but the real FLAC only at HI_RES, so a plain `-q high` run
+  used to yield degraded AAC even when a hi-res FLAC existed. Now `-q max` prefers
+  the FLAC (an Atmos track's only FLAC is its hi-res `max`); `-q high` falls to
+  Atmos only when no FLAC exists; `-q atmos` takes Dolby Atmos first. Non-Atmos
+  tracks attempt the same tiers as before. The "Dolby Atmos" download label now
+  reflects the stream actually delivered, so a track's FLAC is no longer
+  mislabelled Atmos. New pure module `tiddl/core/quality_cascade.py`.
 - `--resume`: skip resources already fully processed in a prior run of the same
   job (same links + options) **before any API call**, so a run interrupted by a
   rate-limit stop or Ctrl-C continues cheaply instead of re-enumerating every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,15 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
   is taken at the first rung from there DOWN that it actually offers. This fixes
   a real trap: TIDAL serves an AAC (`.m4a`) stream for an Atmos-flagged track at
   the LOSSLESS tier but the real FLAC only at HI_RES, so a plain `-q high` run
-  used to yield degraded AAC even when a hi-res FLAC existed. Now `-q max` prefers
-  the FLAC (an Atmos track's only FLAC is its hi-res `max`); `-q high` falls to
-  Atmos only when no FLAC exists; `-q atmos` takes Dolby Atmos first. Non-Atmos
-  tracks attempt the same tiers as before. The "Dolby Atmos" download label now
+  used to yield degraded AAC even when a hi-res FLAC existed. **FLAC is preferred
+  over Atmos:** from a FLAC start (`high`/`max`) the cascade tries BOTH FLAC rungs
+  before Atmos, so `-q high` on an Atmos track (which has no 16-bit FLAC) climbs
+  to the 24-bit `max` FLAC instead of dropping to Atmos — most users want any FLAC
+  over Atmos. `-q atmos` takes Dolby Atmos first for those who want it. (Because a
+  FLAC start may now need the HiRes client for an Atmos track's `max` FLAC,
+  `hires_client="auto"` uses the HiRes client for `-q high` too; the run-wide 429
+  breaker keeps that safe.) Non-Atmos tracks resolve to the same tier as before.
+  The "Dolby Atmos" download label now
   reflects the stream actually delivered, so a track's FLAC is no longer
   mislabelled Atmos. New pure module `tiddl/core/quality_cascade.py`.
 - `--resume`: skip resources already fully processed in a prior run of the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+### Added
+
+- `--resume`: skip resources already fully processed in a prior run of the same
+  job (same links + options) **before any API call**, so a run interrupted by a
+  rate-limit stop or Ctrl-C continues cheaply instead of re-enumerating every
+  artist. Opt-in and off by default; a resource is recorded only on a clean,
+  error-free completion, and the checkpoint is trusted over the filesystem (run
+  without `--resume` for a full re-verify). Checkpoint at `TIDDL_PATH/resume/`.
+
+### Reliability
+
+- **Run-wide 429 circuit breaker.** A giant run that TIDAL throttles repeatedly
+  now stops cleanly — with a "wait and resume" / "re-login" message and a
+  non-zero exit — once 429s cross a run-wide threshold, or when the account is
+  flagged (refresh-blocked 401), instead of thousands of tasks retrying
+  independently until a soft rate-limit escalates into a hard account block. The
+  breaker is shared by the main and fallback clients, and a stopping run now
+  abandons its retry backoff at once. Benefits the CLI and the GUI's embedded
+  engine alike.
+- **Bounded memory on huge expanded runs.** A playlist expanded into every
+  credited artist no longer creates one asyncio task per resource up front; a
+  fixed worker pool keeps at most `artist_concurrency` tasks alive, so peak
+  memory no longer scales with the resource count (previously an out-of-memory
+  hard-kill on very large runs).
+
 ### Documentation
 
 - Added a bilingual destination-safety guide and linked user-facing setup,

--- a/COMPLETE_COMMAND_REFERENCE.md
+++ b/COMPLETE_COMMAND_REFERENCE.md
@@ -89,11 +89,17 @@ tiddl download url https://tidal.com/mix/mixed123xyz
 #### Options
 
 ```bash
-# Audio quality
-tiddl download url --track-quality max https://...     # 24-bit, 192kHz FLAC
-tiddl download url --track-quality high https://...    # 16-bit, 44.1kHz FLAC
+# Audio quality — -q is the STARTING rung of a fidelity cascade, and each track
+# is taken at the first rung from there DOWN that it offers:
+#     max  >  high  >  atmos  >  normal  >  low
+tiddl download url --track-quality max https://...     # 24-bit FLAC (hi-res)
+tiddl download url --track-quality high https://...    # 16-bit FLAC (CD)
+tiddl download url --track-quality atmos https://...   # Dolby Atmos first
 tiddl download url --track-quality normal https://...  # 320kbps AAC
 tiddl download url --track-quality low https://...     # 96kbps AAC
+# Atmos note: on a Dolby-Atmos track TIDAL serves AAC at the LOSSLESS tier and
+# the FLAC only at HI_RES, so an Atmos track's only FLAC is its `max` rung.
+# Start at max to PREFER FLAC over Atmos; -q high falls to Atmos (no 16-bit FLAC).
 
 # Video quality
 tiddl download url --video-quality fhd https://...     # 1080p

--- a/COMPLETE_COMMAND_REFERENCE.md
+++ b/COMPLETE_COMMAND_REFERENCE.md
@@ -142,6 +142,15 @@ tiddl download -q high --quality-policy strict url https://...
 tiddl download --exclude-compilations --exclude-live-albums url https://tidal.com/artist/5237820
 #   also --no-exclude-compilations / --no-exclude-live-albums to override config
 
+# Resume a giant run cheaply: skip resources already fully done in a prior run of
+# the SAME job (same links + options), before any API call — e.g. after a
+# rate-limit safety-stop or Ctrl-C. Opt-in; trusts its checkpoint over the disk.
+tiddl download --resume --artists url https://tidal.com/playlist/...
+#   run WITHOUT --resume for a full re-verify; checkpoint lives in TIDDL_PATH/resume/
+
+# Chunk a huge list instead: stop after N tracks, re-run to continue (skip_existing)
+tiddl download --max-tracks 500 --artists url https://tidal.com/playlist/...
+
 # Debug (global flag, goes before the subcommand)
 tiddl --debug download url https://...
 ```

--- a/COMPLETE_COMMAND_REFERENCE.md
+++ b/COMPLETE_COMMAND_REFERENCE.md
@@ -97,9 +97,11 @@ tiddl download url --track-quality high https://...    # 16-bit FLAC (CD)
 tiddl download url --track-quality atmos https://...   # Dolby Atmos first
 tiddl download url --track-quality normal https://...  # 320kbps AAC
 tiddl download url --track-quality low https://...     # 96kbps AAC
-# Atmos note: on a Dolby-Atmos track TIDAL serves AAC at the LOSSLESS tier and
-# the FLAC only at HI_RES, so an Atmos track's only FLAC is its `max` rung.
-# Start at max to PREFER FLAC over Atmos; -q high falls to Atmos (no 16-bit FLAC).
+# FLAC is preferred over Atmos: from a FLAC start (high/max) BOTH FLAC rungs are
+# tried before Atmos. On a Dolby-Atmos track TIDAL serves AAC at the LOSSLESS
+# tier and the FLAC only at HI_RES, so an Atmos track's only FLAC is `max`;
+# -q high therefore CLIMBS to the 24-bit max FLAC instead of dropping to Atmos.
+# Use -q atmos to take Dolby Atmos first.
 
 # Video quality
 tiddl download url --video-quality fhd https://...     # 1080p

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.4.2"
+version = "1.5.0"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_api_retry.py
+++ b/tests/test_api_retry.py
@@ -16,6 +16,19 @@ from requests.exceptions import HTTPError
 from tiddl.core.api.api import TidalAPI
 
 
+@pytest.fixture(autouse=True)
+def _reset_run_state():
+    """The 429 circuit breaker and the cooperative-cancel flag are process-wide,
+    so reset them around every test to keep strike counts and stop state from
+    leaking between cases."""
+    from tiddl.core import cancel, ratelimit
+    cancel.clear()
+    ratelimit.guard().reset(strike_limit=ratelimit.DEFAULT_STRIKE_LIMIT)
+    yield
+    cancel.clear()
+    ratelimit.guard().reset(strike_limit=ratelimit.DEFAULT_STRIKE_LIMIT)
+
+
 class _FakeClient:
     """A client whose fetch() replays a scripted sequence (values or raises)."""
 

--- a/tests/test_bounded_dispatch.py
+++ b/tests/test_bounded_dispatch.py
@@ -1,0 +1,103 @@
+"""Coverage for the bounded worker pool that dispatches expanded-run resources.
+
+The pool exists so a huge expanded run (a playlist blown up into hundreds of
+thousands of artist resources) never creates one asyncio Task per resource up
+front — the memory blow-up that hard-killed the process. These tests assert the
+two invariants that matter: every item is handled exactly once, and no more than
+``concurrency`` items are ever in flight, regardless of list size.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tiddl.cli.commands.download import _bounded_dispatch
+
+
+def test_processes_all_items_exactly_once():
+    seen: list = []
+
+    async def handler(item, index):
+        seen.append((index, item))
+
+    asyncio.run(_bounded_dispatch(list("abcde"), handler, concurrency=2))
+
+    assert sorted(i for i, _ in seen) == [1, 2, 3, 4, 5]  # 1-based indices
+    assert sorted(x for _, x in seen) == list("abcde")     # every item once
+
+
+def test_respects_concurrency_cap():
+    active = 0
+    peak = 0
+
+    async def handler(item, index):
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        for _ in range(3):        # yield repeatedly so overlap is possible
+            await asyncio.sleep(0)
+        active -= 1
+
+    asyncio.run(_bounded_dispatch(list(range(20)), handler, concurrency=3))
+
+    assert peak <= 3     # hard invariant: never more than `concurrency` in flight
+    assert peak >= 2     # and they really do overlap (not serialized)
+
+
+def test_more_workers_than_items_is_fine():
+    seen: list = []
+
+    async def handler(item, index):
+        seen.append(item)
+
+    asyncio.run(_bounded_dispatch([1, 2], handler, concurrency=10))
+
+    assert sorted(seen) == [1, 2]
+
+
+def test_zero_concurrency_floors_to_one():
+    seen: list = []
+
+    async def handler(item, index):
+        seen.append(item)
+
+    asyncio.run(_bounded_dispatch([1, 2, 3], handler, concurrency=0))
+
+    assert sorted(seen) == [1, 2, 3]
+
+
+def test_empty_items_is_a_noop():
+    async def handler(item, index):  # pragma: no cover - must never be called
+        raise AssertionError("handler called on empty input")
+
+    asyncio.run(_bounded_dispatch([], handler, concurrency=3))
+
+
+def test_one_failing_item_does_not_stop_others():
+    seen: list = []
+
+    async def handler(item, index):
+        if item == "boom":
+            raise ValueError("boom")
+        seen.append(item)
+
+    # A per-item error is swallowed (logged) so the rest still run.
+    asyncio.run(_bounded_dispatch(["a", "boom", "b", "c"], handler, concurrency=1))
+
+    assert sorted(seen) == ["a", "b", "c"]
+
+
+def test_keyboardinterrupt_tears_down_and_propagates():
+    processed: list = []
+
+    async def handler(item, index):
+        if item == 2:
+            raise KeyboardInterrupt
+        processed.append(item)
+        await asyncio.sleep(0)
+
+    with pytest.raises(KeyboardInterrupt):
+        asyncio.run(_bounded_dispatch([1, 2, 3, 4], handler, concurrency=1))
+
+    assert processed == [1]  # stopped at the interrupt, did not finish the list

--- a/tests/test_quality_cascade.py
+++ b/tests/test_quality_cascade.py
@@ -41,9 +41,17 @@ def test_start_max_on_atmos_track_gets_flac_first():
     assert cascade_api_qualities("max", ATMOS_FULL)[0] == "HI_RES_LOSSLESS"
 
 
-def test_start_high_on_atmos_track_falls_to_atmos():
-    # "-q high" on an Atmos track: no 16-bit FLAC exists → cascade to Atmos.
-    assert resolve_cascade("high", ATMOS_FULL) == ["atmos", "normal", "low"]
+def test_start_high_on_atmos_track_climbs_to_max_flac_before_atmos():
+    # "-q high" on an Atmos track: no 16-bit FLAC exists, but FLAC is preferred
+    # over Atmos, so it climbs to `max` (24-bit FLAC) BEFORE dropping to Atmos.
+    assert resolve_cascade("high", ATMOS_FULL) == ["max", "atmos", "normal", "low"]
+    assert cascade_api_qualities("high", ATMOS_FULL)[0] == "HI_RES_LOSSLESS"
+
+
+def test_flac_start_tries_both_flac_rungs_before_atmos():
+    # The whole point: from either FLAC rung, BOTH FLAC rungs precede Atmos.
+    assert resolve_cascade("high", ATMOS_FULL)[:1] == ["max"]      # high→max (FLAC)
+    assert "atmos" not in resolve_cascade("high", ATMOS_FULL)[:1]  # FLAC before atmos
 
 
 def test_start_atmos_prefers_atmos_first():
@@ -63,7 +71,9 @@ def test_start_max_normal_track():
 
 
 def test_start_high_normal_track():
-    assert resolve_cascade("high", HIRES) == ["high", "normal", "low"]
+    # A normal track offers its 16-bit FLAC, so `high` is taken first; `max` is
+    # only a listed fallback (never reached, since high succeeds), Atmos absent.
+    assert resolve_cascade("high", HIRES) == ["high", "max", "normal", "low"]
 
 
 def test_lossless_only_track():

--- a/tests/test_quality_cascade.py
+++ b/tests/test_quality_cascade.py
@@ -1,0 +1,98 @@
+"""Coverage for the fidelity-ordered quality cascade (tiddl.core.quality_cascade)."""
+from __future__ import annotations
+
+from tiddl.core.quality_cascade import (
+    QUALITY_LADDER,
+    available_rungs,
+    cascade_api_qualities,
+    resolve_cascade,
+)
+
+# Tag sets seen in the wild.
+HIRES = ["LOSSLESS", "HIRES_LOSSLESS"]                       # normal hi-res track
+LOSSLESS_ONLY = ["LOSSLESS"]                                 # CD-quality only
+ATMOS_FULL = ["LOSSLESS", "HIRES_LOSSLESS", "DOLBY_ATMOS"]   # e.g. Bryan Adams - Room Service
+AAC_ONLY: list = []                                          # no FLAC tags
+
+
+def test_ladder_is_fidelity_ordered():
+    assert QUALITY_LADDER == ["max", "high", "atmos", "normal", "low"]
+
+
+def test_available_rungs_normal_hires_track():
+    a = available_rungs(HIRES)
+    assert a == {"max": True, "high": True, "atmos": False, "normal": True, "low": True}
+
+
+def test_available_rungs_atmos_track_hides_high():
+    # An Atmos track's LOSSLESS tier is Atmos, not a 16-bit FLAC, so `high` is NOT
+    # offered — its only FLAC is `max`.
+    a = available_rungs(ATMOS_FULL)
+    assert a["max"] is True
+    assert a["high"] is False
+    assert a["atmos"] is True
+
+
+# --- the user's own scenarios -------------------------------------------------
+
+def test_start_max_on_atmos_track_gets_flac_first():
+    # "-q max" on a dual-format Atmos track → hi-res FLAC before Atmos.
+    assert resolve_cascade("max", ATMOS_FULL) == ["max", "atmos", "normal", "low"]
+    assert cascade_api_qualities("max", ATMOS_FULL)[0] == "HI_RES_LOSSLESS"
+
+
+def test_start_high_on_atmos_track_falls_to_atmos():
+    # "-q high" on an Atmos track: no 16-bit FLAC exists → cascade to Atmos.
+    assert resolve_cascade("high", ATMOS_FULL) == ["atmos", "normal", "low"]
+
+
+def test_start_atmos_prefers_atmos_first():
+    # "-q atmos" for someone who collects Atmos.
+    assert resolve_cascade("atmos", ATMOS_FULL) == ["atmos", "normal", "low"]
+
+
+def test_atmos_start_on_non_atmos_track_skips_atmos_rung():
+    # A non-Atmos track simply has no atmos rung; the cascade continues down.
+    assert resolve_cascade("atmos", HIRES) == ["normal", "low"]
+
+
+# --- ordinary tracks ----------------------------------------------------------
+
+def test_start_max_normal_track():
+    assert resolve_cascade("max", HIRES) == ["max", "high", "normal", "low"]
+
+
+def test_start_high_normal_track():
+    assert resolve_cascade("high", HIRES) == ["high", "normal", "low"]
+
+
+def test_lossless_only_track():
+    assert resolve_cascade("max", LOSSLESS_ONLY) == ["high", "normal", "low"]  # no max
+    assert resolve_cascade("high", LOSSLESS_ONLY) == ["high", "normal", "low"]
+
+
+def test_aac_only_track():
+    assert resolve_cascade("max", AAC_ONLY) == ["normal", "low"]
+
+
+def test_start_low():
+    assert resolve_cascade("low", ATMOS_FULL) == ["low"]
+
+
+def test_start_normal():
+    assert resolve_cascade("normal", HIRES) == ["normal", "low"]
+
+
+# --- api mapping & robustness -------------------------------------------------
+
+def test_cascade_api_qualities_dedups():
+    # `high` and `atmos` both map to LOSSLESS; a per-track cascade never has both,
+    # but the de-dup guard keeps consecutive duplicates from ever appearing.
+    apis = cascade_api_qualities("max", ATMOS_FULL)
+    assert apis == ["HI_RES_LOSSLESS", "LOSSLESS", "HIGH", "LOW"]
+    # no consecutive repeats
+    assert all(apis[i] != apis[i + 1] for i in range(len(apis) - 1))
+
+
+def test_unknown_start_treated_as_top():
+    assert resolve_cascade("bogus", HIRES) == resolve_cascade("max", HIRES)

--- a/tests/test_ratelimit_breaker.py
+++ b/tests/test_ratelimit_breaker.py
@@ -1,0 +1,170 @@
+"""Run-wide 429 circuit breaker + cooperative-stop coverage.
+
+The guard (``tiddl.core.ratelimit``) and the cancel flag (``tiddl.core.cancel``)
+are process-wide, so every test resets them to the default budget. ``time.sleep``
+is patched so the backoff waits don't slow the suite.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from requests import Response
+from requests.exceptions import HTTPError
+
+from tiddl.core import cancel, ratelimit
+from tiddl.core.api.api import TidalAPI
+
+
+@pytest.fixture(autouse=True)
+def _reset_and_no_sleep(monkeypatch):
+    cancel.clear()
+    ratelimit.guard().reset(strike_limit=ratelimit.DEFAULT_STRIKE_LIMIT)
+    monkeypatch.setattr("tiddl.core.api.api.time.sleep", lambda *a, **k: None)
+    monkeypatch.setattr("tiddl.core.api.api.random.uniform", lambda *a, **k: 0.0)
+    yield
+    cancel.clear()
+    ratelimit.guard().reset(strike_limit=ratelimit.DEFAULT_STRIKE_LIMIT)
+
+
+def _http_error(status: int, retry_after=None, sub_status=None) -> HTTPError:
+    resp = Response()
+    resp.status_code = status
+    body = {"subStatus": sub_status} if sub_status is not None else {}
+    resp._content = json.dumps(body).encode()
+    resp.headers["Content-Type"] = "application/json"
+    if retry_after is not None:
+        resp.headers["Retry-After"] = str(retry_after)
+    return HTTPError(response=resp)
+
+
+class _Always429:
+    def __init__(self, refresh_blocked: bool = False):
+        self.calls = 0
+        self._refresh_blocked = refresh_blocked
+
+    def fetch(self, *a, **k):
+        self.calls += 1
+        raise _http_error(429, retry_after=0)
+
+
+# --------------------------------------------------------------------------
+# Guard unit
+# --------------------------------------------------------------------------
+
+def test_guard_trips_exactly_once_at_limit():
+    g = ratelimit.RateLimitGuard(strike_limit=3)
+    assert g.note_rate_limited() is False  # strike 1
+    assert g.note_rate_limited() is False  # strike 2
+    assert g.note_rate_limited() is True   # strike 3 -> trips
+    assert g.note_rate_limited() is False  # already tripped, never re-fires
+    assert g.tripped is True
+    assert g.strikes == 4
+
+
+def test_guard_reset_rearms():
+    g = ratelimit.RateLimitGuard(strike_limit=2)
+    g.note_rate_limited()
+    assert g.note_rate_limited() is True
+    g.reset()
+    assert g.strikes == 0
+    assert g.tripped is False
+    assert g.note_rate_limited() is False  # counts from zero again
+
+
+# --------------------------------------------------------------------------
+# _fetch_with_retry integration
+# --------------------------------------------------------------------------
+
+def test_sustained_429_trips_cooperative_stop():
+    # A low budget so the breaker trips within one request's retry schedule.
+    ratelimit.guard().reset(strike_limit=3)
+    client = _Always429()
+    api = TidalAPI(client, "1", "US")
+
+    with pytest.raises(HTTPError):
+        api._fetch_with_retry("Model", "path", {})
+
+    # 3rd 429 trips the breaker; the is_cancelled() check then bails the retry.
+    assert client.calls == 3
+    assert cancel.is_cancelled() is True
+    assert cancel.stop_reason() == "tidal_rate_limit"
+
+
+def test_transient_429_below_limit_does_not_stop():
+    ratelimit.guard().reset(strike_limit=5)
+    # One 429 then success: a normal transient blip must NOT trip anything.
+    class _OneThenOk:
+        def __init__(self):
+            self.calls = 0
+
+        def fetch(self, *a, **k):
+            self.calls += 1
+            if self.calls == 1:
+                raise _http_error(429, retry_after=1)
+            return {"ok": True}
+
+    client = _OneThenOk()
+    api = TidalAPI(client, "1", "US")
+
+    assert api._fetch_with_retry("Model", "path", {}) == {"ok": True}
+    assert client.calls == 2
+    assert cancel.is_cancelled() is False
+    assert cancel.stop_reason() is None
+
+
+def test_flagged_account_401_trips_stop():
+    class _Flagged:
+        def __init__(self):
+            self.calls = 0
+            self._refresh_blocked = True
+
+        def fetch(self, *a, **k):
+            self.calls += 1
+            raise _http_error(401, sub_status=1234)
+
+    client = _Flagged()
+    api = TidalAPI(client, "1", "US")
+
+    with pytest.raises(HTTPError):
+        api._fetch_with_retry("Model", "path", {})
+
+    assert client.calls == 1  # 401 is not retried
+    assert cancel.stop_reason() == "tidal_account_flagged"
+
+
+def test_unflagged_401_does_not_stop_the_run():
+    # A plain 401 whose refresh is NOT blocked must still just raise for this
+    # one call, without stopping the whole run.
+    class _Plain401:
+        def __init__(self):
+            self.calls = 0
+            self._refresh_blocked = False
+
+        def fetch(self, *a, **k):
+            self.calls += 1
+            raise _http_error(401, sub_status=1234)
+
+    client = _Plain401()
+    api = TidalAPI(client, "1", "US")
+
+    with pytest.raises(HTTPError):
+        api._fetch_with_retry("Model", "path", {})
+
+    assert client.calls == 1
+    assert cancel.is_cancelled() is False
+    assert cancel.stop_reason() is None
+
+
+def test_user_cancel_stops_retry_storm():
+    # A user cancel mid-run must make an in-flight retrying request give up at
+    # once instead of sleeping through its whole backoff schedule.
+    cancel.request_cancel("user")
+    client = _Always429()
+    api = TidalAPI(client, "1", "US")
+
+    with pytest.raises(HTTPError):
+        api._fetch_with_retry("Model", "path", {})
+
+    assert client.calls == 1  # one 429, then bail — no retry storm
+    assert cancel.stop_reason() == "user"

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,86 @@
+"""Coverage for the opt-in resume checkpoint (tiddl.core.resume)."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tiddl.core.resume import ResumeLog, compute_signature, resource_key
+
+
+def test_resource_key_format():
+    r = SimpleNamespace(type="artist", id="26125")
+    assert resource_key(r) == "artist/26125"
+
+
+def test_signature_is_stable_and_order_independent():
+    a = compute_signature({"resources": ["artist/1", "artist/2"], "quality": "high"})
+    b = compute_signature({"quality": "high", "resources": ["artist/1", "artist/2"]})
+    assert a == b
+    assert len(a) == 16
+
+
+def test_signature_changes_with_fields():
+    base = {"resources": ["artist/1"], "quality": "high", "audio_mode": "auto"}
+    changed = {**base, "audio_mode": "stereo"}
+    assert compute_signature(base) != compute_signature(changed)
+
+
+def test_empty_when_no_file(tmp_path):
+    log = ResumeLog("sig", base_dir=tmp_path).load()
+    assert log.count == 0
+    assert log.is_done("artist/1") is False
+
+
+def test_mark_done_persists_across_reload(tmp_path):
+    log = ResumeLog("sig", base_dir=tmp_path).load()
+    log.mark_done("artist/1")
+    log.mark_done("album/9")
+    # A fresh instance for the same signature/dir sees the persisted set.
+    reloaded = ResumeLog("sig", base_dir=tmp_path).load()
+    assert reloaded.is_done("artist/1")
+    assert reloaded.is_done("album/9")
+    assert reloaded.is_done("artist/2") is False
+    assert reloaded.count == 2
+
+
+def test_mark_done_is_idempotent(tmp_path):
+    log = ResumeLog("sig", base_dir=tmp_path).load()
+    log.mark_done("artist/1")
+    log.mark_done("artist/1")
+    assert log.count == 1
+
+
+def test_different_signatures_do_not_share(tmp_path):
+    a = ResumeLog("sigA", base_dir=tmp_path).load()
+    a.mark_done("artist/1")
+    b = ResumeLog("sigB", base_dir=tmp_path).load()
+    assert b.is_done("artist/1") is False
+    assert b.count == 0
+
+
+def test_corrupt_file_loads_as_empty(tmp_path):
+    (tmp_path / "sig.json").write_text("{ this is not json", encoding="utf-8")
+    log = ResumeLog("sig", base_dir=tmp_path).load()
+    assert log.count == 0  # never raises, just starts fresh
+
+
+def test_clear_removes_the_checkpoint(tmp_path):
+    log = ResumeLog("sig", base_dir=tmp_path).load()
+    log.mark_done("artist/1")
+    assert (tmp_path / "sig.json").exists()
+    log.clear()
+    assert log.count == 0
+    assert not (tmp_path / "sig.json").exists()
+
+
+def test_mark_many(tmp_path):
+    log = ResumeLog("sig", base_dir=tmp_path).load()
+    log.mark_many(["artist/1", "artist/2", "artist/1"])
+    assert log.count == 2
+    assert ResumeLog("sig", base_dir=tmp_path).load().is_done("artist/2")
+
+
+def test_no_temp_file_left_behind(tmp_path):
+    log = ResumeLog("sig", base_dir=tmp_path).load()
+    log.mark_done("artist/1")
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []  # atomic rename cleaned up the temp

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -892,8 +892,12 @@ def download_callback(
         ctx.obj.prefer_hires = True
     elif _hires_mode == "never":
         ctx.obj.prefer_hires = False
-    else:  # "auto": HiRes only when the user actually asked for max (24-bit)
-        ctx.obj.prefer_hires = (TRACK_QUALITY == "max")
+    else:  # "auto": use the HiRes client for any FLAC start (high or max). high
+        # needs it too now, because an Atmos track has no 16-bit FLAC and the
+        # cascade climbs it to the 24-bit `max` FLAC (preferring FLAC over Atmos),
+        # which only the HiRes client can deliver. The run-wide 429 breaker makes
+        # this safe on big LOSSLESS runs, which is why "auto" no longer avoids it.
+        ctx.obj.prefer_hires = TRACK_QUALITY in ("high", "max")
 
     # Lyrics come from [metadata] in config.toml; these flags override per run
     # (the download flow reads CONFIG.metadata at runtime).

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -465,6 +465,13 @@ def download_callback(
         typer.Option(
             "--track-quality",
             "-q",
+            help=(
+                "Starting rung of the fidelity cascade "
+                "max > high > atmos > normal > low. Each track is taken at the "
+                "first rung from here DOWN that it offers: start at high/max to "
+                "prefer FLAC (Atmos only when no FLAC exists), or at atmos to "
+                "take Dolby Atmos first."
+            ),
         ),
     ] = CONFIG.download.track_quality,
     AUDIO_MODE: Annotated[

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -762,6 +762,19 @@ def download_callback(
             min=0,
         ),
     ] = None,
+    RESUME: Annotated[
+        bool,
+        typer.Option(
+            "--resume/--no-resume",
+            help=(
+                "Skip resources already fully processed in a prior run of this "
+                "SAME job (same links + options), before any API call — so a run "
+                "interrupted by a rate-limit stop or Ctrl-C continues cheaply "
+                "instead of re-enumerating everything. Trusts its checkpoint over "
+                "the filesystem; run without --resume for a full re-verify."
+            ),
+        ),
+    ] = False,
     SAVE_M3U: Annotated[
         Optional[bool],
         typer.Option(
@@ -955,6 +968,34 @@ def download_callback(
         import datetime as _dt
         from tiddl.cli.commands.web_login import auto_refresh_if_needed
         await auto_refresh_if_needed(threshold_minutes=30)
+
+        # Resume checkpoint (opt-in --resume). Capture the job signature from the
+        # ORIGINAL requested resources + the options that change what "done"
+        # means, BEFORE the stereo pre-pass / expansion mutate ctx.obj.resources.
+        resume_log = None
+        if RESUME:
+            from tiddl.core.resume import ResumeLog, compute_signature, resource_key
+            _sig = compute_signature({
+                "resources": sorted(resource_key(r) for r in ctx.obj.resources),
+                "download_path": str(DOWNLOAD_PATH),
+                "quality": TRACK_QUALITY,
+                "audio_mode": AUDIO_MODE,
+                "expand": (
+                    "albums" if EXPAND_ALBUMS
+                    else "tracks" if EXPAND_TRACKS
+                    else "artists" if EXPAND_ARTISTS
+                    else "none"
+                ),
+                "exclude_compilations": bool(CONFIG.download.exclude_compilations),
+                "exclude_live_albums": bool(CONFIG.download.exclude_live_albums),
+                "singles": SINGLES_FILTER,
+            })
+            resume_log = ResumeLog(_sig).load()
+            if resume_log.count:
+                ctx.obj.console.print(
+                    f"[dim][resume] {resume_log.count} resource(s) already done in a "
+                    f"prior run of this job will be skipped.[/]"
+                )
 
         if AUDIO_MODE == "stereo":
 
@@ -2424,8 +2465,16 @@ def download_callback(
                 from tiddl.core.cancel import is_cancelled
                 if is_cancelled():
                     return
+                _rkey = f"{r.type}/{r.id}"
+                # Resume: skip a resource already completed in a prior run of this
+                # job BEFORE any API call — the whole point is to avoid re-enumerating.
+                if resume_log is not None and resume_log.is_done(_rkey):
+                    ctx.obj.console.print(f"[dim][resume] skip {_rkey} (done earlier)[/]")
+                    return
+                ok = False
                 try:
                     await handle_resource(r)
+                    ok = True
                 except HTTPError as e:
                     if e.response is not None and e.response.status_code in [404, 406]:
                          ctx.obj.console.print(f"[yellow]Skipped (Geo-block/Not Found):[/] {r}")
@@ -2440,6 +2489,10 @@ def download_callback(
                     raise
                 except Exception as e:
                     ctx.obj.console.print(f"[red]Error:[/] {e} at {r}")
+                # Mark done only on a clean, non-cancelled completion, so a resource
+                # that errored (or a run that got stopped) is retried on --resume.
+                if ok and resume_log is not None and not is_cancelled():
+                    resume_log.mark_done(_rkey)
 
             async def expand_playlist(resource: TidalResource) -> list[TidalResource]:
                 """--albums/--artists: turn a playlist into its unique albums or

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -332,10 +332,28 @@ def _finish_download_run(
                 "copies were retained where applicable); exiting non-zero.[/]"
             )
         else:
-            console.print(
-                "[red]The download engine stopped the run for safety; "
-                "exiting non-zero.[/]"
-            )
+            from tiddl.core.cancel import stop_reason
+            reason = stop_reason()
+            if reason == "tidal_rate_limit":
+                console.print(
+                    "[red]Stopped: TIDAL rate-limited this run repeatedly. "
+                    "Pushing further risks a hard account block. Wait a while, "
+                    "then re-run — already-downloaded tracks are skipped, so it "
+                    "resumes where it left off (tip: set max_tracks_per_session "
+                    "to download big lists in chunks). Exiting non-zero.[/]"
+                )
+            elif reason == "tidal_account_flagged":
+                console.print(
+                    "[red]Stopped: TIDAL flagged the account and refused a token "
+                    "refresh. Run 'tiddl auth login' to sign in again, then "
+                    "re-run (already-downloaded tracks are skipped). "
+                    "Exiting non-zero.[/]"
+                )
+            else:
+                console.print(
+                    "[red]The download engine stopped the run for safety; "
+                    "exiting non-zero.[/]"
+                )
         sys.exit(exit_code)
 
 
@@ -2503,6 +2521,13 @@ def download_callback(
         # cuando el subcomando falló al parsear sus argumentos).
         if not ctx.obj.resources:
             return
+        # Fresh 429 strike budget per invocation: the run-wide circuit breaker
+        # counts 429s across the whole run, so it must start at zero here (the
+        # GUI reuses this process for run after run). Cancel state is managed by
+        # the caller (the GUI clears it before a batch; a safety stop should
+        # halt the rest of the batch, so it is intentionally NOT cleared here).
+        from tiddl.core.ratelimit import guard as _rl_guard
+        _rl_guard().reset()
         import warnings
         # Suppress ResourceWarning noise from asyncio pipe cleanup on Windows Ctrl+C
         if sys.platform == "win32":

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -357,6 +357,49 @@ def _finish_download_run(
         sys.exit(exit_code)
 
 
+async def _bounded_dispatch(items, handler, concurrency: int) -> None:
+    """Run ``handler(item, index)`` over ``items`` with a FIXED pool of
+    ``concurrency`` worker tasks, so at most ``concurrency`` tasks exist at once
+    no matter how many items there are.
+
+    This bounds memory on huge expanded runs: a playlist expanded into hundreds
+    of thousands of artist resources would otherwise create one asyncio Task per
+    resource up front (each parked on a semaphore), which is what exhausted RAM
+    and hard-killed the process. asyncio is single-threaded, so pulling the next
+    item from the shared iterator between awaits needs no lock. ``index`` is
+    1-based, matching the previous ``enumerate(..., start=1)`` heartbeat.
+
+    Cancellation propagates: a worker raising ``CancelledError`` /
+    ``KeyboardInterrupt`` (or the awaiting caller being cancelled) tears the
+    whole pool down. A per-item error never kills a worker or orphans the rest —
+    the existing ``wrapper`` already swallows every non-cancel exception, and
+    this is the defensive backstop for anything it doesn't."""
+    it = enumerate(items, start=1)
+
+    async def _worker() -> None:
+        while True:
+            try:
+                index, item = next(it)
+            except StopIteration:
+                return
+            try:
+                await handler(item, index)
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                raise
+            except Exception:
+                log.exception("resource dispatch failed; continuing")
+
+    workers = [asyncio.create_task(_worker()) for _ in range(max(1, concurrency))]
+    try:
+        await asyncio.gather(*workers)
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        for w in workers:
+            if not w.done():
+                w.cancel()
+        await asyncio.gather(*workers, return_exceptions=True)
+        raise
+
+
 def plan_stereo_resolution(result, keep_original: bool) -> tuple:
     """Pure pre-confirmation decision for the stereo resolution of one album.
 
@@ -2463,16 +2506,17 @@ def download_callback(
 
             if expanded_run or len(ctx.obj.resources) > 1:
                 # Multi-resource runs (expansions or many pasted URLs) can be
-                # hundreds of resources. Launching them all concurrently starves
-                # every task on the API client's global rate-limit lock (each
-                # task's next request queues behind every other task's), so
-                # nothing visibly completes for a long time. Cap concurrency
-                # like artist downloads do so resource #1 starts producing
-                # output immediately.
-                expand_sem = asyncio.Semaphore(max(1, ARTIST_CONCURRENCY))
+                # hundreds of THOUSANDS of resources (a playlist expanded into
+                # every credited artist). A bounded worker pool keeps at most
+                # ARTIST_CONCURRENCY tasks alive at once, so peak memory does not
+                # scale with the resource count — creating one asyncio Task per
+                # resource up front (each parked on a semaphore) is exactly what
+                # exhausted RAM on a giant stereo+artists run. It also caps
+                # concurrency so resource #1 starts producing output immediately
+                # instead of every task queueing behind the shared rate-limit lock.
                 expand_total = len(ctx.obj.resources)
 
-                async def wrapper_limited(r: TidalResource, idx: int):
+                async def dispatch_one(r: TidalResource, idx: int):
                     # Cooperative cancel: bail BEFORE the heartbeat print so a
                     # cancelled run doesn't flood the log with a burst of
                     # "[idx/total] type/id" lines for every remaining resource
@@ -2480,34 +2524,34 @@ def download_callback(
                     # reads as "still working" even though nothing downloads).
                     if is_cancelled():
                         return
-                    async with expand_sem:
-                        if is_cancelled():
-                            return
-                        # Steady per-resource heartbeat: complete albums are
-                        # skipped silently, so without this the output can go
-                        # quiet for minutes on largely-downloaded expansions.
-                        ctx.obj.console.print(
-                            f"[{idx}/{expand_total}] {r.type}/{r.id}", markup=False
-                        )
-                        await wrapper(r)
+                    # Steady per-resource heartbeat: complete albums are skipped
+                    # silently, so without this the output can go quiet for
+                    # minutes on largely-downloaded expansions.
+                    ctx.obj.console.print(
+                        f"[{idx}/{expand_total}] {r.type}/{r.id}", markup=False
+                    )
+                    await wrapper(r)
 
-                tasks = [
-                    asyncio.create_task(wrapper_limited(r, i))
-                    for i, r in enumerate(ctx.obj.resources, start=1)
-                ]
+                try:
+                    await _bounded_dispatch(
+                        ctx.obj.resources, dispatch_one, max(1, ARTIST_CONCURRENCY)
+                    )
+                finally:
+                    # Flush report_playback pendientes y cierra la sesión HTTP compartida
+                    await downloader.close()
             else:
                 tasks = [asyncio.create_task(wrapper(r)) for r in ctx.obj.resources]
-            try:
-                await asyncio.gather(*tasks)
-            except (asyncio.CancelledError, KeyboardInterrupt):
-                for t in tasks:
-                    if not t.done():
-                        t.cancel()
-                await asyncio.gather(*tasks, return_exceptions=True)
-                raise
-            finally:
-                # Flush report_playback pendientes y cierra la sesión HTTP compartida
-                await downloader.close()
+                try:
+                    await asyncio.gather(*tasks)
+                except (asyncio.CancelledError, KeyboardInterrupt):
+                    for t in tasks:
+                        if not t.done():
+                            t.cancel()
+                    await asyncio.gather(*tasks, return_exceptions=True)
+                    raise
+                finally:
+                    # Flush report_playback pendientes y cierra la sesión HTTP compartida
+                    await downloader.close()
 
         rich_output.show_stats()
 

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -1231,25 +1231,28 @@ class Downloader:
                 # reports LOSSLESS when HI_RES_LOSSLESS is actually available), which
                 # silently prevented downloads in maximum quality.
                 quality_score = {"HI_RES_LOSSLESS": 3, "LOSSLESS": 2, "HIGH": 1, "LOW": 0}
-                max_score = quality_score.get(self.track_quality, 3)
 
-                # Check for Dolby Atmos
-                is_atmos = False
+                # Media tags drive BOTH the Atmos flag and the quality cascade.
+                _tags: list = []
                 if item.mediaMetadata:
-                    tags = []
                     if isinstance(item.mediaMetadata, dict):
-                        tags = item.mediaMetadata.get("tags", [])
+                        _tags = item.mediaMetadata.get("tags", []) or []
                     elif hasattr(item.mediaMetadata, "tags"):
-                        tags = item.mediaMetadata.tags
-                    if "DOLBY_ATMOS" in tags:
-                        is_atmos = True
+                        _tags = item.mediaMetadata.tags or []
+                _tagset = {str(t).upper() for t in _tags}
+                if item.audioModes:
+                    _tagset |= {str(m).upper() for m in item.audioModes}
+                is_atmos = "DOLBY_ATMOS" in _tagset
 
-                if not is_atmos and item.audioModes and "DOLBY_ATMOS" in item.audioModes:
-                    is_atmos = True
-
-                attempt_qualities: list[TrackQuality] = ["HI_RES_LOSSLESS", "LOSSLESS", "HIGH", "LOW"]
-                # Filter out qualities higher than what the track supports
-                attempt_qualities = [q for q in attempt_qualities if quality_score.get(q, 0) <= max_score]
+                # Fidelity cascade from the user's chosen start rung (-q): walk DOWN
+                # max -> high -> atmos -> normal -> low, attempting only the tiers
+                # this track offers. Starting at high/max prefers FLAC and only
+                # falls to Atmos when no FLAC exists; starting at atmos takes Atmos
+                # first. See tiddl.core.quality_cascade.
+                from tiddl.core.quality_cascade import cascade_api_qualities
+                attempt_qualities: list[TrackQuality] = cascade_api_qualities(
+                    self.requested_quality, _tagset
+                ) or ["LOW"]
 
                 for _qi, q in enumerate(attempt_qualities):
                     # Cooperative cancel: don't try the next quality tier if the
@@ -1360,7 +1363,13 @@ class Downloader:
                         download_path = Path(_prepare_long_path(str(download_path.absolute())))
 
                     quality = track_qualities_color[stream.audioQuality]
-                    if is_atmos:
+                    # Label "Dolby Atmos" only when the stream we ACTUALLY got is
+                    # the Atmos one — not merely because the track has an Atmos
+                    # version. On an Atmos track the FLAC comes back as
+                    # HI_RES_LOSSLESS (the cascade's `max` rung); anything lower
+                    # delivered for such a track is the Atmos/AAC stream.
+                    stream_is_flac = stream.audioQuality in ("HI_RES_LOSSLESS", "LOSSLESS")
+                    if is_atmos and not stream_is_flac:
                         quality = "[purple]Dolby Atmos"
                     elif stream.audioQuality in ["HI_RES_LOSSLESS", "LOSSLESS"]:
                         quality = f"{quality} {stream.bitDepth}-bit, {(stream.sampleRate or 0) / 1000:.1f} kHz"

--- a/tiddl/core/api/api.py
+++ b/tiddl/core/api/api.py
@@ -114,6 +114,15 @@ class TidalAPI:
                             print(f"⚠️ Content not ready/available ({status}). Skipping...");
                             raise e
 
+                        # Account flagged: TIDAL refused a token refresh (the
+                        # client sets _refresh_blocked on a permanent 4xx). Every
+                        # remaining task would 401 the same way, and more auth
+                        # traffic only deepens the flag — trip a run-wide safety
+                        # stop so the run ends cleanly and the user re-logs in,
+                        # instead of thousands of tasks hammering the endpoint.
+                        if getattr(self.client, "_refresh_blocked", False):
+                            from tiddl.core.cancel import request_cancel
+                            request_cancel(reason="tidal_account_flagged")
                         print(f"\n❌ TOKEN ERROR ({status}).");
                         raise e
                     if status in [406, 451]:
@@ -127,6 +136,16 @@ class TidalAPI:
                         is_http = True
                         if status == 429:
                             self._rate_limit_delay = min(5.0, self._rate_limit_delay + 1.0)
+                            # Run-wide 429 circuit breaker (shared across every
+                            # task and the fallback client): too many 429s in one
+                            # run means TIDAL is throttling hard — trip a
+                            # cooperative stop before a soft rate-limit escalates
+                            # into a hard account block. The is_cancelled() check
+                            # below then bails this request's retries too.
+                            from tiddl.core.ratelimit import guard as _rl_guard
+                            if _rl_guard().note_rate_limited():
+                                from tiddl.core.cancel import request_cancel
+                                request_cancel(reason="tidal_rate_limit")
                         # 500/502/503/504 fall through to the single capped backoff
                         # in the is_http branch below. There used to be a second
                         # sleep here with an UNCAPPED 2**attempt delay — every server
@@ -136,12 +155,24 @@ class TidalAPI:
                 elif "429" in str(e):
                     is_http = True
                     self._rate_limit_delay = min(5.0, self._rate_limit_delay + 1.0)
+                    from tiddl.core.ratelimit import guard as _rl_guard
+                    if _rl_guard().note_rate_limited():
+                        from tiddl.core.cancel import request_cancel
+                        request_cancel(reason="tidal_rate_limit")
 
                 if not is_net and not is_http: raise e
 
                 attempt += 1
                 if attempt > max_retries:
                     print(f"❌ SKIPPING TRACK: Failed {max_retries} times. Next...")
+                    raise e
+
+                # A run-wide stop — a user cancel OR the 429/flagged-account
+                # safety trips above — means we must not keep retry-storming:
+                # give up this request at once so the run drains, instead of
+                # every in-flight task sleeping through its full backoff.
+                from tiddl.core.cancel import is_cancelled
+                if is_cancelled():
                     raise e
 
                 wait = 0

--- a/tiddl/core/api/playback.py
+++ b/tiddl/core/api/playback.py
@@ -42,7 +42,18 @@ async def report_playback(
         listen_delay = min(duration * random.uniform(0.3, 0.6), 25.0)
         await asyncio.sleep(listen_delay)
 
-        connector = aiohttp.TCPConnector(force_close=True, enable_cleanup_closed=True)
+        # aiohttp's `enable_cleanup_closed` worked around a CPython SSL-transport
+        # leak that recent 3.12/3.13 fixed; there aiohttp ignores it and emits a
+        # DeprecationWarning. Keep passing it (still helps on older runtimes) but
+        # silence the purely cosmetic warning on the fixed ones.
+        import warnings as _warnings
+        with _warnings.catch_warnings():
+            _warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message=".*enable_cleanup_closed.*",
+            )
+            connector = aiohttp.TCPConnector(force_close=True, enable_cleanup_closed=True)
         now = datetime.now(timezone.utc)
         start = now - timedelta(seconds=duration)
         session_id = str(uuid.uuid4())

--- a/tiddl/core/cancel.py
+++ b/tiddl/core/cancel.py
@@ -1,25 +1,57 @@
-"""Cooperative cancellation for in-process (GUI) use.
+"""Cooperative cancellation / safety-stop for in-process (GUI) and CLI use.
 
-The CLI never sets this flag — killing the process is enough there. But when
-tiddl runs *inside* another process (e.g. the single-binary GUI, which invokes
-the download command in a worker thread), there is no process to kill. The GUI
-calls `request_cancel()`, and the download orchestration checks `is_cancelled()`
-at its per-item choke point so queued items drain fast and the run ends.
+A stop can come from two places:
+
+* a **user cancel** — the GUI runs the download command in a worker thread, so
+  there is no process to kill; it calls ``request_cancel()`` and the download
+  orchestration checks ``is_cancelled()`` at its per-item choke points so queued
+  items drain fast and the run ends;
+* a **run-wide safety stop** tripped by the engine itself — e.g. TIDAL is
+  rate-limiting the account so hard that continuing risks a hard block (see
+  :mod:`tiddl.core.ratelimit`), or the account got flagged (refresh-blocked
+  401). These call ``request_cancel(reason=...)`` so the SAME drain path runs.
+
+Both set one flag; the optional *reason* lets the run's final message explain
+WHY it stopped (user vs. rate-limit vs. flagged account). The CLI relies on this
+too now: a safety stop must halt a long terminal run, not only an in-process
+GUI run.
 """
 import threading
+from typing import Optional
 
 _event = threading.Event()
+_lock = threading.Lock()
+_reason: Optional[str] = None
 
 
-def request_cancel() -> None:
-    """Signal that the current in-process download should stop."""
+def request_cancel(reason: str = "user") -> None:
+    """Signal that the current download should stop.
+
+    The FIRST reason wins: a rate-limit trip that fires just before the user
+    also clicks cancel keeps reporting the rate limit (the real cause), and vice
+    versa. ``reason`` defaults to ``"user"`` so existing callers are unchanged.
+    """
+    global _reason
+    with _lock:
+        if _reason is None:
+            _reason = reason
     _event.set()
 
 
 def clear() -> None:
-    """Reset the flag before starting a new run."""
+    """Reset the flag AND the reason before starting a new run."""
+    global _reason
+    with _lock:
+        _reason = None
     _event.clear()
 
 
 def is_cancelled() -> bool:
     return _event.is_set()
+
+
+def stop_reason() -> Optional[str]:
+    """Why the run stopped — ``"user"``, ``"tidal_rate_limit"``,
+    ``"tidal_account_flagged"``, or ``None`` if it did not stop."""
+    with _lock:
+        return _reason

--- a/tiddl/core/quality_cascade.py
+++ b/tiddl/core/quality_cascade.py
@@ -60,17 +60,31 @@ def available_rungs(tags: Iterable[str]) -> Dict[str, bool]:
     }
 
 
-def resolve_cascade(start: str, tags: Iterable[str]) -> List[str]:
-    """Ordered rungs to attempt: from ``start`` DOWN the ladder, offered ones only.
+# The two lossless-FLAC rungs, and everything below them, in fidelity order.
+FLAC_RUNGS = ("max", "high")
+BELOW_FLAC = ("atmos", "normal", "low")
 
-    ``start`` must be a ladder rung. An unknown ``start`` is treated as the top
-    (``max``) so a stray value never silently drops the track to AAC."""
+
+def resolve_cascade(start: str, tags: Iterable[str]) -> List[str]:
+    """Ordered rungs to attempt for a track, given the user's ``start`` rung.
+
+    **FLAC is preferred over Atmos.** When ``start`` is a FLAC rung (``high`` or
+    ``max``), BOTH FLAC rungs are tried before Atmos — the chosen one first, then
+    the other by fidelity — so e.g. ``-q high`` on an Atmos track (which has no
+    16-bit FLAC) climbs to ``max`` for the 24-bit FLAC instead of dropping to
+    Atmos. Most users want any FLAC before Atmos; those who actually want Atmos
+    start at ``-q atmos``, which cascades plainly down (atmos > normal > low).
+
+    An unknown ``start`` is treated as the top (``max``) so a stray value never
+    silently drops the track to AAC."""
+    if start not in QUALITY_LADDER:
+        start = "max"
     avail = available_rungs(tags)
-    try:
-        i = QUALITY_LADDER.index(start)
-    except ValueError:
-        i = 0
-    return [r for r in QUALITY_LADDER[i:] if avail.get(r)]
+    if start in FLAC_RUNGS:
+        order = [start] + [r for r in FLAC_RUNGS if r != start] + list(BELOW_FLAC)
+    else:
+        order = QUALITY_LADDER[QUALITY_LADDER.index(start):]
+    return [r for r in order if avail.get(r)]
 
 
 def cascade_api_qualities(start: str, tags: Iterable[str]) -> List[str]:

--- a/tiddl/core/quality_cascade.py
+++ b/tiddl/core/quality_cascade.py
@@ -1,0 +1,83 @@
+"""User-chosen quality cascade with Dolby Atmos as a rung.
+
+TIDAL does not expose a single linear quality order that includes Atmos: Atmos
+is a separate track *version* (``audioMode`` ``DOLBY_ATMOS``), delivered lossy
+(~768 kbps immersive EAC3), while the real tiers are HI_RES_LOSSLESS / LOSSLESS
+(both FLAC) and HIGH / LOW (AAC). We arrange them into ONE ladder ordered by
+**fidelity** (lossless before lossy):
+
+    max  →  high  →  atmos  →  normal  →  low
+
+The user picks the STARTING rung with ``-q`` (e.g. ``-q max`` starts at the top,
+``-q atmos`` starts at Atmos for those who want it first); the downloader then
+walks DOWN the ladder from that rung and takes the first rung the track actually
+offers. So "prefer FLAC over Atmos" is just "start at high or max": a dual-format
+track resolves to its FLAC, and only a track with no FLAC falls through to Atmos.
+
+Per-track availability comes from ``mediaMetadata.tags``:
+
+* ``max``   — a ``HIRES_LOSSLESS`` tag (24-bit FLAC).
+* ``high``  — a ``LOSSLESS`` tag AND the track is NOT Atmos. On an Atmos track the
+  LOSSLESS tier returns the Atmos stream, not a 16-bit FLAC (verified against
+  TIDAL), so the only FLAC for an Atmos track is ``max``; ``high`` is therefore
+  not offered for it and the cascade falls straight to the ``atmos`` rung.
+* ``atmos`` — a ``DOLBY_ATMOS`` tag.
+* ``normal`` / ``low`` — always (AAC is universal).
+"""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+# Fidelity order, highest to lowest.
+QUALITY_LADDER: List[str] = ["max", "high", "atmos", "normal", "low"]
+
+# Which TIDAL audioquality each rung is fetched at.
+RUNG_TO_API: Dict[str, str] = {
+    "max": "HI_RES_LOSSLESS",
+    "high": "LOSSLESS",
+    "atmos": "LOSSLESS",  # LOSSLESS request on an Atmos track yields the Atmos stream
+    "normal": "HIGH",
+    "low": "LOW",
+}
+
+
+def _tagset(tags: Iterable[str]) -> set:
+    return {str(t).upper() for t in (tags or [])}
+
+
+def available_rungs(tags: Iterable[str]) -> Dict[str, bool]:
+    """Which ladder rungs this track actually offers, from its media tags."""
+    t = _tagset(tags)
+    atmos = "DOLBY_ATMOS" in t
+    return {
+        "max": "HIRES_LOSSLESS" in t,
+        # An Atmos track's LOSSLESS tier is the Atmos stream, not a FLAC, so it
+        # has no separate `high` (16-bit FLAC) rung — its FLAC lives only at `max`.
+        "high": ("LOSSLESS" in t) and not atmos,
+        "atmos": atmos,
+        "normal": True,
+        "low": True,
+    }
+
+
+def resolve_cascade(start: str, tags: Iterable[str]) -> List[str]:
+    """Ordered rungs to attempt: from ``start`` DOWN the ladder, offered ones only.
+
+    ``start`` must be a ladder rung. An unknown ``start`` is treated as the top
+    (``max``) so a stray value never silently drops the track to AAC."""
+    avail = available_rungs(tags)
+    try:
+        i = QUALITY_LADDER.index(start)
+    except ValueError:
+        i = 0
+    return [r for r in QUALITY_LADDER[i:] if avail.get(r)]
+
+
+def cascade_api_qualities(start: str, tags: Iterable[str]) -> List[str]:
+    """The cascade as TIDAL audioquality strings, de-duplicated in order."""
+    out: List[str] = []
+    for rung in resolve_cascade(start, tags):
+        api = RUNG_TO_API[rung]
+        if not out or out[-1] != api:
+            out.append(api)
+    return out

--- a/tiddl/core/ratelimit.py
+++ b/tiddl/core/ratelimit.py
@@ -1,0 +1,84 @@
+"""Process-wide rate-limit circuit breaker.
+
+Every download task — and BOTH the main and the fallback ``TidalAPI`` — share
+ONE guard, so the 429s they each see are counted together for the whole run.
+Each strike is a full ``429`` that already cost its mandatory ``Retry-After``
+wait, so a run that accumulates a dozen of them is being actively and
+repeatedly throttled by TIDAL. Pushing further risks escalating a soft
+rate-limit into a hard account block (the failure the user actually hit on a
+giant playlist-expanded-to-artists run). At that point the safe move is to trip
+a run-wide cooperative stop and let the user resume later — ``skip_existing`` +
+``max_tracks_per_session`` make resuming cheap — rather than let thousands of
+queued tasks keep hammering.
+
+The guard only COUNTS and decides; it never sleeps and never cancels on its own.
+The caller (``TidalAPI._fetch_with_retry``) turns a trip into the actual
+cooperative stop via :mod:`tiddl.core.cancel`, keeping this module free of any
+dependency on the download/cancel machinery. Reset once per ``tiddl download``
+invocation.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+# 429 strikes tolerated in a single run before the breaker trips. Each strike is
+# a full 429 (with its Retry-After wait already paid), so this many means TIDAL
+# is throttling the run hard. Deliberately generous so a handful of transient
+# 429s never aborts a legitimate long run.
+DEFAULT_STRIKE_LIMIT = 12
+
+
+class RateLimitGuard:
+    """Thread-safe 429 strike counter with a one-shot trip.
+
+    ``note_rate_limited`` returns ``True`` exactly once — on the call that
+    crosses the limit — so the caller trips the cooperative stop a single time.
+    """
+
+    def __init__(self, strike_limit: int = DEFAULT_STRIKE_LIMIT) -> None:
+        self._lock = threading.Lock()
+        self._strike_limit = strike_limit
+        self._strikes = 0
+        self._tripped = False
+
+    def reset(self, strike_limit: Optional[int] = None) -> None:
+        """Clear the counter before a new run (optionally re-arm the limit)."""
+        with self._lock:
+            self._strikes = 0
+            self._tripped = False
+            if strike_limit is not None and strike_limit > 0:
+                self._strike_limit = strike_limit
+
+    def note_rate_limited(self) -> bool:
+        """Record one 429. Return ``True`` on the single call that trips the
+        breaker; ``False`` before the limit and on every call after the trip."""
+        with self._lock:
+            self._strikes += 1
+            if self._strikes >= self._strike_limit and not self._tripped:
+                self._tripped = True
+                return True
+            return False
+
+    @property
+    def strikes(self) -> int:
+        with self._lock:
+            return self._strikes
+
+    @property
+    def strike_limit(self) -> int:
+        with self._lock:
+            return self._strike_limit
+
+    @property
+    def tripped(self) -> bool:
+        with self._lock:
+            return self._tripped
+
+
+_guard = RateLimitGuard()
+
+
+def guard() -> RateLimitGuard:
+    """The shared, process-wide guard."""
+    return _guard

--- a/tiddl/core/resume.py
+++ b/tiddl/core/resume.py
@@ -1,0 +1,118 @@
+"""Opt-in resume checkpoint for long download runs.
+
+A giant run (a playlist expanded into every artist's discography) that a
+rate-limit safety-stop or Ctrl-C interrupts is expensive to restart: even with
+``skip_existing``, the engine RE-ENUMERATES every artist (``get_artist_albums``
++ ``get_album_items`` per album) just to discover there is nothing left to
+download — the same API storm that risks re-tripping the rate limit. With
+``--resume``, resources fully processed in a prior run of the SAME job are
+skipped before any API call.
+
+Scope & trust:
+
+* Keyed by a **signature** of the job — its requested resources plus the options
+  that change what "done" means (destination, quality, audio mode, expansion,
+  exclude filters, singles). A different job or different options → a different
+  checkpoint, so runs never contaminate each other.
+* It **trusts the checkpoint over the filesystem**: a resource marked done is
+  skipped without re-checking files. If you deleted files or want a full
+  re-verify, run WITHOUT ``--resume``.
+* A resource is marked done only on a **clean, error-free completion** of that
+  resource, so a resource that hit an error is retried on the next ``--resume``
+  run. (A per-item failure swallowed *inside* a resource — e.g. one geo-blocked
+  album within an artist — is the documented exception: it does not un-mark the
+  resource; run without ``--resume`` to retry those.)
+
+The checkpoint lives at ``TIDDL_PATH/resume/<signature>.json`` and every write is
+best-effort — a failed checkpoint write must never break a download.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+def _base_dir() -> Path:
+    base = os.environ.get("TIDDL_PATH") or str(Path.home() / ".tiddl")
+    return Path(base) / "resume"
+
+
+def compute_signature(fields: dict) -> str:
+    """A stable short hex digest over the job-identity ``fields``.
+
+    ``sort_keys`` makes it order-independent, so the same job always maps to the
+    same checkpoint regardless of dict insertion order."""
+    blob = json.dumps(fields, sort_keys=True, default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+
+
+def resource_key(resource) -> str:
+    """Stable identity for a resource: ``"<type>/<id>"``."""
+    return f"{resource.type}/{resource.id}"
+
+
+class ResumeLog:
+    """Persistent set of completed resource keys for one job signature."""
+
+    def __init__(self, signature: str, base_dir: Optional[Path] = None) -> None:
+        self.signature = signature
+        self._dir = Path(base_dir) if base_dir is not None else _base_dir()
+        self._path = self._dir / f"{signature}.json"
+        self._done: set[str] = set()
+
+    def load(self) -> "ResumeLog":
+        """Read any prior checkpoint for this signature (missing/corrupt = empty)."""
+        try:
+            data = json.loads(self._path.read_text(encoding="utf-8"))
+            done = data.get("completed", [])
+            self._done = {str(k) for k in done} if isinstance(done, list) else set()
+        except (FileNotFoundError, ValueError, OSError):
+            self._done = set()
+        return self
+
+    def is_done(self, key: str) -> bool:
+        return key in self._done
+
+    def mark_done(self, key: str) -> None:
+        if key in self._done:
+            return
+        self._done.add(key)
+        self._persist()
+
+    def mark_many(self, keys: Iterable[str]) -> None:
+        new = {str(k) for k in keys} - self._done
+        if not new:
+            return
+        self._done |= new
+        self._persist()
+
+    def clear(self) -> None:
+        self._done = set()
+        try:
+            self._path.unlink()
+        except OSError:
+            pass
+
+    @property
+    def count(self) -> int:
+        return len(self._done)
+
+    def _persist(self) -> None:
+        # Best-effort atomic write: a failed checkpoint write must never break a
+        # download, and a crash mid-write must not corrupt the existing file.
+        try:
+            self._dir.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".json.tmp")
+            tmp.write_text(
+                json.dumps(
+                    {"signature": self.signature, "completed": sorted(self._done)},
+                    indent=0,
+                ),
+                encoding="utf-8",
+            )
+            os.replace(tmp, self._path)
+        except OSError:
+            pass

--- a/tiddl/core/utils/const.py
+++ b/tiddl/core/utils/const.py
@@ -3,12 +3,18 @@ from typing import Literal
 
 from tiddl.core.api.models import StreamVideoQuality, TrackQuality
 
-TRACK_QUALITY_LITERAL = Literal["low", "normal", "high", "max"]
+# Quality "rungs" the user can pick as the START of the download cascade. Ordered
+# by FIDELITY, highest to lowest: max/high are lossless FLAC, atmos is the
+# (lossy, immersive) Dolby Atmos version, normal/low are AAC. `atmos` is a rung,
+# NOT a distinct TIDAL audioquality — it is served by requesting the LOSSLESS
+# tier on an Atmos-flagged track (see tiddl.core.quality_cascade).
+TRACK_QUALITY_LITERAL = Literal["low", "normal", "atmos", "high", "max"]
 VIDEO_QUALITY_LITERAL = Literal["sd", "hd", "fhd"]
 
 track_qualities: dict[TRACK_QUALITY_LITERAL, TrackQuality] = {
     "low": "LOW",
     "normal": "HIGH",
+    "atmos": "LOSSLESS",  # Atmos stream comes back from the LOSSLESS request
     "high": "LOSSLESS",
     "max": "HI_RES_LOSSLESS",
 }


### PR DESCRIPTION
Release v1.5.0: 429 circuit breaker, bounded-memory worker pool, opt-in `--resume` checkpoint, and the fidelity quality cascade (max > high > atmos > normal > low, FLAC preferred over Atmos). Full suite 388 passed, 3 skipped. See CHANGELOG [1.5.0].

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden large TIDAL download runs with bounded concurrency, cooperative rate-limit protection, resumable checkpoints, and fidelity-aware quality selection.

New Features:
- Add a fidelity-based audio quality cascade with Dolby Atmos support and FLAC preference.
- Add opt-in job-specific resume checkpoints that skip previously completed resources before API calls.

Bug Fixes:
- Correctly label downloads according to the stream actually delivered, avoiding Atmos labels on FLAC files.
- Stop retry storms when TIDAL flags an account or repeatedly rate-limits a run.

Enhancements:
- Bound expanded-resource processing with a fixed worker pool to prevent memory usage from scaling with run size.
- Share cooperative cancellation and rate-limit state across clients and provide clearer safety-stop messages.

Build:
- Bump the project version to 1.5.0.

Documentation:
- Document the quality cascade, Atmos behavior, and resume workflow in the changelog and command reference.
- Update development guidance to reflect CLI and bundled GUI consumers.

Tests:
- Add coverage for bounded dispatch, quality resolution, rate-limit circuit breaking, and resume checkpoints.

Chores:
- Suppress a known aiohttp deprecation warning on supported runtimes.