### PR TITLE
v1.5.2 — complete the --resume signature (exhaustive output-option audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-08-23
+
+### Fixed
+
+- **Complete the `--resume` signature.** Following an exhaustive audit of every
+  option that changes what a resource writes to disk (selection, content,
+  embedded metadata, standalone files, paths, names), the checkpoint signature —
+  now built by the pure `resume.job_signature()` — additionally covers
+  `--video-quality`, `--edition-match`, `--quality-policy`, `hires_client`, the
+  standalone cover file (`[cover] save/size/allowed` + its templates), `[m3u]`
+  (`save/allowed` + templates), `[metadata] enable`, and the video destination.
+  Changing any of them now starts a fresh resume instead of wrongly skipping
+  resources completed under the old settings. (Extends the 1.5.1 signature fix.)
+
 ## [1.5.1] - 2026-08-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.5.1"
+version = "1.5.2"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -3,7 +3,86 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from tiddl.core.resume import ResumeLog, compute_signature, resource_key
+import pytest
+
+from tiddl.core.resume import ResumeLog, compute_signature, job_signature, resource_key
+
+
+def _base_job():
+    """A full, valid set of job_signature() inputs to mutate one field at a time."""
+    return dict(
+        resources=["artist/1", "album/2"],
+        download_path="Z:/Music",
+        video_download_path="Z:/Videos",
+        quality="high",
+        video_quality="fhd",
+        audio_mode="auto",
+        edition_match="best",
+        quality_policy="flexible",
+        hires_client="auto",
+        expand="artists",
+        exclude_compilations=False,
+        exclude_live_albums=False,
+        singles="include",
+        videos_filter="none",
+        templates={
+            "default": "d", "track": "t", "album": "a", "playlist": "p",
+            "video": "v", "mix": "m", "artist_separator": " / ",
+        },
+        metadata={
+            "enable": True, "cover": True, "lyrics": True, "save_lyrics": False,
+            "album_review": False, "update_mtime": False, "rewrite": False,
+        },
+        cover_file={
+            "save": False, "size": 1280, "allowed": [],
+            "tpl_track": "", "tpl_album": "", "tpl_playlist": "",
+        },
+        m3u={
+            "save": False, "allowed": [],
+            "tpl_album": "", "tpl_playlist": "", "tpl_mix": "",
+        },
+    )
+
+
+def test_job_signature_is_stable():
+    assert job_signature(**_base_job()) == job_signature(**_base_job())
+
+
+# One mutation per output-affecting option/group — each MUST change the signature
+# so a resource completed under the old settings is not wrongly skipped.
+@pytest.mark.parametrize("mutate", [
+    lambda k: k.update(resources=["artist/1"]),
+    lambda k: k.update(download_path="D:/Other"),
+    lambda k: k.update(video_download_path="D:/V"),
+    lambda k: k.update(quality="max"),
+    lambda k: k.update(video_quality="hd"),
+    lambda k: k.update(audio_mode="stereo"),
+    lambda k: k.update(edition_match="ask"),
+    lambda k: k.update(quality_policy="strict"),
+    lambda k: k.update(hires_client="never"),
+    lambda k: k.update(expand="albums"),
+    lambda k: k.update(exclude_compilations=True),
+    lambda k: k.update(exclude_live_albums=True),
+    lambda k: k.update(singles="only"),
+    lambda k: k.update(videos_filter="all"),
+    lambda k: k.__setitem__("templates", {**k["templates"], "album": "CHANGED"}),
+    lambda k: k.__setitem__("templates", {**k["templates"], "artist_separator": ", "}),
+    lambda k: k.__setitem__("metadata", {**k["metadata"], "cover": False}),
+    lambda k: k.__setitem__("metadata", {**k["metadata"], "enable": False}),
+    lambda k: k.__setitem__("metadata", {**k["metadata"], "rewrite": True}),
+    lambda k: k.__setitem__("cover_file", {**k["cover_file"], "save": True}),
+    lambda k: k.__setitem__("cover_file", {**k["cover_file"], "size": 640}),
+    lambda k: k.__setitem__("cover_file", {**k["cover_file"], "allowed": ["album"]}),
+    lambda k: k.__setitem__("cover_file", {**k["cover_file"], "tpl_album": "X"}),
+    lambda k: k.__setitem__("m3u", {**k["m3u"], "save": True}),
+    lambda k: k.__setitem__("m3u", {**k["m3u"], "allowed": ["playlist"]}),
+    lambda k: k.__setitem__("m3u", {**k["m3u"], "tpl_mix": "X"}),
+])
+def test_job_signature_sensitive_to_every_output_option(mutate):
+    base = _base_job()
+    changed = _base_job()
+    mutate(changed)
+    assert job_signature(**changed) != job_signature(**base)
 
 
 def test_resource_key_format():

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -985,38 +985,65 @@ def download_callback(
         # means, BEFORE the stereo pre-pass / expansion mutate ctx.obj.resources.
         resume_log = None
         if RESUME:
-            from tiddl.core.resume import ResumeLog, compute_signature, resource_key
-            _sig = compute_signature({
-                "resources": sorted(resource_key(r) for r in ctx.obj.resources),
-                "download_path": str(DOWNLOAD_PATH),
-                "quality": TRACK_QUALITY,
-                "audio_mode": AUDIO_MODE,
-                "expand": (
+            from tiddl.core.resume import ResumeLog, job_signature, resource_key
+            # Every option that changes what a resource produces on disk goes into
+            # the signature (selection, content, metadata, standalone files, paths,
+            # names) so changing any one starts a fresh checkpoint instead of
+            # skipping resources completed under the old settings.
+            _sig = job_signature(
+                resources=[resource_key(r) for r in ctx.obj.resources],
+                download_path=DOWNLOAD_PATH,
+                video_download_path=VIDEO_DOWNLOAD_PATH,
+                quality=TRACK_QUALITY,
+                video_quality=VIDEO_QUALITY,
+                audio_mode=AUDIO_MODE,
+                edition_match=EDITION_MATCH,
+                quality_policy=QUALITY_POLICY,
+                hires_client=CONFIG.download.hires_client,
+                expand=(
                     "albums" if EXPAND_ALBUMS
                     else "tracks" if EXPAND_TRACKS
                     else "artists" if EXPAND_ARTISTS
                     else "none"
                 ),
-                "exclude_compilations": bool(CONFIG.download.exclude_compilations),
-                "exclude_live_albums": bool(CONFIG.download.exclude_live_albums),
-                "singles": SINGLES_FILTER,
-                # Everything else that changes WHAT a resource produces on disk, so
-                # a resource marked done under one template/metadata config is not
-                # wrongly skipped after the user changes them on a --resume run.
-                "templates": [
-                    CONFIG.templates.default, CONFIG.templates.track,
-                    CONFIG.templates.album, CONFIG.templates.playlist,
-                    CONFIG.templates.video, CONFIG.templates.mix,
-                    CONFIG.templates.artist_separator,
-                ],
-                "video_download_path": str(VIDEO_DOWNLOAD_PATH) if VIDEO_DOWNLOAD_PATH else "",
-                "videos_filter": VIDEOS_FILTER,
-                "metadata": [
-                    bool(CONFIG.metadata.cover), bool(CONFIG.metadata.lyrics),
-                    bool(CONFIG.metadata.save_lyrics), bool(CONFIG.metadata.album_review),
-                    bool(CONFIG.download.update_mtime), bool(REWRITE_METADATA),
-                ],
-            })
+                exclude_compilations=CONFIG.download.exclude_compilations,
+                exclude_live_albums=CONFIG.download.exclude_live_albums,
+                singles=SINGLES_FILTER,
+                videos_filter=VIDEOS_FILTER,
+                templates={
+                    "default": CONFIG.templates.default,
+                    "track": CONFIG.templates.track,
+                    "album": CONFIG.templates.album,
+                    "playlist": CONFIG.templates.playlist,
+                    "video": CONFIG.templates.video,
+                    "mix": CONFIG.templates.mix,
+                    "artist_separator": CONFIG.templates.artist_separator,
+                },
+                metadata={
+                    "enable": bool(CONFIG.metadata.enable),
+                    "cover": bool(CONFIG.metadata.cover),
+                    "lyrics": bool(CONFIG.metadata.lyrics),
+                    "save_lyrics": bool(CONFIG.metadata.save_lyrics),
+                    "album_review": bool(CONFIG.metadata.album_review),
+                    "update_mtime": bool(CONFIG.download.update_mtime),
+                    "rewrite": bool(REWRITE_METADATA),
+                },
+                cover_file={
+                    "save": bool(CONFIG.cover.save),
+                    "size": int(CONFIG.cover.size),
+                    "allowed": sorted(CONFIG.cover.allowed or []),
+                    "tpl_track": CONFIG.cover.templates.track,
+                    "tpl_album": CONFIG.cover.templates.album,
+                    "tpl_playlist": CONFIG.cover.templates.playlist,
+                },
+                m3u={
+                    "save": bool(CONFIG.m3u.save),
+                    "allowed": sorted(CONFIG.m3u.allowed or []),
+                    "tpl_album": CONFIG.m3u.templates.album,
+                    "tpl_playlist": CONFIG.m3u.templates.playlist,
+                    "tpl_mix": CONFIG.m3u.templates.mix,
+                },
+            )
             resume_log = ResumeLog(_sig).load()
             if resume_log.count:
                 ctx.obj.console.print(

--- a/tiddl/core/resume.py
+++ b/tiddl/core/resume.py
@@ -54,6 +54,59 @@ def resource_key(resource) -> str:
     return f"{resource.type}/{resource.id}"
 
 
+def job_signature(
+    *,
+    resources,
+    download_path,
+    video_download_path,
+    quality,
+    video_quality,
+    audio_mode,
+    edition_match,
+    quality_policy,
+    hires_client,
+    expand,
+    exclude_compilations,
+    exclude_live_albums,
+    singles,
+    videos_filter,
+    templates,
+    metadata,
+    cover_file,
+    m3u,
+) -> str:
+    """Signature of EVERYTHING that changes what a `--resume` resource produces on
+    disk — its selection, content, embedded metadata, standalone files, paths and
+    names. Changing any of these must start a fresh checkpoint rather than skip a
+    resource completed under the old settings. Grouped dicts (``templates``,
+    ``metadata``, ``cover_file``, ``m3u``) let callers pass the whole sub-config;
+    callers pre-sort any set-like ``allowed`` lists so the hash is stable."""
+    fields = {
+        "resources": sorted(str(r) for r in resources),
+        # destinations
+        "download_path": str(download_path or ""),
+        "video_download_path": str(video_download_path or ""),
+        # selection + content
+        "quality": quality,
+        "video_quality": video_quality,
+        "audio_mode": audio_mode,
+        "edition_match": edition_match,
+        "quality_policy": quality_policy,
+        "hires_client": hires_client,
+        "expand": expand,
+        "exclude_compilations": bool(exclude_compilations),
+        "exclude_live_albums": bool(exclude_live_albums),
+        "singles": singles,
+        "videos_filter": videos_filter,
+        # names + written outputs
+        "templates": dict(templates),
+        "metadata": dict(metadata),
+        "cover_file": dict(cover_file),
+        "m3u": dict(m3u),
+    }
+    return compute_signature(fields)
+
+
 class ResumeLog:
     """Persistent set of completed resource keys for one job signature."""
 


### PR DESCRIPTION
Follow-up to Sourcery's review of #37: the --resume signature still omitted VIDEO_QUALITY and standalone cover settings. Exhaustively audited every output-affecting option and moved the signature to a pure, fully-tested `resume.job_signature()` covering video quality, edition-match, quality-policy, hires-client, cover file (save/size/allowed + templates), m3u (save/allowed + templates), metadata.enable, and the video destination. 27 new tests; full suite 418 passed.

Waiting on Sourcery review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Complete the --resume job signature so changed output settings cannot incorrectly reuse prior checkpoints.

Bug Fixes:
- Ensure --resume starts a fresh checkpoint whenever any output-affecting download, metadata, destination, cover-file, or M3U setting changes.

Enhancements:
- Centralize resume job signature generation in a pure function covering all output-affecting options and configurations.

Build:
- Bump the project version to 1.5.2.

Documentation:
- Document the completed --resume signature coverage in the changelog.

Tests:
- Add exhaustive tests verifying resume signatures are stable and sensitive to each output-affecting option.