### PR TITLE
fix(download): stop HTTP 429 storms from the `high` regression (05b1eca)

### DIFF
--- a/tests/test_download_policy.py
+++ b/tests/test_download_policy.py
@@ -15,19 +15,47 @@ class ResponseError(Exception):
         self.response = SimpleNamespace(status_code=status)
 
 
-def test_session_limit_warns_only_once_for_remaining_scheduled_tracks():
+def test_session_limit_counts_new_downloads_and_warns_once():
+    # New semantic: the cap counts NEW downloads (record), not admitted tracks.
+    # A track is admitted, downloaded, recorded; once the quota of downloads is
+    # used up the gate closes and warns exactly once.
     policy = SessionTrackLimit(limit=1)
 
+    assert policy.admit() == (True, False)      # under quota -> admitted
+    assert not policy.is_reached()
+    policy.record(was_downloaded=True)          # the one allowed NEW download
+    assert policy.is_reached()                  # quota used -> run-wide signal
+    assert policy.admit() == (False, True)      # now closed, announce once
+    assert policy.admit() == (False, False)
+    assert policy.admit() == (False, False)
+
+
+def test_existing_files_do_not_consume_the_cap():
+    # Already-present tracks (was_downloaded=False) must NOT eat the quota, so a
+    # run over a mostly-downloaded library keeps working on the missing tracks.
+    policy = SessionTrackLimit(limit=2)
+
     assert policy.admit() == (True, False)
+    policy.record(was_downloaded=False)         # already on disk -> no charge
+    policy.record(was_downloaded=False)
+    assert not policy.is_reached()
+    assert policy.admit() == (True, False)      # still open after two skips
+    policy.record(was_downloaded=True)          # 1st real download
+    assert not policy.is_reached()
+    policy.record(was_downloaded=True)          # 2nd real download -> quota used
+    assert policy.is_reached()
     assert policy.admit() == (False, True)
-    assert policy.admit() == (False, False)
-    assert policy.admit() == (False, False)
 
 
 def test_zero_session_limit_is_unlimited():
     policy = SessionTrackLimit(limit=0)
 
     assert [policy.admit() for _ in range(3)] == [(True, False)] * 3
+    # record is a no-op when disabled and never latches the signal.
+    for _ in range(5):
+        policy.record(was_downloaded=True)
+    assert not policy.is_reached()
+    assert policy.admit() == (True, False)
 
 
 def test_http_401_is_authentication_not_rate_limit():

--- a/tests/test_download_policy.py
+++ b/tests/test_download_policy.py
@@ -15,47 +15,46 @@ class ResponseError(Exception):
         self.response = SimpleNamespace(status_code=status)
 
 
-def test_session_limit_counts_new_downloads_and_warns_once():
-    # New semantic: the cap counts NEW downloads (record), not admitted tracks.
-    # A track is admitted, downloaded, recorded; once the quota of downloads is
-    # used up the gate closes and warns exactly once.
+async def test_session_limit_counts_new_downloads_and_warns_once():
+    # The cap counts NEW downloads (commit), not admitted tracks. A track is
+    # reserved, downloaded, committed; the commit that reaches the cap latches the
+    # signal and returns the one-shot warning flag.
     policy = SessionTrackLimit(limit=1)
 
-    assert policy.admit() == (True, False)      # under quota -> admitted
+    assert await policy.reserve() is True       # under quota -> reserved
     assert not policy.is_reached()
-    policy.record(was_downloaded=True)          # the one allowed NEW download
+    assert policy.commit() is True              # the one allowed NEW download
     assert policy.is_reached()                  # quota used -> run-wide signal
-    assert policy.admit() == (False, True)      # now closed, announce once
-    assert policy.admit() == (False, False)
-    assert policy.admit() == (False, False)
+    assert await policy.reserve() is False      # now closed
+    assert await policy.reserve() is False
 
 
-def test_existing_files_do_not_consume_the_cap():
-    # Already-present tracks (was_downloaded=False) must NOT eat the quota, so a
-    # run over a mostly-downloaded library keeps working on the missing tracks.
+async def test_existing_files_release_their_reservation_without_charge():
+    # An already-present track releases its reserved slot (was_downloaded=False)
+    # and does NOT eat the quota, so a run over a mostly-downloaded library keeps
+    # working on the missing tracks.
     policy = SessionTrackLimit(limit=2)
 
-    assert policy.admit() == (True, False)
-    policy.record(was_downloaded=False)         # already on disk -> no charge
-    policy.record(was_downloaded=False)
+    assert await policy.reserve() is True
+    policy.release()                            # already on disk -> slot back
     assert not policy.is_reached()
-    assert policy.admit() == (True, False)      # still open after two skips
-    policy.record(was_downloaded=True)          # 1st real download
-    assert not policy.is_reached()
-    policy.record(was_downloaded=True)          # 2nd real download -> quota used
+    assert await policy.reserve() is True       # still open after the release
+    assert policy.commit() is False             # downloaded=1 < 2
+    assert await policy.reserve() is True
+    assert policy.commit() is True              # downloaded=2 == 2 -> reached
     assert policy.is_reached()
-    assert policy.admit() == (False, True)
 
 
-def test_zero_session_limit_is_unlimited():
+async def test_zero_session_limit_is_unlimited():
     policy = SessionTrackLimit(limit=0)
 
-    assert [policy.admit() for _ in range(3)] == [(True, False)] * 3
-    # record is a no-op when disabled and never latches the signal.
+    for _ in range(3):
+        assert await policy.reserve() is True
+    # commit/release are no-ops when disabled and never latch the signal.
     for _ in range(5):
-        policy.record(was_downloaded=True)
+        assert policy.commit() is False
     assert not policy.is_reached()
-    assert policy.admit() == (True, False)
+    assert await policy.reserve() is True
 
 
 def test_http_401_is_authentication_not_rate_limit():

--- a/tests/test_enumeration_client_routing.py
+++ b/tests/test_enumeration_client_routing.py
@@ -1,0 +1,253 @@
+"""Enumeration must stay on the lenient TV client for `high + auto`.
+
+The user's real 429 reproduction was `--artists`, not `--albums`, on the same
+playlist. Root cause (baseline 05b1eca): `high + auto` promoted the WHOLE run to
+the strict HiRes client, and `--artists` enumerates every credited artist's FULL
+discography (`get_artist_albums` + `get_album_items` per album — see resume.py),
+hammering that strict client far harder than `--albums` (only the albums the
+playlist lists). `--resume` skips already-done resources BEFORE any API call, so
+`--albums --resume` stayed quiet — which is exactly why the amplifier is the
+artist FAN-OUT, not `--resume`.
+
+These pin the fixed behaviour at the reachable seams:
+* the playlist expansion (`_expand_playlist_resources`) — modes + fan-out, all on
+  the passed API;
+* the client identity per phase — `ctx.obj.api` (all enumeration) is TV in
+  high+auto; the HiRes client is a distinct secondary reachable only via
+  `hires_api` for a per-track Max stream;
+* `--resume` reduces API calls on the second run (never increases).
+"""
+from __future__ import annotations
+
+import asyncio
+
+from tiddl.cli.commands.download import _expand_playlist_resources, _resolve_prefer_hires
+from tiddl.core.resume import ResumeLog, resource_key
+
+
+# --------------------------------------------------------------------------
+# Fakes for the playlist-expansion phase.
+# --------------------------------------------------------------------------
+def _track(track_id, album_id, artist_ids):
+    from tiddl.core.api.models import Track
+
+    artists = [{"id": a, "name": f"A{a}", "type": "MAIN"} for a in artist_ids]
+    return Track(
+        id=track_id, title=f"T{track_id}", duration=180, replayGain=0.0, peak=1.0,
+        allowStreaming=True, streamReady=True, adSupportedStreamReady=True,
+        djReady=True, stemReady=True, premiumStreamingOnly=False,
+        trackNumber=1, volumeNumber=1, popularity=1, url="http://t",
+        editable=True, explicit=False, audioQuality="LOSSLESS", audioModes=[],
+        mediaMetadata={"tags": ["LOSSLESS"]},
+        artist=artists[0], artists=artists,
+        album={"id": album_id, "title": f"Alb{album_id}", "vibrantColor": "#fff"},
+    )
+
+
+class _FakePlaylistItem:
+    def __init__(self, item):
+        self.item = item
+
+
+class _FakePage:
+    def __init__(self, items, limit, total):
+        self.items = items
+        self.limit = limit
+        self.totalNumberOfItems = total
+
+
+class _FakePlaylistAPI:
+    """Records every call; serves the playlist items in pages of `page_size`."""
+
+    def __init__(self, tracks, *, page_size=100, title="PL"):
+        self._tracks = tracks
+        self._page_size = page_size
+        self._title = title
+        self.calls: list = []
+
+    def get_playlist(self, playlist_uuid):
+        self.calls.append(("get_playlist", playlist_uuid))
+        return type("P", (), {"title": self._title})()
+
+    def get_playlist_items(self, playlist_uuid, offset=0):
+        self.calls.append(("get_playlist_items", playlist_uuid, offset))
+        window = self._tracks[offset:offset + self._page_size]
+        return _FakePage(
+            [_FakePlaylistItem(t) for t in window],
+            limit=self._page_size, total=len(self._tracks),
+        )
+
+
+# A playlist whose tracks span 3 albums but 4 distinct credited artists (one
+# collaboration), so the mode-specific dedupe is observable.
+def _sample_tracks():
+    return [
+        _track(1, album_id=100, artist_ids=[10, 11]),  # album 100, artists 10 & 11
+        _track(2, album_id=100, artist_ids=[10]),      # same album, artist 10
+        _track(3, album_id=101, artist_ids=[12]),      # album 101, artist 12
+        _track(4, album_id=102, artist_ids=[10, 13]),  # album 102, artists 10 & 13
+    ]
+
+
+def _expand(api, *, albums, tracks):
+    return asyncio.run(
+        _expand_playlist_resources(api, "PL-UUID", expand_albums=albums, expand_tracks=tracks)
+    )
+
+
+def test_expand_albums_yields_unique_albums():
+    api = _FakePlaylistAPI(_sample_tracks())
+    resources, skipped, title = _expand(api, albums=True, tracks=False)
+    assert {(r.type, r.id) for r in resources} == {
+        ("album", "100"), ("album", "101"), ("album", "102")
+    }
+    assert skipped == 0 and title == "PL"
+
+
+def test_expand_artists_yields_unique_credited_artists():
+    api = _FakePlaylistAPI(_sample_tracks())
+    resources, _, _ = _expand(api, albums=False, tracks=False)
+    assert {(r.type, r.id) for r in resources} == {
+        ("artist", "10"), ("artist", "11"), ("artist", "12"), ("artist", "13")
+    }
+
+
+def test_expand_tracks_yields_unique_tracks():
+    api = _FakePlaylistAPI(_sample_tracks())
+    resources, _, _ = _expand(api, albums=False, tracks=True)
+    assert {(r.type, r.id) for r in resources} == {
+        ("track", "1"), ("track", "2"), ("track", "3"), ("track", "4")
+    }
+
+
+def test_artists_fan_out_at_least_as_wide_and_feed_discography_enumeration():
+    # --artists resolves to the credited-artist set; each of those artist
+    # resources is later enumerated into its WHOLE discography (get_artist_albums
+    # + get_album_items per album — resume.py), whereas each --albums resource is
+    # a single album enumeration. So even when the RESOURCE counts are close, the
+    # downstream API volume of --artists dwarfs --albums — the real 429 amplifier.
+    api = _FakePlaylistAPI(_sample_tracks())
+    albums, _, _ = _expand(api, albums=True, tracks=False)
+    api2 = _FakePlaylistAPI(_sample_tracks())
+    artists, _, _ = _expand(api2, albums=False, tracks=False)
+    assert len(artists) >= len(albums)
+    assert all(r.type == "artist" for r in artists)
+    assert all(r.type == "album" for r in albums)
+
+
+def test_expansion_only_calls_playlist_endpoints_on_the_given_api():
+    # The expansion touches ONLY get_playlist / get_playlist_items, and only on
+    # the api it was handed — in production ctx.obj.api, the TV client for
+    # high+auto. It never reaches for another client.
+    api = _FakePlaylistAPI(_sample_tracks())
+    _expand(api, albums=False, tracks=False)
+    assert {c[0] for c in api.calls} == {"get_playlist", "get_playlist_items"}
+
+
+def test_expansion_paginates_across_pages():
+    api = _FakePlaylistAPI(_sample_tracks(), page_size=2)  # 4 tracks -> 2 pages
+    resources, _, _ = _expand(api, albums=True, tracks=False)
+    offsets = [c[2] for c in api.calls if c[0] == "get_playlist_items"]
+    assert offsets == [0, 2]  # walked both pages
+    assert {r.id for r in resources} == {"100", "101", "102"}
+
+
+# --------------------------------------------------------------------------
+# Client identity per phase: all enumeration on TV; HiRes is a distinct secondary.
+# --------------------------------------------------------------------------
+class _RecProxy:
+    """Stand-in TidalAPI that records (kind, method) for every attribute call."""
+
+    def __init__(self, kind, log):
+        self._kind = kind
+        self._log = log
+
+    def __getattr__(self, name):
+        def _call(*a, **k):
+            self._log.append((self._kind, name))
+            return None
+        return _call
+
+
+def test_high_auto_every_enumeration_phase_uses_tv_hires_is_secondary_only(monkeypatch):
+    from rich.console import Console
+
+    from tiddl.cli.ctx import ContextObject
+    from tiddl.cli.utils.auth.core import AUTH_FALLBACK_FILE
+
+    log: list = []
+    ctx = ContextObject(api_omit_cache=False, debug_path=None, console=Console())
+    ctx.prefer_hires = _resolve_prefer_hires("high", "auto")  # False -> TV primary
+
+    def fake_build(auth_file, *a, **k):
+        kind = "tv" if auth_file == AUTH_FALLBACK_FILE else "hires"
+        return _RecProxy(kind, log)
+
+    monkeypatch.setattr(ctx, "_build_api", fake_build)
+
+    # Every enumeration phase goes through ctx.obj.api (playlist, artist, album,
+    # credits, track), which in high+auto is the TV client.
+    enum_api = ctx.api
+    for method in (
+        "get_playlist", "get_playlist_items",         # playlist
+        "get_artist", "get_artist_albums", "get_artist_toptracks",  # artist
+        "get_album", "get_album_items_credits", "get_album_review",  # album/credits
+        "get_track", "get_track_credits", "get_track_lyrics",        # track
+    ):
+        getattr(enum_api, method)()
+    assert log and all(kind == "tv" for kind, _ in log)
+
+    # The HiRes client is a DISTINCT secondary, reachable only via hires_api (the
+    # per-track Max ascent); the LOSSLESS fallback is absent in TV-primary mode.
+    hires = ctx.hires_api
+    assert isinstance(hires, _RecProxy) and hires._kind == "hires"
+    assert enum_api is not hires
+    assert ctx.fallback_api is None
+
+
+# --------------------------------------------------------------------------
+# --resume reduces API calls on the second run (never increases).
+# --------------------------------------------------------------------------
+def test_resume_skips_done_resources_with_zero_calls_second_run(tmp_path):
+    # Mirrors wrapper(): a resource marked done in a prior run is skipped BEFORE
+    # any API call. First run enumerates all; second run (same signature) skips
+    # them all -> zero calls, strictly fewer than the first.
+    sig = "sig-artists-run"
+    resources = [
+        type("R", (), {"type": "artist", "id": str(i)})() for i in (10, 11, 12, 13)
+    ]
+
+    def run(resume_enabled):
+        log = ResumeLog(sig, base_dir=tmp_path).load()
+        api_calls = 0
+        for r in resources:
+            key = resource_key(r)
+            if resume_enabled and log.is_done(key):
+                continue  # skipped before any API call (the wrapper contract)
+            api_calls += 1  # stands for this resource's enumeration API traffic
+            log.mark_done(key)
+        return api_calls
+
+    first = run(resume_enabled=True)          # cold checkpoint -> enumerates all 4
+    second = run(resume_enabled=True)         # warm checkpoint -> skips all 4
+    assert first == 4
+    assert second == 0
+    assert second <= first  # --resume never INCREASES calls on the second run
+
+
+def test_without_resume_reprocesses_every_resource(tmp_path):
+    # Control: without --resume the checkpoint is ignored, so the second run does
+    # the same work as the first (this is the API storm --resume exists to avoid).
+    sig = "sig-no-resume"
+    resources = [type("R", (), {"type": "artist", "id": str(i)})() for i in (1, 2, 3)]
+
+    def run():
+        log = ResumeLog(sig, base_dir=tmp_path).load()
+        calls = 0
+        for r in resources:
+            calls += 1
+            log.mark_done(resource_key(r))
+        return calls
+
+    assert run() == 3
+    assert run() == 3  # no --resume -> reprocessed, never fewer than needed

