### PR TITLE
chore(release): prepare v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,15 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ### Fixed
 
-- **Large `--artists` / high-quality runs no longer trip TIDAL's HTTP 429 rate
-  limit.** A regression (`05b1eca`) had widened the client selector so that
-  `-q high` (the default) with `hires_client=auto` promoted the WHOLE run —
-  including all enumeration of playlists, artists, albums and credits — to the
-  strict, low-limit **HiRes** client. On a big `--artists` expansion (every
-  credited artist's full discography = `get_artist_albums` + `get_album_items`
-  per album) TIDAL answered with real **HTTP 429 (`Retry-After: 60`)**. The
-  stable client matrix is restored: `high + auto → TV`, `max + auto → HiRes`,
+- **Large `--artists` / high-quality runs no longer route all traffic through the
+  strict HiRes client, fixing the regression that caused frequent HTTP 429
+  responses.** `05b1eca` had widened the client selector so that `-q high` (the
+  default) with `hires_client=auto` promoted the WHOLE run — including all
+  enumeration of playlists, artists, albums and credits — to the strict, low-limit
+  **HiRes** client. On a big `--artists` expansion (every credited artist's full
+  discography = `get_artist_albums` + `get_album_items` per album) TIDAL responded
+  with frequent **HTTP 429 (`Retry-After: 60`)**. The stable client matrix is
+  restored: `high + auto → TV`, `max + auto → HiRes`,
   `* + never → TV`, `* + always → HiRes`. In `high + auto` **all enumeration
   stays on the lenient TV client**; the 24-bit `HI_RES_LOSSLESS` tier is now
   requested **per track only** — for a track whose only FLAC is 24-bit (e.g.
@@ -38,11 +39,11 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 - **The session-track cap now actually stops the run.** Reaching
   `max_tracks_per_session` used to print "Reinicia para continuar" but the engine
   kept dispatching and enumerating the remaining resources (real API calls, more
-  `[n/total]` lines). Reaching the cap now latches a run-wide stop: no further
-  resource is dequeued, enumerated (credits, covers, edition resolution) or
-  requested; already-in-flight downloads finish cleanly. On `--resume`, a
-  resource cut short by the cap is **not** checkpointed, so a later run re-fetches
-  its remaining tracks.
+  `[n/total]` lines). **No new resource is dequeued or started after the cap is
+  reached; already-started work finishes cleanly** (no further enumeration —
+  credits, covers, edition resolution — or API calls for not-yet-started
+  resources). On `--resume`, a resource cut short by the cap is **not**
+  checkpointed, so a later run re-fetches its remaining tracks.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,57 @@ See [FORK.md](FORK.md) for detailed information about improvements and differenc
 
 ## [Unreleased]
 
+## [1.5.4] - 2026-08-26
+
+### Fixed
+
+- **Large `--artists` / high-quality runs no longer trip TIDAL's HTTP 429 rate
+  limit.** A regression (`05b1eca`) had widened the client selector so that
+  `-q high` (the default) with `hires_client=auto` promoted the WHOLE run —
+  including all enumeration of playlists, artists, albums and credits — to the
+  strict, low-limit **HiRes** client. On a big `--artists` expansion (every
+  credited artist's full discography = `get_artist_albums` + `get_album_items`
+  per album) TIDAL answered with real **HTTP 429 (`Retry-After: 60`)**. The
+  stable client matrix is restored: `high + auto → TV`, `max + auto → HiRes`,
+  `* + never → TV`, `* + always → HiRes`. In `high + auto` **all enumeration
+  stays on the lenient TV client**; the 24-bit `HI_RES_LOSSLESS` tier is now
+  requested **per track only** — for a track whose only FLAC is 24-bit (e.g.
+  Atmos) — through a separate secondary HiRes client, never for enumeration.
+  `hires_client=never` never builds or calls the HiRes client, and a run with no
+  HiRes token never sends the 24-bit request to the TV client.
+- **The session-track cap now actually stops the run.** Reaching
+  `max_tracks_per_session` used to print "Reinicia para continuar" but the engine
+  kept dispatching and enumerating the remaining resources (real API calls, more
+  `[n/total]` lines). Reaching the cap now latches a run-wide stop: no further
+  resource is dequeued, enumerated (credits, covers, edition resolution) or
+  requested; already-in-flight downloads finish cleanly. On `--resume`, a
+  resource cut short by the cap is **not** checkpointed, so a later run re-fetches
+  its remaining tracks.
+
+### Changed
+
+- **One shared per-run request budget** now paces the TV and HiRes clients
+  *together*, so activating both cannot exceed `requests_per_minute` (previously
+  each client had its own limiter, allowing up to ~2× the configured rate). It is
+  built from the effective rate, honouring the `--rpm` CLI override, and is
+  per-run (not process-global). The run-wide 429 circuit breaker remains as the
+  last-resort host-safe stop.
+- **`max_tracks_per_session` counts only NEW downloads.** An already-present file
+  (`skip_existing`) no longer consumes the quota, so a run over a mostly-complete
+  library keeps making progress on the genuinely-missing tracks. Under
+  concurrency the cap is enforced with an **atomic per-track reservation**, so
+  parallel tracks can never overshoot the limit; the "limit reached" warning is
+  emitted immediately by the download that reaches it.
+
+### Notes
+
+- **Reaching the session cap is a normal stop, not an error.** It is a run-wide
+  signal distinct from a user cancel / 429 / 401, so `tiddl download …` still
+  exits **0** when it stops because the cap was reached.
+- **Engine-only release.** No functional change to the CLI's `Ctrl+C` handling.
+  Re-pinning the bundled engine and rebuilding/publishing the GUI are a later,
+  separate step and are not part of this engine release.
+
 ## [1.5.3] - 2026-08-25
 
 ### Fixed

