### PR TITLE
chore(release): prepare v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-08-25
+
+### Fixed
+
+- **A cooperative safety stop no longer terminates the host process.** When a
+  download is cancelled, or the engine trips its own safety stop on a TIDAL
+  rate-limit (429) or a flagged/blocked account (401), the run now ends by
+  **returning** a non-zero exit code instead of calling `sys.exit()` from the
+  download group's `call_on_close` teardown. `_finish_download_run()` returns the
+  code; the `run()` closure raises `click.exceptions.Exit(code)`, which the CLI
+  entry point `tiddl.cli.app:main()` maps to a non-zero `SystemExit`. Under an
+  embedded interpreter (e.g. a bundled GUI) the previous `sys.exit()` hard-killed
+  the whole host process during teardown; the exit is now catchable in-process.
+
+### Notes
+
+- **CLI behaviour is preserved.** `tiddl download …` — and `python -m tiddl …`,
+  which routes through the same `main()` — still exits non-zero on Cancel / 429 /
+  401, so scripts and CI keep the same exit codes.
+- **The matching GUI adaptation is a later, separate change.** The in-process
+  host must catch `click.exceptions.Exit` around `tiddl_app(standalone_mode=False)`;
+  that change, its engine re-pin, and the GUI rebuild/release are not part of this
+  engine release.
+
 ## [1.5.2] - 2026-08-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,25 +21,30 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ### Fixed
 
-- **A cooperative safety stop no longer terminates the host process.** When a
-  download is cancelled, or the engine trips its own safety stop on a TIDAL
-  rate-limit (429) or a flagged/blocked account (401), the run now ends by
-  **returning** a non-zero exit code instead of calling `sys.exit()` from the
-  download group's `call_on_close` teardown. `_finish_download_run()` returns the
-  code; the `run()` closure raises `click.exceptions.Exit(code)`, which the CLI
-  entry point `tiddl.cli.app:main()` maps to a non-zero `SystemExit`. Under an
-  embedded interpreter (e.g. a bundled GUI) the previous `sys.exit()` hard-killed
-  the whole host process during teardown; the exit is now catchable in-process.
+- **A cooperative safety stop no longer terminates the host process.** When a run
+  is stopped through the engine's cooperative cancellation hook
+  (`request_cancel()`, as used by the GUI), or the engine trips its own safety
+  stop on a TIDAL rate-limit (429) or a flagged/blocked account (401), the run
+  now ends by **returning** a non-zero exit code instead of calling `sys.exit()`
+  from the download group's `call_on_close` teardown. `_finish_download_run()`
+  returns the code; the `run()` closure raises `click.exceptions.Exit(code)`,
+  which the CLI entry point `tiddl.cli.app:main()` maps to a non-zero
+  `SystemExit`. Under an embedded interpreter (e.g. a bundled GUI) the previous
+  `sys.exit()` hard-killed the whole host process during teardown; the exit is now
+  catchable in-process.
 
 ### Notes
 
-- **CLI behaviour is preserved.** `tiddl download …` — and `python -m tiddl …`,
-  which routes through the same `main()` — still exits non-zero on Cancel / 429 /
-  401, so scripts and CI keep the same exit codes.
+- **CLI exit codes are preserved for cooperative stops.** On a cooperative
+  cancellation (`request_cancel()`), a rate-limit (429) or a flagged account
+  (401), `tiddl download …` — and `python -m tiddl …`, which routes through the
+  same `main()` — still exits non-zero, so scripts and CI keep the same exit
+  codes. This change concerns the cooperative-stop path only; it does not alter
+  the CLI's `Ctrl+C` / `KeyboardInterrupt` handling (a separate `run()` branch).
 - **The matching GUI adaptation is a later, separate change.** The in-process
-  host must catch `click.exceptions.Exit` around `tiddl_app(standalone_mode=False)`;
-  that change, its engine re-pin, and the GUI rebuild/release are not part of this
-  engine release.
+  host must still catch `click.exceptions.Exit` around
+  `tiddl_app(standalone_mode=False)`; that change, its engine re-pin, and the GUI
+  rebuild/release are not part of this engine release.
 
 ## [1.5.2] - 2026-08-23
 

--- a/RELEASE_NOTES_v1.5.3.md
+++ b/RELEASE_NOTES_v1.5.3.md
@@ -4,35 +4,42 @@
 
 **A cooperative safety stop no longer terminates the host process.**
 