--- a/tests/test_hires_429_regression.py
+++ b/tests/test_hires_429_regression.py
@@ -13,8 +13,20 @@ All offline and deterministic: the budget takes an injected clock, and the
 routing/order is asserted through the same pure helpers the downloader uses, so
 each attempt is recorded as (client_kind, quality).
 """
+import sqlite3
+import types
+from pathlib import Path
+
+import pytest
+
+import tiddl.cli.commands.download.downloader as dl
 from tiddl.cli.commands.download import _resolve_prefer_hires
-from tiddl.cli.commands.download.downloader import _pick_stream_client
+from tiddl.cli.commands.download.downloader import (
+    _hires_capable,
+    _pick_stream_client,
+    _supported_attempts,
+)
+from tiddl.core import cancel
 from tiddl.core.api.budget import SharedRequestBudget
 from tiddl.core.quality_cascade import cascade_api_qualities
 
@@ -96,6 +108,30 @@ def test_pick_client_max_rung_without_secondary_uses_primary():
     # HI_RES_LOSSLESS itself (or, for `never`, HI_RES_LOSSLESS is never requested).
     client, kind = _pick_stream_client("HI_RES_LOSSLESS", "PRIMARY", "hires", None)
     assert client == "PRIMARY" and kind == "hires"
+
+
+# ===========================================================================
+# 2b. Capability/policy filter — HI_RES_LOSSLESS dropped when no HiRes client
+# ===========================================================================
+def test_hires_capable_matrix():
+    assert _hires_capable("hires", None) is True          # HiRes is primary
+    assert _hires_capable("tv", object()) is True         # secondary HiRes present
+    assert _hires_capable("tv", None) is False            # never / no HiRes token
+
+
+def test_supported_attempts_drops_max_when_no_hires_client():
+    # never, or high+auto without a HiRes token: HI_RES_LOSSLESS must be removed,
+    # NOT routed to TV. The remaining tiers are kept in order.
+    qs = ["HI_RES_LOSSLESS", "LOSSLESS", "HIGH", "LOW"]
+    assert _supported_attempts(qs, "tv", None) == ["LOSSLESS", "HIGH", "LOW"]
+
+
+def test_supported_attempts_keeps_max_with_a_hires_client():
+    qs = ["HI_RES_LOSSLESS", "LOSSLESS", "HIGH", "LOW"]
+    # secondary HiRes present (high+auto with token)…
+    assert _supported_attempts(qs, "tv", object()) == qs
+    # …or HiRes primary (max/always).
+    assert _supported_attempts(qs, "hires", None) == qs
 
 
 # ===========================================================================
@@ -202,20 +238,29 @@ def test_two_contexts_have_independent_budgets():
     assert sum(s for s in c2.sleeps if s > 0) == 0.0  # its first request is free
 
 
-def test_budget_refund_returns_the_slot_for_cache_hits():
-    # A "request" served from cache consumes no quota: refund gives the slot back
-    # and does not count toward the combined total.
+def test_budget_has_no_backward_rollback_api():
+    # A concurrent cache hit must never be able to roll the spacing clock back.
+    # The old refund() did exactly that (set _last = now - interval), which under
+    # concurrency could erase a reservation another thread already made. It is
+    # gone: there is deliberately no public method to move _last backward.
+    b = _budget(60, _Clock())
+    assert not hasattr(b, "refund")
+
+
+def test_budget_cache_hit_between_requests_preserves_spacing():
+    # The client peeks the cache BEFORE throttle, so a true cache hit simply never
+    # calls the budget. Simulate two real requests with a cache hit in between
+    # (which touches nothing): the second real request must still wait the full
+    # interval — the cache hit cannot let it burst.
     c = _Clock()
-    b = _budget(60, c)
-    b.throttle()
-    b.throttle()
+    b = _budget(60, c)  # interval 1.0s
+    b.throttle()               # first real request (free)
+    # ... a cache hit happens here: by contract it calls neither throttle nor any
+    # rollback, so the budget state is untouched ...
+    c.advance(0.2)             # only 0.2s elapsed since the first request
+    b.throttle()               # second real request must wait the remaining 0.8s
     assert b.request_count == 2
-    b.refund()
-    assert b.request_count == 1
-    # after a refund the next real request may proceed immediately.
-    before = len([s for s in c.sleeps if s > 0])
-    b.throttle()
-    assert len([s for s in c.sleeps if s > 0]) == before  # no extra wait
+    assert sum(s for s in c.sleeps if s > 0) == pytest.approx(0.8)
 
 
 # ===========================================================================
@@ -280,3 +325,243 @@ def test_high_auto_enumeration_uses_tv_primary(monkeypatch):
     )
     _ = ctx2.api
     assert used2 and used2[0] == AUTH_DATA_FILE
+
+
+# ===========================================================================
+# 8. Effective RPM — the budget is built AFTER the --rpm CLI override resolves
+# ===========================================================================
+def test_configure_request_budget_uses_effective_rpm():
+    # The budget must reflect the EFFECTIVE requests_per_minute (config + any
+    # --rpm override), not whatever the config held at ContextObject creation.
+    from rich.console import Console
+
+    from tiddl.cli.ctx import ContextObject
+
+    ctx = ContextObject(api_omit_cache=False, debug_path=None, console=Console())
+    # Simulate the download command applying `--rpm 120` and then wiring it in.
+    ctx.configure_request_budget(120)
+    assert ctx.request_budget.interval == pytest.approx(60.0 / 120)
+    # Re-resolving (e.g. a different effective value) replaces it cleanly.
+    ctx.configure_request_budget(30)
+    assert ctx.request_budget.interval == pytest.approx(60.0 / 30)
+
+
+def test_request_budget_lazy_default_reads_config():
+    # A command that never touches --rpm gets a budget spaced at the config value,
+    # created lazily on first access.
+    from rich.console import Console
+
+    from tiddl.cli.config import CONFIG
+    from tiddl.cli.ctx import ContextObject
+
+    ctx = ContextObject(api_omit_cache=False, debug_path=None, console=Console())
+    assert ctx._request_budget is None  # not built eagerly
+    expected = 60.0 / max(1, CONFIG.download.requests_per_minute)
+    assert ctx.request_budget.interval == pytest.approx(expected)
+
+
+# ===========================================================================
+# 9. REAL Downloader.download() with fake clients — the actual call sequence
+# ===========================================================================
+# These drive the real cascade/routing/de-dup/filter of Downloader.download()
+# against fake TIDAL clients that RECORD every get_track_stream(kind, quality)
+# call. Only the non-routing collaborators (media transfer, manifest parse,
+# stream inspection, tagging, DB, filesystem) are stubbed — the clients under
+# assertion are the fakes, so the observed calls are the real routing decisions.
+class _StubOut:
+    def __init__(self):
+        self.console = types.SimpleNamespace(print=lambda *a, **k: None)
+
+    def download_start(self, desc):
+        return 1
+
+    def download_finish(self, task_id=None):
+        return types.SimpleNamespace(description="d")
+
+    def show_item_result(self, **k):
+        pass
+
+
+class _FakeAPI:
+    """Stand-in for TidalAPI: records (kind, quality) per stream request and
+    returns a fake manifest whose delivered quality comes from `deliver`
+    (dict quality->delivered, or None to raise a non-429/401 failure)."""
+
+    def __init__(self, kind, calls, deliver):
+        self.kind = kind
+        self._calls = calls
+        self._deliver = deliver
+        self.country_code = "US"
+        self.client = types.SimpleNamespace(
+            session=types.SimpleNamespace(headers={})
+        )
+
+    def get_track_stream(self, track_id, quality):
+        self._calls.append((self.kind, quality))
+        delivered = self._deliver.get(quality)
+        if delivered is None:
+            raise RuntimeError(f"no stream for {quality}")
+        return types.SimpleNamespace(
+            audioQuality=delivered, audioMode="", bitDepth=16, sampleRate=44100
+        )
+
+
+def _make_track(*, tags, audio_modes=None, quality="LOSSLESS", track_id=101):
+    from tiddl.core.api.models import Track
+
+    return Track(
+        id=track_id, title="T", duration=180, replayGain=0.0, peak=1.0,
+        allowStreaming=True, streamReady=True, adSupportedStreamReady=True,
+        djReady=True, stemReady=True, premiumStreamingOnly=False,
+        trackNumber=1, volumeNumber=1, popularity=1, url="http://t",
+        editable=True, explicit=False, audioQuality=quality,
+        audioModes=audio_modes or [], mediaMetadata={"tags": tags},
+        artist={"id": 1, "name": "A", "type": "MAIN"},
+        artists=[{"id": 1, "name": "A", "type": "MAIN"}],
+        album={"id": 9, "title": "Alb", "vibrantColor": "#fff"},
+    )
+
+
+@pytest.fixture
+def dl_env(tmp_path, monkeypatch):
+    """Stub every non-routing collaborator so download() runs its real cascade
+    to a clean success without touching the network/disk/DB machinery."""
+    cancel.clear()
+
+    async def _ok_retry(self, task, urls, task_id):
+        return True
+
+    async def _no_cache(self, p):
+        return False
+
+    monkeypatch.setattr(dl.Downloader, "_download_with_retry", _ok_retry)
+    monkeypatch.setattr(dl.Downloader, "_is_file_in_cache", _no_cache)
+    monkeypatch.setattr(
+        dl.Downloader, "_init_db",
+        lambda self: sqlite3.connect(":memory:", check_same_thread=False),
+    )
+    monkeypatch.setattr(dl.Downloader, "_spawn_bg", lambda self, coro: None)
+
+    monkeypatch.setattr(
+        dl, "inspect_track_stream",
+        lambda *a, **k: types.SimpleNamespace(accepted=True, reason="ok"),
+    )
+    monkeypatch.setattr(dl, "parse_track_stream", lambda stream: (["http://u"], None))
+    monkeypatch.setattr(
+        dl, "get_existing_track_filename", lambda *a, **k: Path("A - T.flac")
+    )
+    monkeypatch.setattr(dl, "_prepare_long_path", lambda s: s)
+    monkeypatch.setattr(dl, "extract_flac", lambda p: p)
+    monkeypatch.setattr(dl, "is_mp4_container", lambda p: False)
+    monkeypatch.setattr(dl, "report_playback", lambda **k: None)
+
+    def _mkdir(root, path, mode):
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        return types.SimpleNamespace(reason="off", anchor_id=None)
+
+    monkeypatch.setattr(dl, "_guarded_mkdir", _mkdir)
+    yield tmp_path
+    cancel.clear()
+
+
+def _make_downloader(tmp_path, *, primary, primary_kind, hires_api, fallback_api, quality):
+    return dl.Downloader(
+        tidal_api=primary,
+        threads_count=1,
+        rich_output=_StubOut(),
+        track_quality=quality,
+        video_quality="hd",
+        videos_filter="include",
+        skip_existing=False,
+        download_path=tmp_path,
+        scan_path=tmp_path,
+        video_download_path=None,
+        fallback_api=fallback_api,
+        hires_api=hires_api,
+        primary_client_kind=primary_kind,
+    )
+
+
+async def _run(tmp_path, item, *, primary, primary_kind, hires_api=None, fallback_api=None,
+               quality="high"):
+    d = _make_downloader(
+        tmp_path, primary=primary, primary_kind=primary_kind,
+        hires_api=hires_api, fallback_api=fallback_api, quality=quality,
+    )
+    try:
+        path, ok = await d.download(item, file_path=tmp_path / "A - T")
+    finally:
+        await d.close()
+    return path, ok
+
+
+async def test_download_high_normal_exactly_one_tv_lossless(dl_env):
+    # High + auto, ordinary Lossless track: exactly ONE stream request, TV/LOSSLESS.
+    calls: list = []
+    tv = _FakeAPI("tv", calls, {"LOSSLESS": "LOSSLESS"})
+    hires = _FakeAPI("hires", calls, {})  # present but must NOT be called
+    _, ok = await _run(
+        dl_env, _make_track(tags=["LOSSLESS"]),
+        primary=tv, primary_kind="tv", hires_api=hires, quality="high",
+    )
+    assert ok is True
+    assert calls == [("tv", "LOSSLESS")]
+
+
+async def test_download_high_atmos_exactly_one_hires_call(dl_env):
+    # High + auto, Atmos track whose only FLAC is 24-bit: exactly ONE HiRes call
+    # (the per-track ascent), and it succeeds — the run is not converted to HiRes.
+    calls: list = []
+    tv = _FakeAPI("tv", calls, {})
+    hires = _FakeAPI("hires", calls, {"HI_RES_LOSSLESS": "HI_RES_LOSSLESS"})
+    _, ok = await _run(
+        dl_env, _make_track(tags=["DOLBY_ATMOS", "HIRES_LOSSLESS"], quality="HI_RES_LOSSLESS"),
+        primary=tv, primary_kind="tv", hires_api=hires, quality="high",
+    )
+    assert ok is True
+    assert calls == [("hires", "HI_RES_LOSSLESS")]
+
+
+async def test_download_never_zero_hires_zero_hires_quality(dl_env):
+    # never: no HiRes client is even built; an Atmos/Max track is only ever asked
+    # on TV, and HI_RES_LOSSLESS is never requested of anyone.
+    calls: list = []
+    tv = _FakeAPI("tv", calls, {"LOSSLESS": "LOSSLESS"})
+    _, ok = await _run(
+        dl_env, _make_track(tags=["DOLBY_ATMOS", "HIRES_LOSSLESS"], quality="HI_RES_LOSSLESS"),
+        primary=tv, primary_kind="tv", hires_api=None, quality="high",
+    )
+    assert ok is True
+    assert all(kind == "tv" for kind, _ in calls)
+    assert not any(q == "HI_RES_LOSSLESS" for _, q in calls)
+
+
+async def test_download_missing_hires_token_does_not_send_max_to_tv(dl_env):
+    # high + auto but NO HiRes token (hires_api is None): the cascade would top
+    # out at HI_RES_LOSSLESS, but with no HiRes-capable client that rung is
+    # dropped — TV must never be asked for HI_RES_LOSSLESS.
+    calls: list = []
+    tv = _FakeAPI("tv", calls, {"LOSSLESS": "LOSSLESS"})
+    _, ok = await _run(
+        dl_env, _make_track(tags=["DOLBY_ATMOS", "HIRES_LOSSLESS"], quality="HI_RES_LOSSLESS"),
+        primary=tv, primary_kind="tv", hires_api=None, quality="high",
+    )
+    assert ok is True
+    assert ("tv", "HI_RES_LOSSLESS") not in calls
+    assert calls[0] == ("tv", "LOSSLESS")
+
+
+async def test_download_fallback_has_no_duplicate_pairs(dl_env):
+    # HiRes-primary (max/auto): primary degrades HI_RES_LOSSLESS -> HIGH, so the
+    # TV fallback re-requests LOSSLESS ONCE. No (client, quality) pair repeats —
+    # the old HiRes->TV duplicate cycle is gone.
+    calls: list = []
+    hires = _FakeAPI("hires", calls, {"HI_RES_LOSSLESS": "HIGH"})   # degraded delivery
+    tv = _FakeAPI("tv", calls, {"LOSSLESS": "LOSSLESS"})            # fallback fixes it
+    _, ok = await _run(
+        dl_env, _make_track(tags=["HIRES_LOSSLESS", "LOSSLESS"], quality="HI_RES_LOSSLESS"),
+        primary=hires, primary_kind="hires", hires_api=None, fallback_api=tv, quality="max",
+    )
+    assert ok is True
+    assert calls == [("hires", "HI_RES_LOSSLESS"), ("tv", "LOSSLESS")]
+    assert len(calls) == len(set(calls))  # no duplicate pairs

--- a/tests/test_hires_429_regression.py
+++ b/tests/test_hires_429_regression.py
@@ -1,0 +1,282 @@
+"""Regression: the HTTP 429 storm introduced by 05b1eca (`-q high` promoted the
+WHOLE run to the strict HiRes client + a duplicate HiRes->TV stream request per
+track). This pins the fix:
+
+* the STABLE client matrix is restored (`high`/`never` -> TV, `max`/`always` -> HiRes),
+* the 24-bit `max` ascent for an Atmos track is decided PER-TRACK from the media
+  tags and routed to a SECONDARY HiRes client only for that track,
+* TV + HiRes share ONE per-run request budget so both clients together cannot
+  exceed `requests_per_minute`,
+* an ordinary Lossless track makes exactly one stream request (TV/LOSSLESS).
+
+All offline and deterministic: the budget takes an injected clock, and the
+routing/order is asserted through the same pure helpers the downloader uses, so
+each attempt is recorded as (client_kind, quality).
+"""
+from tiddl.cli.commands.download import _resolve_prefer_hires
+from tiddl.cli.commands.download.downloader import _pick_stream_client
+from tiddl.core.api.budget import SharedRequestBudget
+from tiddl.core.quality_cascade import cascade_api_qualities
+
+
+# --------------------------------------------------------------------------
+# Deterministic clock for the shared budget.
+# --------------------------------------------------------------------------
+class _Clock:
+    def __init__(self):
+        self.t = 0.0
+        self.sleeps: list[float] = []
+
+    def now(self) -> float:
+        return self.t
+
+    def advance(self, s: float) -> None:
+        self.t += s
+
+    def sleep(self, s: float) -> None:
+        self.sleeps.append(s)
+        if s > 0:
+            self.t += s
+
+
+def _budget(rpm, clock):
+    return SharedRequestBudget(rpm, clock=clock.now, sleeper=clock.sleep, jitter=lambda: 0.0)
+
+
+# The (client_kind, quality) sequence the downloader would attempt for a track:
+# the fidelity cascade from the tags, each rung routed by the SAME per-attempt
+# client picker the real loop uses. `has_hires` is True only in TV-primary
+# `high + auto` (a secondary HiRes client is available for the `max` ascent).
+def _expected_attempts(requested, tags, primary_kind, has_hires):
+    hires = object() if has_hires else None
+    out = []
+    for q in cascade_api_qualities(requested, tags):
+        _, kind = _pick_stream_client(q, "PRIMARY", primary_kind, hires)
+        out.append((kind, q))
+    return out
+
+
+# ===========================================================================
+# 1. Stable client matrix (restored from d1613b0)
+# ===========================================================================
+def test_prefer_hires_matrix():
+    # high + auto -> TV (the whole point: no run-wide HiRes for `high`).
+    assert _resolve_prefer_hires("high", "auto") is False
+    # max + auto -> HiRes.
+    assert _resolve_prefer_hires("max", "auto") is True
+    # never -> TV, even for max.
+    assert _resolve_prefer_hires("max", "never") is False
+    assert _resolve_prefer_hires("high", "never") is False
+    # always -> HiRes, even for high/normal.
+    assert _resolve_prefer_hires("high", "always") is True
+    assert _resolve_prefer_hires("normal", "always") is True
+    # lower tiers in auto stay on TV.
+    assert _resolve_prefer_hires("normal", "auto") is False
+    assert _resolve_prefer_hires("low", "auto") is False
+
+
+# ===========================================================================
+# 2. Per-track routing (the pure picker the loop uses)
+# ===========================================================================
+def test_pick_client_max_rung_ascends_to_secondary_hires():
+    hires = object()
+    client, kind = _pick_stream_client("HI_RES_LOSSLESS", "TV", "tv", hires)
+    assert client is hires and kind == "hires"
+
+
+def test_pick_client_ordinary_tier_stays_on_primary():
+    hires = object()
+    for q in ("LOSSLESS", "HIGH", "LOW"):
+        client, kind = _pick_stream_client(q, "TV", "tv", hires)
+        assert client == "TV" and kind == "tv"
+
+
+def test_pick_client_max_rung_without_secondary_uses_primary():
+    # HiRes-primary (max/always) or never: no secondary client -> primary serves
+    # HI_RES_LOSSLESS itself (or, for `never`, HI_RES_LOSSLESS is never requested).
+    client, kind = _pick_stream_client("HI_RES_LOSSLESS", "PRIMARY", "hires", None)
+    assert client == "PRIMARY" and kind == "hires"
+
+
+# ===========================================================================
+# 3. Call table — client / order / count per scenario
+# ===========================================================================
+def test_high_auto_ordinary_lossless_one_tv_request():
+    # A normal Lossless track (LOSSLESS, not Atmos): exactly ONE stream request,
+    # on TV, yielding FLAC. No HiRes call.
+    tags = ["LOSSLESS"]
+    attempts = _expected_attempts("high", tags, primary_kind="tv", has_hires=True)
+    assert attempts[0] == ("tv", "LOSSLESS")
+    assert all(kind == "tv" for kind, _ in attempts)
+    assert not any(kind == "hires" for kind, _ in attempts)
+
+
+def test_high_auto_atmos_with_max_flac_ascends_only_that_track():
+    # Atmos track whose only FLAC is 24-bit: the cascade climbs to `max`
+    # (HI_RES_LOSSLESS) and routes THAT rung to the secondary HiRes client; the
+    # run is not converted to HiRes.
+    tags = ["DOLBY_ATMOS", "HIRES_LOSSLESS"]
+    attempts = _expected_attempts("high", tags, primary_kind="tv", has_hires=True)
+    assert attempts[0] == ("hires", "HI_RES_LOSSLESS")
+    # exactly one HiRes attempt (the ascent), the rest fall back on TV.
+    assert sum(1 for kind, _ in attempts if kind == "hires") == 1
+
+
+def test_high_auto_no_high_no_max_stays_on_tv():
+    # No LOSSLESS and no HIRES tag: only HIGH/LOW remain, all on TV.
+    tags = []
+    attempts = _expected_attempts("high", tags, primary_kind="tv", has_hires=True)
+    assert attempts and all(kind == "tv" for kind, _ in attempts)
+    assert not any(kind == "hires" for kind, _ in attempts)
+
+
+def test_max_auto_uses_hires_primary_no_secondary():
+    # max + auto: HiRes is the primary (has_hires=False here — no separate
+    # secondary), so the HI_RES_LOSSLESS request goes on the primary HiRes.
+    tags = ["HIRES_LOSSLESS", "LOSSLESS"]
+    attempts = _expected_attempts("max", tags, primary_kind="hires", has_hires=False)
+    assert attempts[0] == ("hires", "HI_RES_LOSSLESS")
+
+
+def test_never_never_calls_hires():
+    # `never`: no secondary HiRes client at all; even a track advertising Max/Atmos
+    # is only ever requested on the TV primary.
+    tags = ["DOLBY_ATMOS", "HIRES_LOSSLESS"]
+    attempts = _expected_attempts("high", tags, primary_kind="tv", has_hires=False)
+    assert not any(kind == "hires" for kind, _ in attempts)
+
+
+def test_always_hires_run_wide():
+    # `always`: HiRes is the run-wide primary; every attempt is on HiRes.
+    tags = ["LOSSLESS"]
+    attempts = _expected_attempts("high", tags, primary_kind="hires", has_hires=False)
+    assert attempts and all(kind == "hires" for kind, _ in attempts)
+
+
+# ===========================================================================
+# 4. Shared per-run request budget (deterministic clock)
+# ===========================================================================
+def test_budget_first_request_never_waits():
+    c = _Clock()
+    b = _budget(60, c)  # interval 1.0s
+    b.throttle()
+    assert c.sleeps == [] or c.sleeps == [0.0] or all(s <= 0 for s in c.sleeps)
+    assert b.request_count == 1
+
+
+def test_budget_spaces_combined_traffic_at_rpm():
+    # 60 rpm -> 1.0s spacing. Five requests (from either client) take 4 intervals.
+    c = _Clock()
+    b = _budget(60, c)
+    for _ in range(5):
+        b.throttle()
+    assert b.request_count == 5
+    # first free, next four each wait one interval -> 4.0s of enforced spacing.
+    assert sum(s for s in c.sleeps if s > 0) == 4.0
+
+
+def test_budget_shared_by_two_clients_cannot_double_rpm():
+    # One budget injected into BOTH clients: interleaving TV + HiRes requests
+    # stays on the SAME 1.0s cadence — activating both does NOT double the rate.
+    c = _Clock()
+    shared = _budget(60, c)
+    # simulate: TV, HiRes, TV, HiRes, TV, HiRes (6 combined requests) — the same
+    # shared budget backs both clients, so the cadence stays 60/min COMBINED.
+    for _ in range(6):
+        shared.throttle()
+    assert shared.request_count == 6
+    # 6 combined requests over 5 intervals => 5.0s, i.e. exactly 60/min combined.
+    assert sum(s for s in c.sleeps if s > 0) == 5.0
+
+
+def test_two_contexts_have_independent_budgets():
+    # Per-context (NOT process-global): a fresh budget starts clean, so a prior
+    # run cannot contaminate the next and its first request never waits.
+    c1, c2 = _Clock(), _Clock()
+    b1, b2 = _budget(60, c1), _budget(60, c2)
+    for _ in range(3):
+        b1.throttle()
+    assert b1.request_count == 3
+    b2.throttle()
+    assert b2.request_count == 1  # independent counter
+    assert sum(s for s in c2.sleeps if s > 0) == 0.0  # its first request is free
+
+
+def test_budget_refund_returns_the_slot_for_cache_hits():
+    # A "request" served from cache consumes no quota: refund gives the slot back
+    # and does not count toward the combined total.
+    c = _Clock()
+    b = _budget(60, c)
+    b.throttle()
+    b.throttle()
+    assert b.request_count == 2
+    b.refund()
+    assert b.request_count == 1
+    # after a refund the next real request may proceed immediately.
+    before = len([s for s in c.sleeps if s > 0])
+    b.throttle()
+    assert len([s for s in c.sleeps if s > 0]) == before  # no extra wait
+
+
+# ===========================================================================
+# 5. No duplicate stream request for an ordinary high+auto track
+# ===========================================================================
+def test_high_auto_ordinary_has_no_hires_then_tv_duplicate():
+    # The pre-fix bug: HiRes/LOSSLESS->HIGH then TV/LOSSLESS->FLAC (two requests).
+    # With TV as primary and no fallback in TV mode, an ordinary track is a single
+    # TV/LOSSLESS attempt.
+    tags = ["LOSSLESS"]
+    attempts = _expected_attempts("high", tags, primary_kind="tv", has_hires=True)
+    assert attempts[0] == ("tv", "LOSSLESS")
+    # the same (client, quality) pair is never issued twice.
+    assert len(attempts) == len(set(attempts))
+
+
+# ===========================================================================
+# 6. strict nuance — never issue a request the metadata already proves incompatible
+# ===========================================================================
+def test_no_request_for_a_tier_the_tags_already_rule_out():
+    # A track whose tags offer no FLAC at all (no LOSSLESS / no HIRES_LOSSLESS):
+    # the cascade never even ATTEMPTS HI_RES_LOSSLESS or LOSSLESS, so no request
+    # that the metadata already proves incompatible is made. (This is why we do
+    # NOT pre-assert `strict` == zero requests: HIGH/LOW are still offered; strict
+    # simply must not ACCEPT an out-of-policy tier, which stream_policy handles.)
+    qs = cascade_api_qualities("high", [])  # only universal normal/low remain
+    assert "HI_RES_LOSSLESS" not in qs
+    assert "LOSSLESS" not in qs
+    assert qs and qs[0] == "HIGH"
+
+
+# ===========================================================================
+# 7. Enumeration client — `high + auto` (incl. expanded discography) uses TV
+# ===========================================================================
+def test_high_auto_enumeration_uses_tv_primary(monkeypatch):
+    # In `high + auto`, prefer_hires is False, so the PRIMARY api — which backs
+    # ALL enumeration (playlists, artists, albums, credits, metadata) — is the TV
+    # client. HiRes is only ever a per-track ascent, never the enumerator, so a
+    # `--artists` discography run cannot storm the HiRes limit during enumeration.
+    from rich.console import Console
+
+    from tiddl.cli.ctx import ContextObject
+    from tiddl.cli.utils.auth.core import AUTH_DATA_FILE, AUTH_FALLBACK_FILE
+
+    ctx = ContextObject(api_omit_cache=False, debug_path=None, console=Console())
+    ctx.prefer_hires = _resolve_prefer_hires("high", "auto")  # -> False (TV)
+    used: list = []
+    monkeypatch.setattr(
+        ctx, "_build_api",
+        lambda auth_file, *a, **k: (used.append(auth_file), object())[1],
+    )
+    _ = ctx.api
+    assert used and used[0] == AUTH_FALLBACK_FILE  # TV auth file backs enumeration
+
+    # And in max/always the primary IS the HiRes auth file.
+    ctx2 = ContextObject(api_omit_cache=False, debug_path=None, console=Console())
+    ctx2.prefer_hires = _resolve_prefer_hires("max", "auto")  # -> True (HiRes)
+    used2: list = []
+    monkeypatch.setattr(
+        ctx2, "_build_api",
+        lambda auth_file, *a, **k: (used2.append(auth_file), object())[1],
+    )
+    _ = ctx2.api
+    assert used2 and used2[0] == AUTH_DATA_FILE

--- a/tests/test_session_limit_concurrency.py
+++ b/tests/test_session_limit_concurrency.py
@@ -1,0 +1,147 @@
+"""`max_tracks_per_session` must hold EXACTLY under concurrency.
+
+The earlier design bumped the counter after the download finished, so several
+concurrent tasks could all pass the check and overshoot the cap. The fix is an
+atomic per-track reservation on `SessionTrackLimit`:
+
+    admitted = await reserve()          # takes a slot up front (or waits / rejects)
+    path, new = await download()
+    commit() if new else release()      # new keeps the slot; existing gives it back
+
+These tests pin the invariant `downloaded + reserved <= limit`, that existing
+files don't consume the cap while a waiter takes their freed slot, the immediate
+one-shot warning on the reaching commit, and clean release on cancel/error.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tiddl.cli.commands.download import _resource_resume_done
+from tiddl.core.download_policy import SessionTrackLimit
+
+
+async def _process(limit, track, observed_max):
+    """Mirror handle_item for ONE track: reserve -> download -> commit/release.
+
+    `track` is ("new"|"existing"|"error", id). Returns (outcome, id, announced)."""
+    admitted = await limit.reserve()
+    if not admitted:
+        return ("rejected", track[1], False)
+    # Probe the invariant while THIS task holds its reservation (no await between
+    # reserve() returning and here, so the sample is consistent).
+    observed_max[0] = max(observed_max[0], limit.downloaded + limit.reserved)
+    await asyncio.sleep(0)  # yield so tasks genuinely interleave
+    kind = track[0]
+    if kind == "error":
+        limit.release()     # handle_item's except path frees the reservation
+        return ("error", track[1], False)
+    if kind == "existing":
+        limit.release()     # already on disk: slot back, no charge
+        return ("existing", track[1], False)
+    announced = limit.commit()          # a real new download
+    return ("downloaded", track[1], announced)
+
+
+async def _run(limit_value, tracks):
+    limit = SessionTrackLimit(limit=limit_value)
+    observed_max = [0]
+    results = await asyncio.gather(
+        *[_process(limit, t, observed_max) for t in tracks]
+    )
+    return limit, results, observed_max[0]
+
+
+async def test_limit3_concurrency5_five_new_tracks_exactly_three_downloads():
+    # 1. Limit 3, concurrency 5, five NEW tracks -> exactly 3 downloads.
+    limit, results, mx = await _run(3, [("new", i) for i in range(5)])
+    downloads = [r for r in results if r[0] == "downloaded"]
+    assert len(downloads) == 3
+    assert limit.downloaded == 3
+    assert mx <= 3                                   # never exceeded the cap
+    assert limit.reserved == 0                       # everything settled
+    assert limit.is_reached()
+    assert sum(1 for _, _, announced in results if announced) == 1  # warned once
+
+
+async def test_limit3_concurrency5_existing_tracks_do_not_consume_quota():
+    # 2. Limit 3, concurrency 5, several EXISTING tracks -> three NEW downloads,
+    #    and the existing ones do not consume the quota.
+    tracks = [("existing", "e1"), ("existing", "e2"),
+              ("new", "n1"), ("new", "n2"), ("new", "n3")]
+    limit, results, mx = await _run(3, tracks)
+    downloaded_ids = {r[1] for r in results if r[0] == "downloaded"}
+    assert downloaded_ids == {"n1", "n2", "n3"}      # exactly the 3 new tracks
+    assert limit.downloaded == 3
+    assert mx <= 3
+    assert not (downloaded_ids & {"e1", "e2"})       # no existing track counted
+
+
+async def test_waiter_proceeds_when_another_track_turns_out_existing():
+    # 3(a). A waiting NEW task must proceed when another track releases (existing).
+    #       Limit 1: the existing track frees its slot for a waiting new track.
+    limit, results, mx = await _run(1, [("existing", "e1"), ("new", "n1"), ("new", "n2")])
+    downloads = [r for r in results if r[0] == "downloaded"]
+    assert len(downloads) == 1                       # exactly one new download
+    assert limit.downloaded == 1
+    assert mx <= 1
+    assert ("existing", "e1", False) in results      # e1 released, not counted
+
+
+async def test_announce_fires_once_when_the_last_track_reaches_the_limit():
+    # 3(b). Exact finish on the final track: the reaching commit announces
+    #       immediately, even with no later track. Sequential so the last commit
+    #       is the reaching one.
+    limit = SessionTrackLimit(limit=3)
+    announced = []
+    for i in range(3):
+        assert await limit.reserve() is True
+        if limit.commit():
+            announced.append(i)
+    assert announced == [2]                          # only the 3rd (last) commit
+    assert limit.is_reached()
+
+
+async def test_error_during_reservation_releases_it_no_deadlock():
+    # 4(a). A task that errors AFTER reserving frees its slot (handle_item's
+    #       except -> release), so the cap never leaks and others aren't blocked.
+    limit, results, mx = await _run(
+        2, [("error", "x1"), ("new", "n1"), ("new", "n2"), ("error", "x2")]
+    )
+    downloads = [r for r in results if r[0] == "downloaded"]
+    assert len(downloads) == 2                       # both new tracks got through
+    assert limit.downloaded == 2
+    assert mx <= 2
+    assert limit.reserved == 0                       # no reservation leaked
+    assert limit.is_reached()
+
+
+async def test_reserve_cancelled_while_waiting_is_cleaned_up():
+    # 4(b). A task cancelled WHILE parked in reserve() removes itself from the
+    #       wait list — no leak, no deadlock for the rest.
+    limit = SessionTrackLimit(limit=1)
+    assert await limit.reserve() is True             # slot taken; next one waits
+    waiter = asyncio.ensure_future(limit.reserve())
+    await asyncio.sleep(0)                            # let it park on its future
+    assert limit._waiters                            # it is waiting
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    assert limit._waiters == []                      # cleaned itself up
+    limit.release()                                  # freeing the held slot is safe
+    assert limit.reserved == 0
+
+
+async def test_resume_does_not_checkpoint_a_cap_truncated_resource():
+    # 5. --resume after the cap: a resource cut short by the limit must NOT be
+    #    marked complete, so a later --resume retries its missing tracks.
+    limit = SessionTrackLimit(limit=1)
+    assert await limit.reserve() is True
+    limit.commit()                                   # reaches the cap mid-resource
+    assert limit.is_reached()
+    # ok=True (no error) but cut short by the cap -> not checkpointable.
+    assert _resource_resume_done(
+        ok=True, resume_enabled=True, cancelled=False,
+        session_limit_reached=limit.is_reached(),
+    ) is False

