### PR TITLE
v1.5.1 — fix Sourcery-flagged -q atmos & resume edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-08-23
+
+### Fixed
+
+- `-q atmos` no longer crashes with `--audio-mode stereo` (or artist stereo
+  expansion): the edition resolver now maps the Atmos rung to `high` (its
+  LOSSLESS tier) instead of raising `ValueError: unsupported quality`.
+- `-q atmos --quality-policy strict` no longer stops before downloading: the
+  Atmos rung has no single clean tier, so the exact-quality strict gate is
+  skipped for it (and `atmos` now maps to `LOSSLESS`, not a bogus `ATMOS`).
+- The **`--resume` signature** now includes the output-affecting options
+  (naming templates, artist separator, video path/filter, metadata/lyrics/cover,
+  `update_mtime`, `rewrite_metadata`), so changing any of them starts a fresh
+  resume instead of wrongly skipping resources completed under the old settings.
+- The **"Dolby Atmos" download label** now reflects the DELIVERED stream's
+  `audioMode`, so a track that has an Atmos version but was served FLAC or a
+  degraded non-Atmos AAC is no longer mislabelled Dolby Atmos.
+
 ## [1.5.0] - 2026-08-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.5.0"
+version = "1.5.1"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_edition_resolver.py
+++ b/tests/test_edition_resolver.py
@@ -50,6 +50,14 @@ def test_normalization_handles_case_accents_and_punctuation():
     assert normalize_catalog_text("  Ahí — (Remix)! ") == "ahi remix"
 
 
+def test_atmos_rung_maps_to_high_instead_of_raising():
+    # The `atmos` download rung is fetched at the LOSSLESS tier, which the edition
+    # resolver only knows as `high`; `-q atmos --audio-mode stereo` must resolve,
+    # not raise ValueError (regression).
+    assert quality_fallback_order("atmos") == quality_fallback_order("high")
+    assert quality_fallback_order("atmos", "strict") == quality_fallback_order("high", "strict")
+
+
 def test_flexible_quality_is_a_user_ceiling_with_downward_fallback():
     assert quality_fallback_order("max") == ("max", "high", "normal", "low")
     assert quality_fallback_order("high") == ("high", "normal", "low")

--- a/tests/test_stream_policy.py
+++ b/tests/test_stream_policy.py
@@ -12,6 +12,23 @@ def stream(mode="STEREO", quality="LOSSLESS", bit_depth=16, sample_rate=44100):
     )
 
 
+def test_atmos_rung_not_blocked_by_strict_policy():
+    # The `atmos` rung has no clean tier, so the strict exact-quality gate must
+    # NOT stop it (regression: `-q atmos --quality-policy strict` always stopped).
+    result = inspect_track_stream(
+        stream(mode="DOLBY_ATMOS", quality="HIGH"),
+        requested_quality="atmos",
+        quality_policy="strict",
+    )
+    assert result.accepted
+
+
+def test_atmos_rung_flexible_accepts_lossless():
+    # `atmos` maps to the LOSSLESS tier (not a garbage "ATMOS" wanted value).
+    result = inspect_track_stream(stream(quality="LOSSLESS"), requested_quality="atmos")
+    assert result.accepted
+
+
 def test_stereo_high_is_verified_from_playback_metadata():
     result = inspect_track_stream(stream(), audio_mode="stereo", requested_quality="high")
 

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -1000,6 +1000,22 @@ def download_callback(
                 "exclude_compilations": bool(CONFIG.download.exclude_compilations),
                 "exclude_live_albums": bool(CONFIG.download.exclude_live_albums),
                 "singles": SINGLES_FILTER,
+                # Everything else that changes WHAT a resource produces on disk, so
+                # a resource marked done under one template/metadata config is not
+                # wrongly skipped after the user changes them on a --resume run.
+                "templates": [
+                    CONFIG.templates.default, CONFIG.templates.track,
+                    CONFIG.templates.album, CONFIG.templates.playlist,
+                    CONFIG.templates.video, CONFIG.templates.mix,
+                    CONFIG.templates.artist_separator,
+                ],
+                "video_download_path": str(VIDEO_DOWNLOAD_PATH) if VIDEO_DOWNLOAD_PATH else "",
+                "videos_filter": VIDEOS_FILTER,
+                "metadata": [
+                    bool(CONFIG.metadata.cover), bool(CONFIG.metadata.lyrics),
+                    bool(CONFIG.metadata.save_lyrics), bool(CONFIG.metadata.album_review),
+                    bool(CONFIG.download.update_mtime), bool(REWRITE_METADATA),
+                ],
             })
             resume_log = ResumeLog(_sig).load()
             if resume_log.count:

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -1364,12 +1364,12 @@ class Downloader:
 
                     quality = track_qualities_color[stream.audioQuality]
                     # Label "Dolby Atmos" only when the stream we ACTUALLY got is