-- Cancelling a download — or the engine's own safety stop when TIDAL
-  rate-limits the run (**429**) or flags/blocks the account (**401**) — now ends
-  the run by **returning a non-zero exit code** instead of calling `sys.exit()`
-  during teardown.
-- **The CLI is unchanged:** `tiddl download …` and `python -m tiddl …` still exit
-  non-zero on Cancel / 429 / 401, so scripts and CI keep the same exit codes.
+- A **cooperative cancellation requested through the engine's hook**
+  (`request_cancel()`, as used by the GUI) — or the engine's own safety stop when
+  TIDAL rate-limits the run (**429**) or flags/blocks the account (**401**) — now
+  ends the run by **returning a non-zero exit code** instead of calling
+  `sys.exit()` during teardown.
+- **CLI exit codes are preserved** for these cooperative stops: `tiddl download …`
+  and `python -m tiddl …` still exit non-zero on a cooperative cancellation / 429
+  / 401. This concerns the cooperative-stop path only; it does not change the
+  CLI's `Ctrl+C` / `KeyboardInterrupt` handling.
 - **Why it matters:** under an embedded interpreter (a bundled GUI), the old
   `sys.exit()` hard-killed the whole host process during teardown. The exit is
   now a normal `click.exceptions.Exit` that can be caught in-process.
-- **The matching GUI adaptation is a later, separate step:** catching that exit
-  in-process, re-pinning the bundled engine, and rebuilding/publishing the GUI
-  are not part of this engine release.
+- **The matching GUI adaptation is a later, separate step:** the in-process host
+  must still catch that `click.exceptions.Exit` around
+  `tiddl_app(standalone_mode=False)`; re-pinning the bundled engine and
+  rebuilding/publishing the GUI are not part of this engine release.
 
 ## 🇪🇸 Novedades
 
 **Una parada de seguridad cooperativa ya no termina el proceso anfitrión.**
 
-- Cancelar una descarga —o la parada de seguridad del propio motor cuando TIDAL
-  limita la tasa de la corrida (**429**) o marca/bloquea la cuenta (**401**)—
-  ahora finaliza la corrida **devolviendo un código de salida no cero** en lugar
-  de llamar a `sys.exit()` durante el cierre.
-- **El CLI no cambia:** `tiddl download …` y `python -m tiddl …` siguen saliendo
-  con código no cero ante Cancel / 429 / 401, así que los scripts y la CI
-  conservan los mismos códigos de salida.
+- Una **cancelación cooperativa solicitada mediante el hook del motor**
+  (`request_cancel()`, como la usa la GUI) —o la parada de seguridad del propio
+  motor cuando TIDAL limita la tasa de la corrida (**429**) o marca/bloquea la
+  cuenta (**401**)— ahora finaliza la corrida **devolviendo un código de salida
+  no cero** en lugar de llamar a `sys.exit()` durante el cierre.
+- **Se conservan los códigos de salida del CLI** ante estas paradas cooperativas:
+  `tiddl download …` y `python -m tiddl …` siguen saliendo con código no cero ante
+  una cancelación cooperativa / 429 / 401. Esto atañe solo al camino de parada
+  cooperativa; no cambia el manejo de `Ctrl+C` / `KeyboardInterrupt` del CLI.
 - **Por qué importa:** bajo un intérprete embebido (una GUI empaquetada), el
   `sys.exit()` anterior mataba de golpe todo el proceso anfitrión durante el
   cierre. Ahora la salida es un `click.exceptions.Exit` normal que puede
   capturarse dentro del proceso.
 - **La adaptación correspondiente de la GUI es un paso posterior e
-  independiente:** capturar esa salida en el proceso, re-fijar el pin del motor
-  empaquetado y reconstruir/publicar la GUI no forman parte de esta versión del
-  motor.
+  independiente:** el host en proceso todavía debe capturar ese
+  `click.exceptions.Exit` alrededor de `tiddl_app(standalone_mode=False)`;
+  re-fijar el pin del motor empaquetado y reconstruir/publicar la GUI no forman
+  parte de esta versión del motor.