--- a/RELEASE_NOTES_v1.5.4.md
+++ b/RELEASE_NOTES_v1.5.4.md
@@ -2,14 +2,15 @@
 
 ## 🇬🇧 What's new
 
-**Large `--artists` / high-quality runs no longer trip TIDAL's HTTP 429 rate limit.**
+**Large `--artists` / high-quality runs no longer route all traffic through the strict HiRes client, fixing the regression that caused frequent HTTP 429 responses.**
 
 - A regression had promoted the **whole run** to the strict, low-limit **HiRes**
   client whenever `-q high` (the default) ran with `hires_client=auto` — including
   **all enumeration** of playlists, artists, albums and credits. On a big
-  `--artists` expansion (every credited artist's full discography) TIDAL answered
-  with real **HTTP 429 (`Retry-After: 60`)**. `--albums` stayed quiet only because
-  it enumerates far less; the amplifier is the artist fan-out, not `--resume`.
+  `--artists` expansion (every credited artist's full discography) TIDAL responded
+  with frequent **HTTP 429 (`Retry-After: 60`)**. `--albums` stayed quiet only
+  because it enumerates far less; the amplifier is the artist fan-out, not
+  `--resume`.
 - The stable client matrix is restored — `high + auto → TV`, `max + auto → HiRes`,
   `* + never → TV`, `* + always → HiRes`. In **`high + auto` all enumeration now
   stays on the lenient TV client**; the 24-bit `HI_RES_LOSSLESS` tier is requested
@@ -25,9 +26,10 @@
 
 - Reaching the cap used to print "Reinicia para continuar" while the engine kept
   dispatching and enumerating the remaining resources (real API calls, more
-  `[n/total]` lines). Reaching the cap now **stops the run**: no further resource
-  is dequeued, enumerated (credits, covers, edition resolution) or requested;
-  already-in-flight downloads finish cleanly.
+  `[n/total]` lines). Now, **no new resource is dequeued or started after the cap
+  is reached; already-started work finishes cleanly** (no further enumeration —
+  credits, covers, edition resolution — or API calls for not-yet-started
+  resources).
 - The cap **counts only NEW downloads** — an already-present file
   (`skip_existing`) no longer consumes the quota. Under concurrency it is enforced
   with an **atomic per-track reservation**, so parallel tracks can never overshoot
@@ -41,15 +43,15 @@
 
 ## 🇪🇸 Novedades
 
-**Las corridas grandes `--artists` / de alta calidad ya no disparan el límite HTTP 429 de TIDAL.**
+**Las corridas grandes `--artists` / de alta calidad ya no envían todo el tráfico por el cliente HiRes estricto, corrigiendo la regresión que provocaba respuestas HTTP 429 frecuentes.**
 
 - Una regresión promovía **toda la corrida** al cliente **HiRes** estricto (de
   límite bajo) siempre que `-q high` (el valor por defecto) corría con
   `hires_client=auto` — incluida **toda la enumeración** de playlists, artistas,
   álbumes y créditos. En una expansión grande `--artists` (la discografía completa
-  de cada artista acreditado) TIDAL respondía con **HTTP 429 real
-  (`Retry-After: 60`)**. `--albums` quedaba tranquilo solo porque enumera mucho
-  menos; el amplificador es el fan-out de artistas, no `--resume`.
+  de cada artista acreditado) TIDAL respondía con **HTTP 429 (`Retry-After: 60`)
+  frecuente**. `--albums` quedaba tranquilo solo porque enumera mucho menos; el
+  amplificador es el fan-out de artistas, no `--resume`.
 - Se restaura la matriz estable de clientes — `high + auto → TV`,
   `max + auto → HiRes`, `* + never → TV`, `* + always → HiRes`. En
   **`high + auto` toda la enumeración se queda ahora en el cliente TV lenient**; el