-                    # the Atmos one — not merely because the track has an Atmos
-                    # version. On an Atmos track the FLAC comes back as
-                    # HI_RES_LOSSLESS (the cascade's `max` rung); anything lower
-                    # delivered for such a track is the Atmos/AAC stream.
-                    stream_is_flac = stream.audioQuality in ("HI_RES_LOSSLESS", "LOSSLESS")
-                    if is_atmos and not stream_is_flac:
+                    # Atmos — read the DELIVERED stream's audioMode, not the track
+                    # tag. A track that HAS an Atmos version but was served a FLAC
+                    # (cascade `max`) or a degraded non-Atmos AAC must be labelled
+                    # by its real quality, not mislabelled Dolby Atmos.
+                    stream_is_atmos = str(getattr(stream, "audioMode", "") or "").upper() == "DOLBY_ATMOS"
+                    if stream_is_atmos:
                         quality = "[purple]Dolby Atmos"
                     elif stream.audioQuality in ["HI_RES_LOSSLESS", "LOSSLESS"]:
                         quality = f"{quality} {stream.bitDepth}-bit, {(stream.sampleRate or 0) / 1000:.1f} kHz"

--- a/tiddl/core/edition_resolver.py
+++ b/tiddl/core/edition_resolver.py
@@ -20,6 +20,11 @@ SUPPORTED_QUALITIES = ("low", "normal", "high", "max")
 def quality_fallback_order(requested_quality: str, policy: str = "flexible") -> tuple[str, ...]:
     """Catalog tiers to try, from the user's ceiling down to LOW."""
     quality = requested_quality.casefold()
+    # The `atmos` download rung is fetched at the LOSSLESS tier, which the
+    # catalog/edition resolver only knows as `high`; treat them the same here so
+    # `-q atmos --audio-mode stereo` resolves instead of raising ValueError.
+    if quality == "atmos":
+        quality = "high"
     if quality not in SUPPORTED_QUALITIES:
         raise ValueError(f"unsupported quality: {requested_quality}")
     if policy.casefold() == "strict":

--- a/tiddl/core/stream_policy.py
+++ b/tiddl/core/stream_policy.py
@@ -12,6 +12,7 @@ QUALITY_RANK = {
 REQUESTED_QUALITY = {
     "low": "LOW",
     "normal": "HIGH",
+    "atmos": "LOSSLESS",  # the Atmos rung is fetched at the LOSSLESS tier
     "high": "LOSSLESS",
     "max": "HI_RES_LOSSLESS",
 }
@@ -55,7 +56,14 @@ def inspect_track_stream(
             f"requested stereo but TIDAL returned {mode}",
         )
 
-    if quality_policy.casefold() == "strict" and quality != wanted:
+    # The Atmos rung has no single clean tier (its stream reports HIGH/LOSSLESS
+    # depending on the master), so an exact-tier strict check can never pass for
+    # it — skip the gate for `-q atmos` rather than always stopping the download.
+    if (
+        quality_policy.casefold() == "strict"
+        and requested_quality.casefold() != "atmos"
+        and quality != wanted
+    ):
         return StreamInspection(
             mode,
             quality,


### PR DESCRIPTION
Addresses Sourcery's review of #36: -q atmos crash with stereo, -q atmos + strict never downloading, incomplete --resume signature, and the Atmos label heuristic. 3 new tests; full suite 391 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Atmos download edge cases and make resume decisions sensitive to output-affecting settings.

Bug Fixes:
- Fix Atmos quality handling so stereo requests resolve correctly and strict quality policies do not prevent valid Atmos downloads.
- Correct download quality labels to reflect the audio mode of the delivered stream.
- Prevent resumed downloads from incorrectly skipping resources when output, video, or metadata settings have changed.

Build:
- Bump the project version to 1.5.1.

Tests:
- Add regression coverage for Atmos edition resolution and strict/flexible stream-policy behavior.