--- a/RELEASE_NOTES_v1.5.3.md
+++ b/RELEASE_NOTES_v1.5.3.md
@@ -1,0 +1,38 @@
+# tiddl-elvigilante v1.5.3
+
+## 🇬🇧 What's new
+
+**A cooperative safety stop no longer terminates the host process.**
+
+- Cancelling a download — or the engine's own safety stop when TIDAL
+  rate-limits the run (**429**) or flags/blocks the account (**401**) — now ends
+  the run by **returning a non-zero exit code** instead of calling `sys.exit()`
+  during teardown.
+- **The CLI is unchanged:** `tiddl download …` and `python -m tiddl …` still exit
+  non-zero on Cancel / 429 / 401, so scripts and CI keep the same exit codes.
+- **Why it matters:** under an embedded interpreter (a bundled GUI), the old
+  `sys.exit()` hard-killed the whole host process during teardown. The exit is
+  now a normal `click.exceptions.Exit` that can be caught in-process.
+- **The matching GUI adaptation is a later, separate step:** catching that exit
+  in-process, re-pinning the bundled engine, and rebuilding/publishing the GUI
+  are not part of this engine release.
+
+## 🇪🇸 Novedades
+
+**Una parada de seguridad cooperativa ya no termina el proceso anfitrión.**
+
+- Cancelar una descarga —o la parada de seguridad del propio motor cuando TIDAL
+  limita la tasa de la corrida (**429**) o marca/bloquea la cuenta (**401**)—
+  ahora finaliza la corrida **devolviendo un código de salida no cero** en lugar
+  de llamar a `sys.exit()` durante el cierre.
+- **El CLI no cambia:** `tiddl download …` y `python -m tiddl …` siguen saliendo
+  con código no cero ante Cancel / 429 / 401, así que los scripts y la CI
+  conservan los mismos códigos de salida.
+- **Por qué importa:** bajo un intérprete embebido (una GUI empaquetada), el
+  `sys.exit()` anterior mataba de golpe todo el proceso anfitrión durante el
+  cierre. Ahora la salida es un `click.exceptions.Exit` normal que puede
+  capturarse dentro del proceso.
+- **La adaptación correspondiente de la GUI es un paso posterior e
+  independiente:** capturar esa salida en el proceso, re-fijar el pin del motor
+  empaquetado y reconstruir/publicar la GUI no forman parte de esta versión del
+  motor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.5.2"
+version = "1.5.3"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Scope

Release **preparation** for engine **v1.5.3**. Bundles the host-safe
cooperative-stop fix already merged to `main` (#39) under a version number.

**Changes (no functional code changes):**
- `pyproject.toml`: version `1.5.2` → `1.5.3` (the single authoritative source).
- `CHANGELOG.md`: new `## [1.5.3]` section.
- `RELEASE_NOTES_v1.5.3.md`: bilingual release notes (What's new / Novedades).

## What v1.5.3 ships (from #39)

- A cooperative safety stop — **Cancel**, a TIDAL rate-limit (**429**), or a
  flagged/blocked account (**401**) — no longer terminates the host process. The
  engine **returns** a non-zero exit code instead of calling `sys.exit()` from the
  download group's `call_on_close` teardown.
- **CLI behaviour preserved:** `tiddl download …` and `python -m tiddl …` still
  exit non-zero on Cancel / 429 / 401.
- **The matching GUI adaptation is later and separate** (catch the exit in-process
  around `tiddl_app(standalone_mode=False)`, re-pin the bundled engine, rebuild).

## Verification (local)

- Full suite: **433 passed, 3 skipped**.
- `compileall` 3.10 **and** 3.13: OK.
- Lockfile in sync (in-place compile → no diff).
- Ruff: informational in CI; no Python changed here, so no delta vs `main`.
- Only the version bump changes code; `git diff` excluding CHANGELOG/notes shows
  just `version = "1.5.2" → "1.5.3"`.

## Not part of this PR / not yet authorized

Merging this PR, creating a tag/release or publishing v1.5.3, installing the
engine, modifying the GUI or its pin, rebuilding/publishing GUI 1.0.22, and Phase 2
(subprocess isolation) are all separate, later, explicitly-authorized steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prepare the v1.5.3 engine release with updated version metadata and documentation for the cooperative-stop fix.

Documentation:
- Add bilingual v1.5.3 release notes and document cooperative-stop behavior and release scope in the changelog.

Chores:
- Bump the project version from 1.5.2 to 1.5.3.