--- a/tests/test_session_limit_concurrency.py
+++ b/tests/test_session_limit_concurrency.py
@@ -133,6 +133,33 @@ async def test_reserve_cancelled_while_waiting_is_cleaned_up():
     assert limit.reserved == 0
 
 
+async def test_wakeup_is_passed_on_when_a_woken_waiter_is_cancelled():
+    # Race: release() wakes waiter A, but A is cancelled BEFORE it reserves. The
+    # freed slot must not be orphaned — A hands the wakeup to waiter B, which then
+    # obtains the slot. No deadlock, no negative counter, invariant preserved.
+    limit = SessionTrackLimit(limit=1)
+    assert await limit.reserve() is True          # H holds the only slot
+    a = asyncio.ensure_future(limit.reserve())    # A parks
+    b = asyncio.ensure_future(limit.reserve())    # B parks
+    await asyncio.sleep(0)                         # let both park on their futures
+    assert len(limit._waiters) == 2
+
+    limit.release()                               # frees the slot -> wakes A (first)
+    assert len(limit._waiters) == 1               # A dequeued; B still waiting
+
+    a.cancel()                                    # cancel A before it can reserve
+    with pytest.raises(asyncio.CancelledError):
+        await a
+
+    # B must get the slot handed on from A's aborted wakeup.
+    assert await b is True
+    assert limit.reserved == 1                    # exactly B holds it now
+    assert limit.downloaded == 0
+    assert limit.reserved >= 0                    # never went negative
+    assert limit.downloaded + limit.reserved <= limit.limit
+    assert limit._waiters == []                   # no stranded waiter
+
+
 async def test_resume_does_not_checkpoint_a_cap_truncated_resource():
     # 5. --resume after the cap: a resource cut short by the limit must NOT be
     #    marked complete, so a later --resume retries its missing tracks.