@@ -66,9 +68,10 @@
 
 - Al alcanzar el límite se imprimía "Reinicia para continuar" mientras el motor
   seguía despachando y enumerando los recursos restantes (llamadas API reales, más
-  líneas `[n/total]`). Alcanzar el límite ahora **detiene la corrida**: no se
-  toma, enumera (créditos, portadas, resolución de ediciones) ni solicita ningún
-  recurso más; las descargas ya en curso terminan limpiamente.
+  líneas `[n/total]`). Ahora, **después de alcanzar el límite no se toma ni inicia
+  ningún recurso nuevo; el trabajo ya iniciado termina limpiamente** (sin más
+  enumeración —créditos, portadas, resolución de ediciones— ni llamadas API para
+  recursos no iniciados).
 - El límite **cuenta solo descargas nuevas** — un archivo ya presente
   (`skip_existing`) ya no consume el cupo. Con concurrencia se aplica mediante una
   **reserva atómica por pista**, de modo que las pistas en paralelo nunca superan

--- a/RELEASE_NOTES_v1.5.4.md
+++ b/RELEASE_NOTES_v1.5.4.md
@@ -1,0 +1,83 @@
+# tiddl-elvigilante v1.5.4
+
+## 🇬🇧 What's new
+
+**Large `--artists` / high-quality runs no longer trip TIDAL's HTTP 429 rate limit.**
+
+- A regression had promoted the **whole run** to the strict, low-limit **HiRes**
+  client whenever `-q high` (the default) ran with `hires_client=auto` — including
+  **all enumeration** of playlists, artists, albums and credits. On a big
+  `--artists` expansion (every credited artist's full discography) TIDAL answered
+  with real **HTTP 429 (`Retry-After: 60`)**. `--albums` stayed quiet only because
+  it enumerates far less; the amplifier is the artist fan-out, not `--resume`.
+- The stable client matrix is restored — `high + auto → TV`, `max + auto → HiRes`,
+  `* + never → TV`, `* + always → HiRes`. In **`high + auto` all enumeration now
+  stays on the lenient TV client**; the 24-bit `HI_RES_LOSSLESS` tier is requested
+  **per track only** — for a track whose only FLAC is 24-bit (e.g. Atmos) — via a
+  separate secondary HiRes client, never for enumeration. `hires_client=never`
+  never builds or calls the HiRes client.
+- **One shared per-run request budget** now paces the TV and HiRes clients
+  *together*, so activating both cannot exceed `requests_per_minute` (before, each
+  client had its own limiter — up to ~2× the rate). It honours the `--rpm`
+  override. The 429 circuit breaker stays as a last-resort host-safe stop.
+
+**The `max_tracks_per_session` cap now actually stops the run.**
+
+- Reaching the cap used to print "Reinicia para continuar" while the engine kept
+  dispatching and enumerating the remaining resources (real API calls, more
+  `[n/total]` lines). Reaching the cap now **stops the run**: no further resource
+  is dequeued, enumerated (credits, covers, edition resolution) or requested;
+  already-in-flight downloads finish cleanly.
+- The cap **counts only NEW downloads** — an already-present file
+  (`skip_existing`) no longer consumes the quota. Under concurrency it is enforced
+  with an **atomic per-track reservation**, so parallel tracks can never overshoot
+  the limit, and the warning is shown the moment the cap is reached.
+- On `--resume`, a resource cut short by the cap is **not** marked complete, so a
+  later run re-fetches its remaining tracks. Reaching the cap is a **normal stop**
+  (distinct from a user cancel / 429 / 401): `tiddl download …` still exits **0**.
+
+- **Engine-only release.** Re-pinning the bundled engine and rebuilding/publishing
+  the GUI are a later, separate step and are not part of this engine release.
+
+## 🇪🇸 Novedades
+
+**Las corridas grandes `--artists` / de alta calidad ya no disparan el límite HTTP 429 de TIDAL.**
+
+- Una regresión promovía **toda la corrida** al cliente **HiRes** estricto (de
+  límite bajo) siempre que `-q high` (el valor por defecto) corría con
+  `hires_client=auto` — incluida **toda la enumeración** de playlists, artistas,
+  álbumes y créditos. En una expansión grande `--artists` (la discografía completa
+  de cada artista acreditado) TIDAL respondía con **HTTP 429 real
+  (`Retry-After: 60`)**. `--albums` quedaba tranquilo solo porque enumera mucho
+  menos; el amplificador es el fan-out de artistas, no `--resume`.
+- Se restaura la matriz estable de clientes — `high + auto → TV`,
+  `max + auto → HiRes`, `* + never → TV`, `* + always → HiRes`. En
+  **`high + auto` toda la enumeración se queda ahora en el cliente TV lenient**; el
+  nivel 24-bit `HI_RES_LOSSLESS` se pide **solo por pista** —para una pista cuyo
+  único FLAC es 24-bit (p. ej. Atmos)— mediante un cliente HiRes secundario, nunca
+  para enumerar. `hires_client=never` nunca construye ni llama al cliente HiRes.
+- **Un único presupuesto de solicitudes compartido por corrida** regula ahora a
+  los clientes TV y HiRes *en conjunto*, de modo que activar ambos no puede superar
+  `requests_per_minute` (antes cada cliente tenía su propio limitador — hasta ~2×
+  la tasa). Respeta el override `--rpm`. El circuit breaker de 429 permanece como
+  parada host-safe de último recurso.
+
+**El límite `max_tracks_per_session` ahora detiene de verdad la corrida.**
+
+- Al alcanzar el límite se imprimía "Reinicia para continuar" mientras el motor
+  seguía despachando y enumerando los recursos restantes (llamadas API reales, más
+  líneas `[n/total]`). Alcanzar el límite ahora **detiene la corrida**: no se
+  toma, enumera (créditos, portadas, resolución de ediciones) ni solicita ningún
+  recurso más; las descargas ya en curso terminan limpiamente.
+- El límite **cuenta solo descargas nuevas** — un archivo ya presente
+  (`skip_existing`) ya no consume el cupo. Con concurrencia se aplica mediante una
+  **reserva atómica por pista**, de modo que las pistas en paralelo nunca superan
+  el límite, y el aviso se muestra en el momento en que se alcanza.
+- Con `--resume`, un recurso truncado por el límite **no** se marca completo, así
+  que una corrida posterior vuelve a bajar sus pistas restantes. Alcanzar el límite
+  es una **parada normal** (distinta de una cancelación del usuario / 429 / 401):
+  `tiddl download …` sigue saliendo con código **0**.
+
+- **Versión solo del motor.** Re-fijar el pin del motor empaquetado y
+  reconstruir/publicar la GUI son un paso posterior e independiente, y no forman
+  parte de esta versión del motor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tiddl-elvigilante"
-version = "1.5.3"
+version = "1.5.4"
 description = "Modern Python 3.10+ compatible TIDAL downloader - Independent fork with production-grade quality"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release preparation — engine **v1.5.4**

Docs/version only. **No functional code changes** — `tiddl/` and tests are untouched (the fixes already landed on `main` via #41). **Not to be merged, tagged, or published** until a separate authorization.

### Files
- `pyproject.toml` — `1.5.3` → `1.5.4` (single authoritative version source).
- `CHANGELOG.md` — `[1.5.4]` section.
- `RELEASE_NOTES_v1.5.4.md` — bilingual notes (What's new / Novedades).

### What v1.5.4 ships (delivered by #41, already on `main`)
- **HTTP 429 fix / TV-HiRes routing.** `high + auto` keeps **all enumeration** (playlists, artists, albums, credits) on the lenient **TV** client; the 24-bit `HI_RES_LOSSLESS` tier is a **per-track** ascent via a secondary HiRes client, never for enumeration. This stops the real `429 (Retry-After: 60)` seen on large `--artists` expansions. Stable client matrix restored (`high+auto→TV`, `max+auto→HiRes`, `*+never→TV`, `*+always→HiRes`).
- **Shared request budget.** One per-run budget paces TV + HiRes **together** within `requests_per_minute` (honours `--rpm`); the 429 circuit breaker remains as the last-resort host-safe stop.
- **`max_tracks_per_session` now stops the run.** No further dispatch / enumeration / API for the remaining resources once the cap is hit; counts **only new downloads**; enforced with an **atomic per-track reservation** under concurrency; a cap-truncated resource is **not** checkpointed for `--resume`. Reaching the cap exits **0** (not a cancel/429/401).

### Validation
- Full suite **485 passed / 3 skipped** (no code change).
- `requirements.lock` — no drift from the version bump.
- `git diff --check` clean.

### Not in this PR / not authorized yet
Merge · git tag · GitHub release · local install · GUI re-pin or code change · rebuild/publish · Phase 2.

## Summary by Sourcery

Prepare the engine-only v1.5.4 release metadata and documentation without changing functional code.

Documentation:
- Document the v1.5.4 release in the changelog and add bilingual release notes covering request routing, shared rate limiting, and session-cap behavior.

Chores:
- Bump the project version from 1.5.3 to 1.5.4.