--- a/tests/test_session_limit_stop.py
+++ b/tests/test_session_limit_stop.py
@@ -63,15 +63,14 @@ def test_mandatory_no_heartbeat_or_api_for_remaining_resources_after_limit():
         heartbeats.append((idx, album))          # the `[idx/total]` line
         # wrapper -> handle_resource: enumerating a resource IS an API call.
         api_calls.append(("enumerate", album))
-        # handle_item per track: admit-gate, then a real download is an API call.
+        # handle_item per track: reserve -> download -> commit (a real download).
         for _t in range(tracks_per_album):
-            admitted, announce = limit.admit()
-            if announce:
-                announces.append(album)
+            admitted = await limit.reserve()
             if not admitted:
                 break                            # cap hit: stop admitting more
             api_calls.append(("stream", album))
-            limit.record(was_downloaded=True)
+            if limit.commit():                   # the commit that reached the cap
+                announces.append(album)
 
     asyncio.run(
         _bounded_dispatch(albums, dispatch_one_like, concurrency=1,
@@ -110,7 +109,7 @@ def test_resource_resume_done_truth_table():
     assert done(True, False, False, False) is False
 
 
-def test_session_limit_is_not_user_cancel_or_rate_limit():
+async def test_session_limit_is_not_user_cancel_or_rate_limit():
     # Point 7: the cap must NOT masquerade as Cancel/401/429 — it is its own
     # run-local signal on the policy object, leaving global cancel untouched.
     from tiddl.core import cancel
@@ -118,7 +117,8 @@ def test_session_limit_is_not_user_cancel_or_rate_limit():
     cancel.clear()
     try:
         limit = SessionTrackLimit(limit=1)
-        limit.record(was_downloaded=True)
+        assert await limit.reserve() is True
+        limit.commit()
         assert limit.is_reached()
         assert not cancel.is_cancelled()  # reaching the cap never cancels the run
     finally:

--- a/tests/test_session_limit_stop.py
+++ b/tests/test_session_limit_stop.py
@@ -1,0 +1,125 @@
+"""Reaching `max_tracks_per_session` must STOP the run, not just refuse further
+downloads while the dispatcher keeps enumerating the remaining resources.
+
+The reproduced bug: after printing "Límite de sesión alcanzado … Reinicia para
+continuar", the engine kept emitting `[53/69]`, `[54/69]` and hitting the API for
+the remaining resources, because `SessionTrackLimit.admit()` only returned False
+inside `handle_item()` without a run-wide stop.
+
+The fix latches a run-wide `reached` signal (distinct from Cancel/401/429) that
+`_bounded_dispatch` (via `should_stop`), `dispatch_one` and `wrapper` all honour.
+These tests pin the dispatch-level behaviour on the REAL `_bounded_dispatch`.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from tiddl.cli.commands.download import _bounded_dispatch, _resource_resume_done
+from tiddl.core.download_policy import SessionTrackLimit
+
+
+def test_bounded_dispatch_should_stop_halts_pulling_new_items():
+    # Once should_stop() flips True, the pool stops dequeuing NEW items.
+    handled: list = []
+    stop = {"v": False}
+
+    async def handler(item, idx):
+        handled.append(item)
+        if item == "b":
+            stop["v"] = True  # stop after handling b
+
+    asyncio.run(
+        _bounded_dispatch(list("abcde"), handler, concurrency=1,
+                          should_stop=lambda: stop["v"])
+    )
+    assert handled == ["a", "b"]  # c, d, e were never pulled or handled
+
+
+def test_should_stop_true_from_the_start_handles_nothing():
+    async def handler(item, idx):  # pragma: no cover - must never run
+        raise AssertionError("handler ran despite should_stop=True")
+
+    asyncio.run(
+        _bounded_dispatch([1, 2, 3], handler, concurrency=2, should_stop=lambda: True)
+    )
+
+
+def test_mandatory_no_heartbeat_or_api_for_remaining_resources_after_limit():
+    # MANDATORY: small cap + several albums. After the cap is reached mid-run,
+    # NO further `[n/total]` heartbeat appears and NO API call is made for the
+    # remaining resources. Drives the REAL _bounded_dispatch with a handler that
+    # mirrors dispatch_one -> wrapper -> handle_resource -> handle_item.
+    limit = SessionTrackLimit(limit=6)
+    albums = [f"album{i}" for i in range(1, 7)]  # 6 albums
+    tracks_per_album = 4
+    heartbeats: list = []
+    api_calls: list = []
+    announces: list = []
+
+    async def dispatch_one_like(album, idx):
+        # dispatch_one guard: no heartbeat and no wrapper() once reached.
+        if limit.is_reached():
+            return
+        heartbeats.append((idx, album))          # the `[idx/total]` line
+        # wrapper -> handle_resource: enumerating a resource IS an API call.
+        api_calls.append(("enumerate", album))
+        # handle_item per track: admit-gate, then a real download is an API call.
+        for _t in range(tracks_per_album):
+            admitted, announce = limit.admit()
+            if announce:
+                announces.append(album)
+            if not admitted:
+                break                            # cap hit: stop admitting more
+            api_calls.append(("stream", album))
+            limit.record(was_downloaded=True)
+
+    asyncio.run(
+        _bounded_dispatch(albums, dispatch_one_like, concurrency=1,
+                          should_stop=limit.is_reached)
+    )
+
+    # album1 downloads 4 (4<6), album2 downloads 2 -> total 6 == cap, reached
+    # during album2; its remaining tracks and albums 3..6 are never touched.
+    assert limit.is_reached()
+    assert limit.downloaded == 6
+    # Heartbeats only for the two albums that actually ran — none afterwards.
+    assert [a for _, a in heartbeats] == ["album1", "album2"]
+    # No enumeration / stream API for any remaining resource.
+    touched = {a for _, a in api_calls}
+    assert touched == {"album1", "album2"}
+    for gone in ["album3", "album4", "album5", "album6"]:
+        assert ("enumerate", gone) not in api_calls
+        assert ("stream", gone) not in api_calls
+    # The warning fired exactly once, during the album where the cap was hit.
+    assert announces == ["album2"]
+
+
+def test_resource_resume_done_truth_table():
+    # Point 6: a resource is checkpointed done ONLY on a clean completion that was
+    # not stopped underneath it — never when cut short by the cap or cancel.
+    done = _resource_resume_done
+    assert done(ok=True, resume_enabled=True, cancelled=False,
+                session_limit_reached=False) is True
+    # cap reached during it -> NOT done (its remaining tracks weren't fetched).
+    assert done(True, True, False, True) is False
+    # cancelled -> NOT done.
+    assert done(True, True, True, False) is False
+    # errored (ok False) -> NOT done.
+    assert done(False, True, False, False) is False
+    # --resume disabled -> nothing to checkpoint.
+    assert done(True, False, False, False) is False
+
+
+def test_session_limit_is_not_user_cancel_or_rate_limit():
+    # Point 7: the cap must NOT masquerade as Cancel/401/429 — it is its own
+    # run-local signal on the policy object, leaving global cancel untouched.
+    from tiddl.core import cancel
+
+    cancel.clear()
+    try:
+        limit = SessionTrackLimit(limit=1)
+        limit.record(was_downloaded=True)
+        assert limit.is_reached()
+        assert not cancel.is_cancelled()  # reaching the cap never cancels the run
+    finally:
+        cancel.clear()

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -1437,14 +1437,14 @@ def download_callback(
                 log.debug(f"{item.id=}, {file_path=}")
                 rich_output.total_increment()
 
-                # Límite de tracks por sesión
-                admitted, announce_limit = _session_track_limit.admit()
+                # Session cap: reserve a slot BEFORE downloading. With concurrency
+                # this is the only correct gate — a reservation is atomic, so N
+                # tasks can never all slip past and overshoot the cap. reserve()
+                # may wait (all slots reserved) and resume when one is released, or
+                # be rejected once the cap is used up. A reserved slot MUST be
+                # settled below (commit on a real download, release otherwise).
+                admitted = await _session_track_limit.reserve()
                 if not admitted:
-                    if announce_limit:
-                        ctx.obj.console.print(
-                            f"[yellow]Límite de sesión alcanzado ({_session_limit} tracks). "
-                            f"Reinicia para continuar.[/]"
-                        )
                     return Path(""), item
 
                 if not track_metadata:
@@ -1458,18 +1458,33 @@ def download_callback(
                 # always matches dispatch order), while still letting a track's
                 # delay run concurrently with the *previous* track's in-flight
                 # download instead of stacking dead time after it.
-                download_path, was_downloaded = await downloader.download(
-                    item=item, file_path=Path(file_path),
-                    source_type=source_type, source_id=source_id,
-                )
+                try:
+                    download_path, was_downloaded = await downloader.download(
+                        item=item, file_path=Path(file_path),
+                        source_type=source_type, source_id=source_id,
+                    )
+                except BaseException:
+                    # Cancel/error after reserving but before settling: give the
+                    # slot back (sync, uninterruptible) so waiting tracks proceed
+                    # and the cap never leaks a reservation. Then re-raise.
+                    _session_track_limit.release()
+                    raise
 
                 log.debug(f"{download_path=}, {was_downloaded=}")
 
-                # Count only tracks this run actually fetched toward the session
-                # cap; an already-present file (skip_existing) must not consume it.
-                # Reaching the cap latches the run-wide `reached` signal that
-                # stops dispatch/enumeration of the remaining resources.
-                _session_track_limit.record(bool(was_downloaded))
+                # Settle the reservation. A real new download COMMITS its slot —
+                # and if it's the one that reaches the cap, the warning is printed
+                # NOW (immediately, even if no later track follows). An
+                # already-present file RELEASES its slot, unused, so a waiting
+                # track takes its place and existing files never eat the quota.
+                if was_downloaded:
+                    if _session_track_limit.commit():
+                        ctx.obj.console.print(
+                            f"[yellow]Límite de sesión alcanzado ({_session_limit} tracks). "
+                            f"Reinicia para continuar.[/]"
+                        )
+                else:
+                    _session_track_limit.release()
 
                 # Destination-volume identity (operations 4/5/6/9, v2.2 §1 /
                 # v2.3 §1): the same root operations 1/2/3 already checked for

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -311,6 +311,22 @@ def _download_exit_code(
     return 1 if any_identity_refused or cooperative_stop else None
 
 
+def _resource_resume_done(
+    ok: bool, resume_enabled: bool, cancelled: bool, session_limit_reached: bool
+) -> bool:
+    """Whether a resource may be marked done in the ``--resume`` checkpoint.
+
+    A resource is checkpointed ONLY when it completed cleanly AND the run was not
+    stopped underneath it: not cancelled, and — crucially — the session-track
+    limit was not reached during it. Reaching the cap cuts a resource short (its
+    remaining tracks are never admitted), so marking it done would make a later
+    ``--resume`` skip those tracks and silently lose them. Conservative on
+    purpose: a resource that actually finished just before the cap is re-checked
+    next run, where ``skip_existing`` makes it cheap. Pure function for direct
+    unit coverage, same pattern as ``_download_exit_code``."""
+    return ok and resume_enabled and not cancelled and not session_limit_reached
+
+
 def _resolve_prefer_hires(track_quality: str, hires_client: str) -> bool:
     """Which client backs the WHOLE run, from the requested ``-q`` + config
     ``hires_client`` — the STABLE matrix (restored from ``d1613b0``):
@@ -384,7 +400,7 @@ def _finish_download_run(
     return exit_code
 
 
-async def _bounded_dispatch(items, handler, concurrency: int) -> None:
+async def _bounded_dispatch(items, handler, concurrency: int, should_stop=None) -> None:
     """Run ``handler(item, index)`` over ``items`` with a FIXED pool of
     ``concurrency`` worker tasks, so at most ``concurrency`` tasks exist at once
     no matter how many items there are.
@@ -396,6 +412,12 @@ async def _bounded_dispatch(items, handler, concurrency: int) -> None:
     item from the shared iterator between awaits needs no lock. ``index`` is
     1-based, matching the previous ``enumerate(..., start=1)`` heartbeat.
 
+    ``should_stop`` is an optional zero-arg predicate checked before each pull:
+    once it returns True the workers stop taking NEW items and drain. This is how
+    reaching ``max_tracks_per_session`` halts a run — no further resource is even
+    dequeued (so none is enumerated or produces API traffic), while items already
+    handed to a worker finish cleanly.
+
     Cancellation propagates: a worker raising ``CancelledError`` /
     ``KeyboardInterrupt`` (or the awaiting caller being cancelled) tears the
     whole pool down. A per-item error never kills a worker or orphans the rest —
@@ -405,6 +427,8 @@ async def _bounded_dispatch(items, handler, concurrency: int) -> None:
 
     async def _worker() -> None:
         while True:
+            if should_stop is not None and should_stop():
+                return
             try:
                 index, item = next(it)
             except StopIteration:
@@ -1392,6 +1416,12 @@ def download_callback(
                 )
 
                 log.debug(f"{download_path=}, {was_downloaded=}")
+
+                # Count only tracks this run actually fetched toward the session
+                # cap; an already-present file (skip_existing) must not consume it.
+                # Reaching the cap latches the run-wide `reached` signal that
+                # stops dispatch/enumeration of the remaining resources.
+                _session_track_limit.record(bool(was_downloaded))
 
                 # Destination-volume identity (operations 4/5/6/9, v2.2 §1 /
                 # v2.3 §1): the same root operations 1/2/3 already checked for
@@ -2550,11 +2580,13 @@ def download_callback(
         ):
 
             async def wrapper(r: TidalResource):
-                # Cooperative cancel: on a multi-URL batch, skip every remaining
-                # resource the moment the user cancels instead of processing the
-                # whole pasted list.
+                # Cooperative cancel OR session-limit reached: skip every remaining
+                # resource the moment the run is stopped, instead of enumerating it
+                # (credits, covers, edition resolution) and issuing API calls. This
+                # is the single choke point that stops ALL per-resource work for
+                # not-yet-started resources once the cap is hit.
                 from tiddl.core.cancel import is_cancelled
-                if is_cancelled():
+                if is_cancelled() or _session_track_limit.is_reached():
                     return
                 _rkey = f"{r.type}/{r.id}"
                 # Resume: skip a resource already completed in a prior run of this
@@ -2580,9 +2612,15 @@ def download_callback(
                     raise
                 except Exception as e:
                     ctx.obj.console.print(f"[red]Error:[/] {e} at {r}")
-                # Mark done only on a clean, non-cancelled completion, so a resource
-                # that errored (or a run that got stopped) is retried on --resume.
-                if ok and resume_log is not None and not is_cancelled():
+                # Mark done only on a clean completion that was NOT stopped
+                # underneath it — not cancelled, and not cut short by the session
+                # cap (whose remaining tracks were never admitted). See
+                # _resource_resume_done: marking a cap-truncated resource done
+                # would make a later --resume skip its missing tracks.
+                if _resource_resume_done(
+                    ok, resume_log is not None, is_cancelled(),
+                    _session_track_limit.is_reached(),
+                ):
                     resume_log.mark_done(_rkey)
 
             async def expand_playlist(resource: TidalResource) -> list[TidalResource]:
@@ -2661,12 +2699,14 @@ def download_callback(
                 expand_total = len(ctx.obj.resources)
 
                 async def dispatch_one(r: TidalResource, idx: int):
-                    # Cooperative cancel: bail BEFORE the heartbeat print so a
-                    # cancelled run doesn't flood the log with a burst of
-                    # "[idx/total] type/id" lines for every remaining resource
-                    # (on a big expanded batch that's thousands of lines, which
-                    # reads as "still working" even though nothing downloads).
-                    if is_cancelled():
+                    # Cooperative cancel OR session-limit reached: bail BEFORE the
+                    # heartbeat print and before wrapper(), so a stopped run
+                    # doesn't flood the log with a burst of "[idx/total] type/id"
+                    # lines for every remaining resource (on a big expanded batch
+                    # that's thousands of lines, which reads as "still working"
+                    # even though nothing downloads) and issues no API traffic for
+                    # resources it will not process.
+                    if is_cancelled() or _session_track_limit.is_reached():
                         return
                     # Steady per-resource heartbeat: complete albums are skipped
                     # silently, so without this the output can go quiet for
@@ -2678,7 +2718,8 @@ def download_callback(
 
                 try:
                     await _bounded_dispatch(
-                        ctx.obj.resources, dispatch_one, max(1, ARTIST_CONCURRENCY)
+                        ctx.obj.resources, dispatch_one, max(1, ARTIST_CONCURRENCY),
+                        should_stop=_session_track_limit.is_reached,
                     )
                 finally:
                     # Flush report_playback pendientes y cierra la sesión HTTP compartida

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -311,6 +311,29 @@ def _download_exit_code(
     return 1 if any_identity_refused or cooperative_stop else None
 
 
+def _resolve_prefer_hires(track_quality: str, hires_client: str) -> bool:
+    """Which client backs the WHOLE run, from the requested ``-q`` + config
+    ``hires_client`` — the STABLE matrix (restored from ``d1613b0``):
+
+    | quality  | hires_client | primary |
+    |----------|--------------|---------|
+    | high     | auto         | TV      |
+    | max      | auto         | HiRes   |
+    | any      | never        | TV      |
+    | any      | always       | HiRes   |
+
+    Only ``max`` (auto) or ``always`` put the strict HiRes client on the whole
+    run; ``high`` (auto) and ``never`` stay on the lenient TV client. A ``high``
+    run's occasional 24-bit-only (Atmos) track is escalated PER-TRACK to a
+    secondary HiRes client instead of promoting the whole run (which is what
+    ``05b1eca`` did, causing real 429s). Pure function for direct unit coverage."""
+    if hires_client == "always":
+        return True
+    if hires_client == "never":
+        return False
+    return track_quality == "max"  # "auto"
+
+
 def _finish_download_run(
     console, any_identity_refused: bool, cooperative_stop: bool = False
 ) -> "int | None":
@@ -891,17 +914,12 @@ def download_callback(
     # `hires_client` + the requested -q. The HiRes client has a strict TIDAL
     # rate limit (429 on big lists); the TV client is lenient but tops at
     # LOSSLESS. Set BEFORE any ctx.obj.api access (the refresh below builds it).
-    _hires_mode = CONFIG.download.hires_client
-    if _hires_mode == "always":
-        ctx.obj.prefer_hires = True
-    elif _hires_mode == "never":
-        ctx.obj.prefer_hires = False
-    else:  # "auto": use the HiRes client for any FLAC start (high or max). high
-        # needs it too now, because an Atmos track has no 16-bit FLAC and the
-        # cascade climbs it to the 24-bit `max` FLAC (preferring FLAC over Atmos),
-        # which only the HiRes client can deliver. The run-wide 429 breaker makes
-        # this safe on big LOSSLESS runs, which is why "auto" no longer avoids it.
-        ctx.obj.prefer_hires = TRACK_QUALITY in ("high", "max")
+    # Which client_id backs ALL requests this run — the stable matrix
+    # (`high`/`never` -> TV lenient LOSSLESS, `max`/`always` -> HiRes strict). A
+    # `high` run's occasional 24-bit-only (Atmos) track is escalated PER-TRACK to
+    # a secondary HiRes client (see the downloader), NOT run-wide, so a big `high`
+    # run cannot storm the HiRes rate limit. (Reverts 05b1eca.)
+    ctx.obj.prefer_hires = _resolve_prefer_hires(TRACK_QUALITY, CONFIG.download.hires_client)
 
     # Lyrics come from [metadata] in config.toml; these flags override per run
     # (the download flow reads CONFIG.metadata at runtime).
@@ -1267,6 +1285,16 @@ def download_callback(
             scan_path=SCAN_PATH,
             video_download_path=VIDEO_DOWNLOAD_PATH,
             fallback_api=ctx.obj.fallback_api,
+            # Secondary HiRes client for the PER-TRACK `max` ascent — only in
+            # `auto` while TV is the primary (i.e. `high + auto`). In `max`/`always`
+            # HiRes is already the primary (`api`), and `never` must never build or
+            # call a HiRes client, so both pass None here.
+            hires_api=(
+                ctx.obj.hires_api
+                if (CONFIG.download.hires_client == "auto" and not ctx.obj.prefer_hires)
+                else None
+            ),
+            primary_client_kind=("hires" if ctx.obj.prefer_hires else "tv"),
             destination_identity=CONFIG.download.destination_identity,
             identity_tracker=identity_tracker,
             audio_mode=AUDIO_MODE,

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -451,6 +451,54 @@ async def _bounded_dispatch(items, handler, concurrency: int, should_stop=None) 
         raise
 
 
+async def _expand_playlist_resources(
+    api, playlist_uuid: str, *, expand_albums: bool, expand_tracks: bool
+) -> "tuple[list[TidalResource], int, str]":
+    """Expand one playlist into its unique albums / credited artists / tracks.
+
+    The dedupe + mode semantics of the inline ``expand_playlist``, lifted to a
+    module function so the expansion FAN-OUT is directly testable with a fake API
+    — this is where ``--artists`` (every credited artist, each later enumerated
+    into a WHOLE discography) diverges from ``--albums`` (only the albums the
+    playlist already lists). Every call goes through ``api``; in production that
+    is ``ctx.obj.api``, which for ``high + auto`` is the lenient TV client — so a
+    ``--artists`` expansion never touches the strict HiRes client.
+
+    Returns ``(resources, skipped_videos, playlist_title)``."""
+    playlist = await asyncio.to_thread(api.get_playlist, playlist_uuid=playlist_uuid)
+    seen: set = set()
+    expanded: "list[TidalResource]" = []
+    skipped_videos = 0
+    offset = 0
+    while True:
+        page = await asyncio.to_thread(
+            api.get_playlist_items, playlist_uuid=playlist_uuid, offset=offset,
+        )
+        for playlist_item in page.items:
+            item = playlist_item.item
+            if not isinstance(item, Track):
+                skipped_videos += 1
+                continue
+            if expand_albums:
+                if item.album and item.album.id not in seen:
+                    seen.add(item.album.id)
+                    expanded.append(TidalResource(type="album", id=str(item.album.id)))
+            elif expand_tracks:
+                if item.id not in seen:
+                    seen.add(item.id)
+                    expanded.append(TidalResource(type="track", id=str(item.id)))
+            else:
+                artists = item.artists or ([item.artist] if item.artist else [])
+                for artist in artists:
+                    if artist and artist.id and artist.id not in seen:
+                        seen.add(artist.id)
+                        expanded.append(TidalResource(type="artist", id=str(artist.id)))
+        offset += page.limit
+        if offset >= page.totalNumberOfItems:
+            break
+    return expanded, skipped_videos, getattr(playlist, "title", "")
+
+
 def plan_stereo_resolution(result, keep_original: bool) -> tuple:
     """Pure pre-confirmation decision for the stereo resolution of one album.
 
@@ -2625,44 +2673,18 @@ def download_callback(
 
             async def expand_playlist(resource: TidalResource) -> list[TidalResource]:
                 """--albums/--artists: turn a playlist into its unique albums or
-                credited artists (same dedupe semantics as tidmon playlist)."""
-                playlist = await asyncio.to_thread(
-                    ctx.obj.api.get_playlist, playlist_uuid=resource.id
+                credited artists (same dedupe semantics as tidmon playlist).
+
+                Core lives in the module-level `_expand_playlist_resources` (so the
+                expansion fan-out is unit-testable); this keeps the console line.
+                Every API call goes through `ctx.obj.api` — TV for high+auto."""
+                expanded, skipped_videos, title = await _expand_playlist_resources(
+                    ctx.obj.api, resource.id,
+                    expand_albums=EXPAND_ALBUMS, expand_tracks=EXPAND_TRACKS,
                 )
-                seen: set = set()
-                expanded: list[TidalResource] = []
-                skipped_videos = 0
-                offset = 0
-                while True:
-                    page = await asyncio.to_thread(
-                        ctx.obj.api.get_playlist_items,
-                        playlist_uuid=resource.id, offset=offset,
-                    )
-                    for playlist_item in page.items:
-                        item = playlist_item.item
-                        if not isinstance(item, Track):
-                            skipped_videos += 1
-                            continue
-                        if EXPAND_ALBUMS:
-                            if item.album and item.album.id not in seen:
-                                seen.add(item.album.id)
-                                expanded.append(TidalResource(type="album", id=str(item.album.id)))
-                        elif EXPAND_TRACKS:
-                            if item.id not in seen:
-                                seen.add(item.id)
-                                expanded.append(TidalResource(type="track", id=str(item.id)))
-                        else:
-                            artists = item.artists or ([item.artist] if item.artist else [])
-                            for artist in artists:
-                                if artist and artist.id and artist.id not in seen:
-                                    seen.add(artist.id)
-                                    expanded.append(TidalResource(type="artist", id=str(artist.id)))
-                    offset += page.limit
-                    if offset >= page.totalNumberOfItems:
-                        break
                 kind = "albums" if EXPAND_ALBUMS else ("tracks" if EXPAND_TRACKS else "artists")
                 msg = (
-                    f"\n[bold magenta]Playlist expanded:[/] {playlist.title} "
+                    f"\n[bold magenta]Playlist expanded:[/] {title} "
                     f"-> [bold]{len(expanded)} unique {kind}[/]"
                 )
                 if skipped_videos:

--- a/tiddl/cli/commands/download/__init__.py
+++ b/tiddl/cli/commands/download/__init__.py
@@ -889,6 +889,11 @@ def download_callback(
         CONFIG.download.hires_client = HIRES_CLIENT
     if REQUESTS_PER_MINUTE is not None:
         CONFIG.download.requests_per_minute = REQUESTS_PER_MINUTE
+    # Build the ONE shared request budget from the EFFECTIVE rpm (config +
+    # optional --rpm override just applied) BEFORE any client is constructed, so
+    # both the TV and HiRes clients space their COMBINED traffic at the effective
+    # rate. Done unconditionally: with no --rpm this uses the config value.
+    ctx.obj.configure_request_budget(CONFIG.download.requests_per_minute)
     if UPDATE_MTIME is not None:
         CONFIG.download.update_mtime = UPDATE_MTIME
     if EXCLUDE_COMPILATIONS is not None:

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -100,6 +100,30 @@ def _pick_stream_client(quality, primary_api, primary_kind: str, hires_api):
     return primary_api, primary_kind
 
 
+def _hires_capable(primary_kind: str, hires_api) -> bool:
+    """Whether THIS run can serve a 24-bit ``HI_RES_LOSSLESS`` request at all:
+    either the primary client is HiRes (``max``/``always``), or a secondary HiRes
+    client exists for the per-track ascent (``high + auto`` with a HiRes token).
+
+    False for ``never`` and for ``high + auto`` when no HiRes token is set up.
+    """
+    return primary_kind == "hires" or hires_api is not None
+
+
+def _supported_attempts(qualities, primary_kind: str, hires_api):
+    """Filter the per-track cascade down to tiers a client can actually serve.
+
+    Only ``HI_RES_LOSSLESS`` is capability-gated: when the run has no HiRes-capable
+    client (:func:`_hires_capable` is False) it is DROPPED rather than routed to
+    the TV primary — the TV client cannot deliver the 24-bit FLAC, so sending it
+    ``HI_RES_LOSSLESS`` would waste a request and (pre-fix) mislabel the result.
+    The cascade then continues on the next offered tier per ``quality_policy``.
+    Every other tier is served by the primary (TV or HiRes) and is kept as-is."""
+    if _hires_capable(primary_kind, hires_api):
+        return list(qualities)
+    return [q for q in qualities if q != "HI_RES_LOSSLESS"]
+
+
 def _guarded_mkdir(root: Path, path: Path, mode: str) -> "anchor.AnchorCheck":
     """Operations 1/2 (destination-volume identity, v2.2 §1): checked
     immediately before creating this item's directory — a refusal here is
@@ -417,12 +441,9 @@ class Downloader:
         # Secondary HiRes client for the PER-TRACK `max` (HI_RES_LOSSLESS) ascent
         # while TV backs the run (`high + auto`). None in HiRes-primary / `never`.
         self.hires_api = hires_api
-        # Which client backs `self.api`, for the per-attempt (client_kind, quality)
-        # record: "tv" for `high`/`never`, "hires" for `max`/`always`.
+        # Which client backs `self.api`: "tv" for `high`/`never`, "hires" for
+        # `max`/`always`. Used per-attempt to route and de-dup stream requests.
         self.primary_client_kind = primary_client_kind
-        # Stream attempts of the LAST download() call as (client_kind, quality) —
-        # for the no-cycle de-dup and for offline tests (client/order/count).
-        self.last_stream_attempts: list[tuple[str, str]] = []
         self.rich_output = rich_output
         self.semaphore = asyncio.Semaphore(threads_count)
         # Keep the user tier separate from TIDAL's playback enum. User
@@ -1278,11 +1299,19 @@ class Downloader:
                 attempt_qualities: list[TrackQuality] = cascade_api_qualities(
                     self.requested_quality, _tagset
                 ) or ["LOW"]
+                # Capability filter: if this run has no HiRes-capable client
+                # (`never`, or `high + auto` without a HiRes token) drop the 24-bit
+                # HI_RES_LOSSLESS rung instead of routing it to the TV primary,
+                # which cannot serve it. Keeps `never` from ever emitting a HiRes
+                # quality and stops a missing-token run from sending Max to TV.
+                attempt_qualities = _supported_attempts(
+                    attempt_qualities, self.primary_client_kind, self.hires_api
+                ) or ["LOW"]
 
-                # Per-track (client_kind, quality) record: for de-dup (never issue
-                # the same pair twice — prevents a request cycle when a controlled
-                # fallback re-enters the cascade) and for offline tests.
-                self.last_stream_attempts = []
+                # Per-track de-dup: never issue the same (client_kind, quality)
+                # pair twice — prevents a request cycle when a controlled fallback
+                # re-enters the cascade. LOCAL to this download() call (no shared
+                # instance state) so concurrent tracks never race on it.
                 _tried: set = set()
 
                 for _qi, q in enumerate(attempt_qualities):
@@ -1302,7 +1331,6 @@ class Downloader:
                     if (_kind, q) in _tried:
                         continue
                     _tried.add((_kind, q))
-                    self.last_stream_attempts.append((_kind, q))
                     try:
                         # Use asyncio.to_thread to prevent blocking the event loop during retries (sleep)
                         stream = await asyncio.to_thread(_client.get_track_stream, track_id=item.id, quality=q)
@@ -1349,7 +1377,6 @@ class Downloader:
                             and quality_score.get(stream.audioQuality, 0) < quality_score.get("LOSSLESS", 2)
                             and ("tv", "LOSSLESS") not in _tried):
                         _tried.add(("tv", "LOSSLESS"))
-                        self.last_stream_attempts.append(("tv", "LOSSLESS"))
                         try:
                             _fb = await asyncio.to_thread(
                                 self.fallback_api.get_track_stream, track_id=item.id, quality="LOSSLESS"

--- a/tiddl/cli/commands/download/downloader.py
+++ b/tiddl/cli/commands/download/downloader.py
@@ -86,6 +86,20 @@ def _abort_for_authentication_error(error: Exception) -> bool:
     return True
 
 
+def _pick_stream_client(quality, primary_api, primary_kind: str, hires_api):
+    """Client + kind for ONE per-track stream attempt.
+
+    The 24-bit ``max`` (``HI_RES_LOSSLESS``) tier goes to the SECONDARY HiRes
+    client when one is provided — the per-track ascent in TV-primary
+    ``high + auto`` for an Atmos track whose only FLAC is 24-bit. Every other
+    tier — and ``HI_RES_LOSSLESS`` itself when no secondary HiRes client exists
+    (HiRes is already primary, or ``never``) — goes to the primary. Pure function
+    for direct unit coverage of the per-track routing."""
+    if quality == "HI_RES_LOSSLESS" and hires_api is not None:
+        return hires_api, "hires"
+    return primary_api, primary_kind
+
+
 def _guarded_mkdir(root: Path, path: Path, mode: str) -> "anchor.AnchorCheck":
     """Operations 1/2 (destination-volume identity, v2.2 §1): checked
     immediately before creating this item's directory — a refusal here is
@@ -389,6 +403,8 @@ class Downloader:
         scan_path: Path,
         video_download_path: Optional[Path] = None,
         fallback_api: Optional[TidalAPI] = None,
+        hires_api: Optional[TidalAPI] = None,
+        primary_client_kind: Literal["tv", "hires"] = "hires",
         destination_identity: Literal["off", "strict"] = "off",
         identity_tracker: Optional["anchor.IdentityFailureTracker"] = None,
         audio_mode: Literal["auto", "stereo"] = "auto",
@@ -398,6 +414,15 @@ class Downloader:
         # Modo hibrido: cliente TV (lossless) para cuando el primario (HiRes)
         # degrada un track no-HiRes a 320. None = sin fallback.
         self.fallback_api = fallback_api
+        # Secondary HiRes client for the PER-TRACK `max` (HI_RES_LOSSLESS) ascent
+        # while TV backs the run (`high + auto`). None in HiRes-primary / `never`.
+        self.hires_api = hires_api
+        # Which client backs `self.api`, for the per-attempt (client_kind, quality)
+        # record: "tv" for `high`/`never`, "hires" for `max`/`always`.
+        self.primary_client_kind = primary_client_kind
+        # Stream attempts of the LAST download() call as (client_kind, quality) —
+        # for the no-cycle de-dup and for offline tests (client/order/count).
+        self.last_stream_attempts: list[tuple[str, str]] = []
         self.rich_output = rich_output
         self.semaphore = asyncio.Semaphore(threads_count)
         # Keep the user tier separate from TIDAL's playback enum. User
@@ -1254,14 +1279,33 @@ class Downloader:
                     self.requested_quality, _tagset
                 ) or ["LOW"]
 
+                # Per-track (client_kind, quality) record: for de-dup (never issue
+                # the same pair twice — prevents a request cycle when a controlled
+                # fallback re-enters the cascade) and for offline tests.
+                self.last_stream_attempts = []
+                _tried: set = set()
+
                 for _qi, q in enumerate(attempt_qualities):
                     # Cooperative cancel: don't try the next quality tier if the
                     # user cancelled while the previous tier was being fetched.
                     if is_cancelled():
                         return None, False
+                    # Per-track `max` ascent: an Atmos track whose only FLAC is the
+                    # 24-bit HI_RES_LOSSLESS tier needs the SECONDARY HiRes client
+                    # for THIS request only; every other tier stays on the primary.
+                    # In HiRes-primary / `never`, hires_api is None.
+                    _client, _kind = _pick_stream_client(
+                        q, self.api, self.primary_client_kind, self.hires_api
+                    )
+                    # Never re-issue the same (client, quality): a controlled
+                    # fallback must not form a request cycle.
+                    if (_kind, q) in _tried:
+                        continue
+                    _tried.add((_kind, q))
+                    self.last_stream_attempts.append((_kind, q))
                     try:
                         # Use asyncio.to_thread to prevent blocking the event loop during retries (sleep)
-                        stream = await asyncio.to_thread(self.api.get_track_stream, track_id=item.id, quality=q)
+                        stream = await asyncio.to_thread(_client.get_track_stream, track_id=item.id, quality=q)
                     except Exception as e:
                         # Check for Asset Not Ready (4005) first to avoid noisy logs
                         try:
@@ -1302,7 +1346,10 @@ class Downloader:
                     # lossless), pide LOSSLESS al cliente fallback (TV), que SI entrega
                     # el FLAC 16-bit. Headless, sin ventanas. Sustituye el stream.
                     if (self.fallback_api is not None
-                            and quality_score.get(stream.audioQuality, 0) < quality_score.get("LOSSLESS", 2)):
+                            and quality_score.get(stream.audioQuality, 0) < quality_score.get("LOSSLESS", 2)
+                            and ("tv", "LOSSLESS") not in _tried):
+                        _tried.add(("tv", "LOSSLESS"))
+                        self.last_stream_attempts.append(("tv", "LOSSLESS"))
                         try:
                             _fb = await asyncio.to_thread(
                                 self.fallback_api.get_track_stream, track_id=item.id, quality="LOSSLESS"

--- a/tiddl/cli/ctx.py
+++ b/tiddl/cli/ctx.py
@@ -12,6 +12,7 @@ from filelock import FileLock
 from rich.console import Console
 
 from tiddl.core.api import TidalClientImproved, TidalAPI
+from tiddl.core.api.budget import SharedRequestBudget
 from tiddl.cli.config import APP_PATH, CONFIG
 from tiddl.core.auth import AuthAPI
 from tiddl.core.auth.client import get_auth_client_for
@@ -30,6 +31,9 @@ class ContextObject:
     _api: TidalAPI | None
     _fallback_api: TidalAPI | None
     _fallback_built: bool
+    _hires_api: TidalAPI | None
+    _hires_built: bool
+    request_budget: SharedRequestBudget
     api_omit_cache: bool
     debug_path: Path | None
 
@@ -41,8 +45,16 @@ class ContextObject:
         self._api = None
         self._fallback_api = None
         self._fallback_built = False
+        self._hires_api = None
+        self._hires_built = False
         self.api_omit_cache = api_omit_cache
         self.debug_path = debug_path
+        # ONE shared request budget for THIS run/context: the primary client, the
+        # LOSSLESS fallback (HiRes mode) and the secondary HiRes client (per-track
+        # `max` ascent in TV mode) all draw from it, so their COMBINED traffic
+        # stays within requests_per_minute. Per-context (NOT process-global): a new
+        # run starts clean and Cancel/401/429 cleanup just drops the context.
+        self.request_budget = SharedRequestBudget(CONFIG.download.requests_per_minute)
         # Which client_id backs the PRIMARY api. True = HiRes (fX2Jxdmnt): 24-bit
         # but a STRICT TIDAL rate limit (429 on big lists). False = TV
         # (4N3n6Q1x95LL5K7p): LOSSLESS 16-bit but lenient. The download command
@@ -102,6 +114,7 @@ class ContextObject:
             refresh_token=auth_data.refresh_token,
             token_expiry=auth_data.expires_at,
             requests_per_minute=CONFIG.download.requests_per_minute,
+            budget=self.request_budget,
         )
 
         return TidalAPI(client, auth_data.user_id, auth_data.country_code)
@@ -140,6 +153,25 @@ class ContextObject:
                 AUTH_FALLBACK_FILE, "auth_refresh_fallback.lock", "api_cache_fallback", require=False
             )
         return self._fallback_api
+
+    @property
+    def hires_api(self) -> TidalAPI | None:
+        """SECONDARY HiRes client for the per-track ``max`` ascent in TV-primary
+        mode — an Atmos track whose only FLAC is the 24-bit HI_RES_LOSSLESS tier.
+
+        DISTINCT from ``fallback_api`` (which is the TV client used to fix HiRes
+        degradation when HiRes is primary): this is the HiRes client used only for
+        the occasional per-track HI_RES_LOSSLESS request while TV backs the run.
+        It shares this run's request budget. The caller must NOT touch it when
+        ``hires_client='never'`` and does not need it when HiRes is already the
+        primary (``max``/``always`` — then ``api`` handles HI_RES_LOSSLESS).
+        ``require=False`` so it is ``None`` when no HiRes token exists."""
+        if not self._hires_built:
+            self._hires_built = True
+            self._hires_api = self._build_api(
+                AUTH_DATA_FILE, "auth_refresh.lock", "api_cache", require=False
+            )
+        return self._hires_api
 
 
 class Context(typer.Context):

--- a/tiddl/cli/ctx.py
+++ b/tiddl/cli/ctx.py
@@ -33,7 +33,7 @@ class ContextObject:
     _fallback_built: bool
     _hires_api: TidalAPI | None
     _hires_built: bool
-    request_budget: SharedRequestBudget
+    _request_budget: SharedRequestBudget | None
     api_omit_cache: bool
     debug_path: Path | None
 
@@ -54,13 +54,43 @@ class ContextObject:
         # `max` ascent in TV mode) all draw from it, so their COMBINED traffic
         # stays within requests_per_minute. Per-context (NOT process-global): a new
         # run starts clean and Cancel/401/429 cleanup just drops the context.
-        self.request_budget = SharedRequestBudget(CONFIG.download.requests_per_minute)
+        #
+        # Created LAZILY (see the `request_budget` property) so it captures the
+        # EFFECTIVE requests_per_minute — the download command applies any `--rpm`
+        # CLI override to CONFIG and then calls `configure_request_budget()` BEFORE
+        # the first client is built. Building it eagerly here would freeze the
+        # pre-override config value and silently ignore `--rpm`.
+        self._request_budget = None
         # Which client_id backs the PRIMARY api. True = HiRes (fX2Jxdmnt): 24-bit
         # but a STRICT TIDAL rate limit (429 on big lists). False = TV
         # (4N3n6Q1x95LL5K7p): LOSSLESS 16-bit but lenient. The download command
         # sets this from config `hires_client` + the requested -q. Default True
         # for back-compat (auth/other commands keep using the primary token).
         self.prefer_hires = True
+
+    @property
+    def request_budget(self) -> SharedRequestBudget:
+        """The ONE shared budget for this run, created on first access from the
+        EFFECTIVE requests_per_minute in CONFIG. The download command resolves the
+        effective RPM (config + optional `--rpm`) and calls
+        `configure_request_budget()` before any client is built, so both clients
+        get a budget spaced at the effective rate. Commands that never touch
+        `--rpm` simply read the config value here."""
+        if self._request_budget is None:
+            self._request_budget = SharedRequestBudget(
+                CONFIG.download.requests_per_minute
+            )
+        return self._request_budget
+
+    def configure_request_budget(self, requests_per_minute: int) -> None:
+        """(Re)create the shared budget from the EFFECTIVE requests_per_minute.
+
+        Called by the download command AFTER applying any `--rpm` CLI override to
+        CONFIG and BEFORE the first client is constructed (clients capture the
+        budget object at build time). Recreating — rather than mutating — keeps
+        the object immutable once handed to a client, and starts the run's spacing
+        clock clean."""
+        self._request_budget = SharedRequestBudget(requests_per_minute)
 
     def _build_api(
         self, auth_file: Path, lock_name: str, cache_name: str, require: bool

--- a/tiddl/core/api/budget.py
+++ b/tiddl/core/api/budget.py
@@ -12,10 +12,15 @@ each client — deliberately **NOT** process-global:
 * tests are deterministic (inject a fake clock);
 * the reusable in-process GUI host accrues no extra global state.
 
-Only a **real HTTP request** consumes budget: a cache hit must call neither
-:meth:`throttle` nor must it leave a slot spent (see :meth:`refund`). A 429
-retry is a real request and consumes budget again (and still counts for the
-run-wide 429 circuit breaker, which is a separate last-resort protection).
+Only a **real HTTP request** consumes budget, and the client enforces that by
+*peeking the cache first*: a true cache hit returns before :meth:`throttle` is
+ever called, so it pays no spacing. There is deliberately **no** "refund" that
+moves the spacing clock backward — in concurrent use that could roll back a slot
+another thread had already reserved and let a later request burst past the RPM.
+A conditional revalidation that comes back ``304`` is a genuine network
+round-trip, so it correctly keeps the slot it throttled for. A 429 retry is a
+real request too and consumes budget again (and still counts for the run-wide
+429 circuit breaker, which is a separate last-resort protection).
 """
 from __future__ import annotations
 
@@ -72,11 +77,3 @@ class SharedRequestBudget:
                 self._sleep(wait)
             self._last = self._clock()
             self.request_count += 1
-
-    def refund(self) -> None:
-        """Return the slot when an admitted 'request' was actually served from
-        cache (revalidated) and consumed no network quota."""
-        with self._lock:
-            self._last = self._clock() - self._interval
-            if self.request_count > 0:
-                self.request_count -= 1

--- a/tiddl/core/api/budget.py
+++ b/tiddl/core/api/budget.py
@@ -1,0 +1,82 @@
+"""Per-run shared request budget.
+
+ONE throttle, shared by every client_id of a single :class:`ContextObject`, so
+the TV and HiRes clients *together* cannot exceed the configured
+``requests_per_minute``. It is created by the ``ContextObject`` and injected into
+each client — deliberately **NOT** process-global:
+
+* a new run/context gets a fresh budget, so a prior run cannot contaminate the
+  next;
+* state cleanup after Cancel / 401 / 429 is trivial (drop the context);
+* two independent contexts can coexist in one process;
+* tests are deterministic (inject a fake clock);
+* the reusable in-process GUI host accrues no extra global state.
+
+Only a **real HTTP request** consumes budget: a cache hit must call neither
+:meth:`throttle` nor must it leave a slot spent (see :meth:`refund`). A 429
+retry is a real request and consumes budget again (and still counts for the
+run-wide 429 circuit breaker, which is a separate last-resort protection).
+"""
+from __future__ import annotations
+
+import random
+import threading
+import time as _time
+from typing import Callable, Optional
+
+
+class SharedRequestBudget:
+    """Shared fixed-interval throttle for the combined TV + HiRes traffic of one run.
+
+    ``TV requests + HiRes requests`` are spaced at ``60 / requests_per_minute``
+    seconds, so their aggregate rate stays at or below the configured RPM.
+    """
+
+    def __init__(
+        self,
+        requests_per_minute: int = 50,
+        *,
+        clock: Optional[Callable[[], float]] = None,
+        sleeper: Optional[Callable[[float], None]] = None,
+        jitter: Optional[Callable[[], float]] = None,
+    ) -> None:
+        rpm = requests_per_minute if requests_per_minute > 0 else 50
+        self._interval = 60.0 / rpm
+        self._lock = threading.Lock()
+        # -inf so the FIRST request of a run never waits (nothing precedes it),
+        # matching the previous per-client behaviour where a 0 timestamp vs a
+        # large wall clock left the first request un-throttled.
+        self._last = float("-inf")
+        # Injectable for deterministic tests; default to real monotonic time.
+        self._clock = clock or _time.monotonic
+        self._sleep = sleeper or _time.sleep
+        self._jitter = jitter if jitter is not None else (lambda: random.uniform(0, 0.3))
+        # Count of real HTTP requests admitted (cache hits excluded). For tests
+        # and inspection; the combined TV+HiRes total of this run.
+        self.request_count = 0
+
+    @property
+    def interval(self) -> float:
+        return self._interval
+
+    def throttle(self) -> None:
+        """Block until a real HTTP request may proceed under the SHARED interval.
+
+        Call exactly once immediately before a real network request — never for
+        a cache hit.
+        """
+        with self._lock:
+            now = self._clock()
+            wait = self._interval - (now - self._last) + self._jitter()
+            if wait > 0:
+                self._sleep(wait)
+            self._last = self._clock()
+            self.request_count += 1
+
+    def refund(self) -> None:
+        """Return the slot when an admitted 'request' was actually served from
+        cache (revalidated) and consumed no network quota."""
+        with self._lock:
+            self._last = self._clock() - self._interval
+            if self.request_count > 0:
+                self.request_count -= 1

--- a/tiddl/core/api/client.py
+++ b/tiddl/core/api/client.py
@@ -230,10 +230,12 @@ class TidalClientImproved:
                 params=params,
                 expire_after=expire_after
             )
-
-            # Cache hits don't consume API quota — release the slot
-            if getattr(res, 'from_cache', False):
-                self._budget.refund()
+            # A true cache hit was already served by the only_if_cached peek
+            # above (before throttle). If this GET still comes back from_cache it
+            # was a conditional revalidation — a real network round-trip — so it
+            # keeps the slot it just throttled for. We deliberately never hand the
+            # slot back: moving the shared spacing clock backward here could roll
+            # back a reservation another thread already made and burst past RPM.
 
         # ============================================================
         # IMPROVEMENT 5: Detailed rate limiting handling (429)

--- a/tiddl/core/api/client.py
+++ b/tiddl/core/api/client.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 from time import sleep
 import time
 import random
-import threading
 
 # CRITICAL FIX: Import HTTPError
 from requests.exceptions import JSONDecodeError, HTTPError
@@ -21,6 +20,7 @@ from requests_cache import (
 import requests as _requests
 
 from .exceptions import ApiError
+from .budget import SharedRequestBudget
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -46,9 +46,8 @@ class TidalClientImproved:
     session: CachedSession
     on_token_expiry: Optional[Callable[[bool, int], Union[tuple[str, int, Union[str, None]], None]]]
     
-    # Rate Limiting: 60 requests per minute
-    _last_request_time: float
-    _request_interval: float
+    # Base fixed-interval spacing lives in a SHARED per-run budget (budget.py);
+    # only the adaptive 429 backoff is per-client.
 
     def __init__(
         self,
@@ -60,18 +59,19 @@ class TidalClientImproved:
         refresh_token: Optional[str] = None,
         token_expiry: Optional[int] = None,  # Unix timestamp
         requests_per_minute: int = 50,
+        budget: "SharedRequestBudget | None" = None,
     ) -> None:
         self.on_token_expiry = on_token_expiry
         self.debug_path = debug_path
         self._refresh_token = refresh_token
         self._token_expiry = token_expiry
 
-        # Rate Limiting Init
-        safe_rpm = requests_per_minute if requests_per_minute > 0 else 50
-        self._last_request_time = 0.0
-        self._request_interval = 60.0 / safe_rpm
-        self._rate_lock = threading.Lock()
-        self._rate_limit_delay: float = 0.0  # Adaptive: grows on 429, shrinks on success
+        # Rate Limiting Init. The base fixed-interval spacing lives in a SHARED
+        # per-run budget so the TV + HiRes clients of one context cannot jointly
+        # exceed requests_per_minute. If no budget is injected (standalone use),
+        # own a private one — preserving prior single-client behaviour.
+        self._budget = budget if budget is not None else SharedRequestBudget(requests_per_minute)
+        self._rate_limit_delay: float = 0.0  # Adaptive per-client 429 backoff
         self._refresh_blocked: bool = False  # Set when refresh returns a permanent 4xx
         
         self._omit_cache = omit_cache
@@ -220,13 +220,10 @@ class TidalClientImproved:
             if self._rate_limit_delay > 0:
                 time.sleep(self._rate_limit_delay)
 
-            # Rate Limiting Enforcement (thread-safe, fixed interval + jitter)
-            with self._rate_lock:
-                elapsed = time.time() - self._last_request_time
-                wait = self._request_interval - elapsed + random.uniform(0, 0.3)
-                if wait > 0:
-                    time.sleep(wait)
-                self._last_request_time = time.time()
+            # Shared per-run budget: the combined TV + HiRes traffic of this
+            # context is spaced at 60/RPM, so activating both clients cannot
+            # double the configured requests_per_minute. Thread-safe + jittered.
+            self._budget.throttle()
 
             res = self.session.get(
                 f"{base_url}/{endpoint}",
@@ -236,8 +233,7 @@ class TidalClientImproved:
 
             # Cache hits don't consume API quota — release the slot
             if getattr(res, 'from_cache', False):
-                with self._rate_lock:
-                    self._last_request_time = time.time() - self._request_interval
+                self._budget.refund()
 
         # ============================================================
         # IMPROVEMENT 5: Detailed rate limiting handling (429)

--- a/tiddl/core/download_policy.py
+++ b/tiddl/core/download_policy.py
@@ -3,22 +3,54 @@ from dataclasses import dataclass
 
 @dataclass
 class SessionTrackLimit:
-    """Small, synchronous gate for a per-process track limit.
+    """Per-run gate for ``max_tracks_per_session``.
 
-    ``admit`` returns whether the item may continue and whether the caller
-    should display the limit warning.  The warning is deliberately emitted
-    only once even when many already-scheduled items reach the gate.
+    **What the cap counts (defined):** only tracks this run actually FETCHED
+    (``record(was_downloaded=True)``). A track already complete on disk — the
+    common ``skip_existing`` case — does NOT consume the cap, so a run over a
+    mostly-downloaded library keeps making progress on the genuinely-missing
+    tracks instead of the cap being eaten by files already present. This is a
+    deliberate change from the old behaviour, which counted every *admitted*
+    track (i.e. also the already-present ones).
+
+    Reaching the cap latches :attr:`reached` — a run-wide signal that is
+    **distinct from Cancel / 401 / 429**. It means "this run has downloaded its
+    quota; stop taking new work and let the caller resume later", NOT an error or
+    a user cancel, so the run still exits 0. Callers gate new dispatch /
+    enumeration on :meth:`is_reached` and let already-admitted downloads finish.
     """
 
     limit: int
-    count: int = 0
+    downloaded: int = 0
+    reached: bool = False
     announced: bool = False
 
+    def is_enabled(self) -> bool:
+        return self.limit > 0
+
+    def is_reached(self) -> bool:
+        """Run-wide 'quota used up' signal. Monotonic once set."""
+        return self.reached
+
     def admit(self) -> tuple[bool, bool]:
-        if self.limit > 0 and self.count >= self.limit:
+        """Gate ONE track just before it is downloaded.
+
+        Returns ``(admitted, should_announce)``. Not admitted once the quota of
+        NEW downloads is used up; the warning is flagged exactly once even when
+        many already-scheduled tracks reach the gate afterwards.
+        """
+        if self.limit > 0 and self.downloaded >= self.limit:
+            self.reached = True
             should_announce = not self.announced
             self.announced = True
             return False, should_announce
-
-        self.count += 1
         return True, False
+
+    def record(self, was_downloaded: bool) -> None:
+        """Count a finished track toward the cap. Only a NEW download consumes
+        it — an already-present file does not. Latches :attr:`reached` when the
+        quota is exhausted so the run stops taking new work."""
+        if self.limit > 0 and was_downloaded:
+            self.downloaded += 1
+            if self.downloaded >= self.limit:
+                self.reached = True

--- a/tiddl/core/download_policy.py
+++ b/tiddl/core/download_policy.py
@@ -75,7 +75,14 @@ class SessionTrackLimit:
                 await fut
             except asyncio.CancelledError:
                 if fut in self._waiters:
+                    # Cancelled BEFORE being woken: just drop out of the queue.
                     self._waiters.remove(fut)
+                elif self.downloaded + self.reserved < self.limit:
+                    # Cancelled AFTER a release woke us but BEFORE we reserved: we
+                    # consumed a wakeup we can't use while a slot is still free. Pass
+                    # it on to the next waiter, or the freed slot is orphaned and the
+                    # remaining waiters deadlock. (Same re-wake asyncio.Lock does.)
+                    self._wake_one()
                 raise
             # woken: re-check from the top
 

--- a/tiddl/core/download_policy.py
+++ b/tiddl/core/download_policy.py
@@ -1,29 +1,49 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
 
 
 @dataclass
 class SessionTrackLimit:
-    """Per-run gate for ``max_tracks_per_session``.
+    """Per-run gate for ``max_tracks_per_session`` with an ATOMIC reservation.
 
-    **What the cap counts (defined):** only tracks this run actually FETCHED
-    (``record(was_downloaded=True)``). A track already complete on disk — the
-    common ``skip_existing`` case — does NOT consume the cap, so a run over a
-    mostly-downloaded library keeps making progress on the genuinely-missing
-    tracks instead of the cap being eaten by files already present. This is a
-    deliberate change from the old behaviour, which counted every *admitted*
-    track (i.e. also the already-present ones).
+    **The concurrency problem it solves.** Tracks download concurrently. A naive
+    "check a counter in ``admit()``, bump it after the download finishes" lets
+    several tasks pass the check at once (all see ``downloaded < limit``) and
+    overshoot the cap. So the cap is enforced with a per-track reservation:
 
-    Reaching the cap latches :attr:`reached` — a run-wide signal that is
-    **distinct from Cancel / 401 / 429**. It means "this run has downloaded its
-    quota; stop taking new work and let the caller resume later", NOT an error or
-    a user cancel, so the run still exits 0. Callers gate new dispatch /
-    enumeration on :meth:`is_reached` and let already-admitted downloads finish.
+        admitted = await reserve()   # takes a slot up front (or waits / is rejected)
+        path, new = await download()
+        commit() if new else release()   # a real download keeps the slot; an
+                                         # existing file gives it back
+
+    **Invariant:** ``downloaded + reserved <= limit`` at all times. ``reserve``
+    only takes a slot while ``downloaded + reserved < limit``; when every slot is
+    reserved it WAITS, and a ``release`` (an existing file, or a cancelled/errored
+    task) wakes one waiter so it can take the freed slot. Once ``downloaded``
+    reaches ``limit`` the cap is latched (:attr:`reached`) and every pending
+    waiter is woken to be rejected — a run-wide stop signal DISTINCT from
+    Cancel/401/429 (the run still exits 0).
+
+    **What counts (defined):** only a NEW download (``commit``) consumes the cap;
+    an already-present file (``release``) does not, and a waiter proceeds in its
+    place — so a run over a mostly-downloaded library keeps making progress on
+    the genuinely-missing tracks.
+
+    **Thread-safety.** asyncio is single-threaded; every counter read-modify-write
+    below happens WITHOUT an ``await`` in between (the only await is a waiter
+    parking on its own future), so the counters are never seen half-updated by
+    another task. This is the same discipline ``asyncio.Semaphore`` uses — a
+    future-based wait list, not an unguarded counter shared across ``await``s.
     """
 
     limit: int
     downloaded: int = 0
+    reserved: int = 0
     reached: bool = False
     announced: bool = False
+    _waiters: "list[asyncio.Future]" = field(default_factory=list, repr=False)
 
     def is_enabled(self) -> bool:
         return self.limit > 0
@@ -32,25 +52,75 @@ class SessionTrackLimit:
         """Run-wide 'quota used up' signal. Monotonic once set."""
         return self.reached
 
-    def admit(self) -> tuple[bool, bool]:
-        """Gate ONE track just before it is downloaded.
+    async def reserve(self) -> bool:
+        """Take a slot for ONE track before downloading it.
 
-        Returns ``(admitted, should_announce)``. Not admitted once the quota of
-        NEW downloads is used up; the warning is flagged exactly once even when
-        many already-scheduled tracks reach the gate afterwards.
+        Returns ``True`` if admitted (a slot was reserved — the caller MUST later
+        ``commit`` or ``release`` it), ``False`` if the cap is already used up.
+        Blocks while every remaining slot is reserved but not yet resolved, and
+        resumes when a ``release`` frees one or the cap is reached (then rejects).
         """
-        if self.limit > 0 and self.downloaded >= self.limit:
-            self.reached = True
-            should_announce = not self.announced
-            self.announced = True
-            return False, should_announce
-        return True, False
-
-    def record(self, was_downloaded: bool) -> None:
-        """Count a finished track toward the cap. Only a NEW download consumes
-        it — an already-present file does not. Latches :attr:`reached` when the
-        quota is exhausted so the run stops taking new work."""
-        if self.limit > 0 and was_downloaded:
-            self.downloaded += 1
+        if self.limit <= 0:
+            return True  # unlimited: no reservation needed
+        while True:
             if self.downloaded >= self.limit:
-                self.reached = True
+                return False  # cap used up — reject (already latched by commit)
+            if self.downloaded + self.reserved < self.limit:
+                self.reserved += 1  # atomic: no await between the check and here
+                return True
+            # Every slot is reserved (in flight). Wait for a release or the latch.
+            fut = asyncio.get_running_loop().create_future()
+            self._waiters.append(fut)
+            try:
+                await fut
+            except asyncio.CancelledError:
+                if fut in self._waiters:
+                    self._waiters.remove(fut)
+                raise
+            # woken: re-check from the top
+
+    def commit(self) -> bool:
+        """Confirm the reserved slot was a REAL new download.
+
+        Returns ``True`` iff THIS commit is the one that reached the cap and the
+        "limit reached" warning should be printed now — immediately, without
+        depending on a later track ever calling :meth:`reserve`."""
+        if self.limit <= 0:
+            return False
+        self.reserved -= 1
+        self.downloaded += 1
+        if self.downloaded >= self.limit:
+            self.reached = True
+            announce = self._announce()
+            self._wake_all()  # reject every pending waiter; stop the dispatcher
+            return announce
+        return False
+
+    def release(self) -> None:
+        """Give the reserved slot back WITHOUT counting it — an already-present
+        file, or a cancelled/errored task. Synchronous (never awaits), so it can
+        run safely from an ``except``/``finally`` during cancellation. Wakes one
+        waiter so it can take the freed slot."""
+        if self.limit <= 0:
+            return
+        self.reserved -= 1
+        self._wake_one()
+
+    def _announce(self) -> bool:
+        if not self.announced:
+            self.announced = True
+            return True
+        return False
+
+    def _wake_one(self) -> None:
+        while self._waiters:
+            fut = self._waiters.pop(0)
+            if not fut.done():
+                fut.set_result(None)
+                return
+
+    def _wake_all(self) -> None:
+        waiters, self._waiters = self._waiters, []
+        for fut in waiters:
+            if not fut.done():
+                fut.set_result(None)


### PR DESCRIPTION
## Problem

`05b1eca` widened `prefer_hires` from `TRACK_QUALITY == "max"` to `TRACK_QUALITY in ("high", "max")`. That made a whole **`high + auto`** run — every playlist / artist / album / credits enumeration included — go through the strict-rate-limited **HiRes** client (`fX2Jxdmnt`), and TIDAL answered with **real HTTP 429 (`Retry-After: 60`)** — not circuit-breaker false positives. Two amplifiers made it worse:

- each client owned its **own** per-minute limiter, so TV + HiRes could jointly issue up to **2× `requests_per_minute`**;
- the LOSSLESS `fallback_api` re-requested every HiRes track, **doubling** stream calls (`HiRes/LOSSLESS→HIGH` then `TV/LOSSLESS→FLAC`).

Baseline for comparison — `d1613b0`: `prefer_hires = TRACK_QUALITY == "max"` (stable). `05b1eca`: `TRACK_QUALITY in ("high", "max")` (regressed). This PR restores the `d1613b0` semantics and adds the per-track ascent + shared budget on top.

## Fix

**1. Stable client matrix** (revert the widening) — `_resolve_prefer_hires()` centralises it:

| `-q` | `hires_client` | primary client |
|------|----------------|----------------|
| high | auto | **TV** (LOSSLESS) |
| max  | auto | **HiRes** |
| any  | never | **TV** |
| any  | always | **HiRes** |

Enumeration (playlists / artists / albums / credits / metadata) in `high + auto` stays **entirely on TV**.

**2. Per-track `max` ascent (NOT run-wide).** The cascade decides from `mediaMetadata.tags`: only a track whose *sole* FLAC is the 24-bit `HI_RES_LOSSLESS` rung (e.g. Atmos) borrows a **secondary HiRes client** for that one stream; ordinary LOSSLESS tracks stay on TV. A dedicated `ContextObject.hires_api` (distinct from `fallback_api`) backs the ascent and is **never built or called** when `hires_client='never'`.

**3. `SharedRequestBudget` — per run/context, NOT process-global.** One budget object is created by `ContextObject` and injected into every client, so **TV + HiRes combined** traffic stays within `requests_per_minute` and cannot double it. Cache hits **refund** their slot (only a real HTTP request consumes budget; 429 retries do consume it and count for the breaker). A new run starts clean, and Cancel/401/429 cleanup just drops the context — no cross-run contamination, two independent contexts per process, deterministic tests.

```
ContextObject
└── SharedRequestBudget
    ├── TV client
    └── HiRes client
```

**4. No duplicate stream requests.** Each attempt is recorded as `(client_kind, quality)` and a pair is never issued twice, so the old `HiRes→TV` LOSSLESS re-request cycle is gone.

The run-wide **429 circuit breaker** stays as the last-resort host-safe stop (Cancel/401/429 handling from v1.5.3 is preserved); the budget is the primary defence, not a replacement for it.

## Call-count table (per scenario / client)

Stream requests per track, `requests_per_minute` shared across both clients.

| Scenario (`-q` / `hires_client`) | tags | TV | HiRes | note |
|---|---|---|---|---|
| high / auto — ordinary | `LOSSLESS` | 1 (`LOSSLESS`) | 0 | one TV request, FLAC |
| high / auto — Atmos w/ max FLAC | `DOLBY_ATMOS`,`HIRES_LOSSLESS` | 0 | 1 (`HI_RES_LOSSLESS`) | ascent only for this track; run stays TV |
| high / auto — no high/no max | (normal/low) | 1 (`HIGH`) | 0 | degrade per quality_policy, TV |
| max / auto | `HIRES_LOSSLESS` | 0 (fallback only) | 1 (`HI_RES_LOSSLESS`) | HiRes primary, no repeat |
| any / never | any | 1 | **0 (never built)** | HiRes client never constructed |
| any / always | any | 0 | 1 | HiRes run-wide |

Enumeration in `high + auto`: **all TV, 0 HiRes**.

## Validation

- Full suite: **451 passed, 3 skipped**. New `tests/test_hires_429_regression.py`: **18/18**.
- `ruff` on new files: clean; no new errors on modified files (`client.py` 29 == origin baseline).
- `compileall` on **3.10** and **3.13**: exit 0.
- CI (this PR): ubuntu + windows × Python 3.10–3.13.

## Scope / not in this PR

Engine only. **No merge** (awaiting independent authorization), no version bump / tag / release, no local install, no GUI repo or pin change, no GUI rebuild/publish, no Phase-2 subprocess isolation. All untracked local files preserved.

## Summary by Sourcery

Restore stable download client routing and add per-run rate budgeting and concurrency-safe session limits to prevent HiRes 429 storms and unnecessary API traffic.

New Features:
- Route high-quality downloads through TV by default while allowing per-track HiRes escalation for 24-bit-only streams.
- Share request-rate limiting across all clients within a download context.
- Stop session-limited runs cleanly and avoid checkpointing resources that were cut short.

Bug Fixes:
- Prevent HTTP 429 request storms caused by run-wide HiRes routing, independent client rate limits, and duplicate fallback stream requests.
- Prevent concurrent downloads from exceeding the configured session track limit.
- Prevent enumeration and API traffic from continuing after the session track limit is reached.

Enhancements:
- Eliminate duplicate client-and-quality stream attempts and preserve distinct routing for primary, fallback, and secondary HiRes clients.
- Keep playlist expansion and enumeration on the selected primary client, including high-quality auto runs.
- Make session-limit reservations release correctly for existing files, errors, and cancellation.

Tests:
- Add regression coverage for client routing, HiRes escalation, shared request budgets, duplicate stream prevention, playlist enumeration, session-limit concurrency, stopping, and resume behavior.